### PR TITLE
feat(cli): add configurable CSV separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ poetry run forest5 backtest --data demo.csv --fast 12 --slow 26
 
 # 5) Grid-search
 poetry run forest5 grid --data demo.csv --fast 6 12 6 --slow 20 40 10
+```
+
+CLI automatycznie wykrywa separator CSV przy użyciu `csv.Sniffer` i szybkiego
+parsera C. W razie potrzeby separator można podać ręcznie opcją `--sep`,
+np. `--sep ';'`.


### PR DESCRIPTION
## Summary
- autodetect CSV delimiter with csv.Sniffer and use fast C parser
- add optional `--sep` to backtest and grid CLI commands
- document delimiter detection and `--sep` option in README

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a1dd2495d88326a3c7308d68e2d4e4