### PR TITLE
Use shared OHLC CSV reader and add tests

### DIFF
--- a/src/forest5/utils/io.py
+++ b/src/forest5/utils/io.py
@@ -1,38 +1,69 @@
 from __future__ import annotations
 
+import csv
+from pathlib import Path
 import pandas as pd
 
 
-def read_ohlc_csv(path: str, time_col: str = "time", tz: str | None = None) -> pd.DataFrame:
-    """
-    Load OHLC CSV used by Forest5 backtests.
+def read_ohlc_csv(
+    path: str | Path,
+    time_col: str | None = None,
+    tz: str | None = None,
+    sep: str | None = None,
+) -> pd.DataFrame:
+    """Load OHLC CSV used by Forest5 backtests.
 
-    Expected columns (case-insensitive): time, open, high, low, close.
-    The function lower-cases headers and returns a frame indexed by a tz-naive
-    DatetimeIndex (Forest5 internals operate on tz-naive timestamps).
+    This reader normalises column names (case/whitespace/aliases), parses the
+    timestamp column and returns a frame indexed by a tz-naive
+    :class:`~pandas.DatetimeIndex` with canonical ``open/high/low/close``
+    columns.
 
     Parameters
     ----------
-    path : str
+    path:
         Path to a CSV file.
-    time_col : str, default "time"
-        Name of the timestamp column. If missing, try to parse current index.
-    tz : str | None
+    time_col:
+        Name of the timestamp column. If ``None`` it will try common aliases
+        such as ``time``/``timestamp``/``date``/``datetime``/``dt``.
+    tz:
         Optional timezone if the input timestamps are *naive* and you know
-        their timezone. They will be localized to `tz` and then converted to
+        their timezone. They will be localized to ``tz`` and converted to
         tz-naive (wall-clock) to avoid tz-aware/naive mix-ups downstream.
+    sep:
+        Optional CSV separator. When ``None`` it will be auto-detected.
 
     Returns
     -------
-    pd.DataFrame with columns: open, high, low, close
+    pd.DataFrame
+        Data indexed by time with columns ``open``, ``high``, ``low``, ``close``.
     """
-    df = pd.read_csv(path)
-    # normalize headers
-    df.columns = df.columns.str.lower()
 
-    # build index
-    if time_col in df.columns:
+    path = Path(path)
+
+    # detect separator if not provided
+    if sep is None:
+        try:
+            with open(path, "r", newline="") as f:
+                sample = f.read(4096)
+                sep = csv.Sniffer().sniff(sample).delimiter
+        except csv.Error:
+            sep = ","
+
+    df = pd.read_csv(path, sep=sep)
+    # normalise headers
+    df.columns = df.columns.str.strip().str.lower()
+
+    # normalise time column argument and discover aliases when absent
+    time_col = time_col.lower() if time_col is not None else None
+    if time_col is None:
+        for alias in ("time", "timestamp", "date", "datetime", "dt"):
+            if alias in df.columns:
+                time_col = alias
+                break
+
+    if time_col and time_col in df.columns:
         idx = pd.to_datetime(df[time_col], errors="coerce", utc=False)
+        df = df.drop(columns=[time_col])
     else:
         idx = pd.to_datetime(df.index, errors="coerce", utc=False)
 
@@ -42,12 +73,30 @@ def read_ohlc_csv(path: str, time_col: str = "time", tz: str | None = None) -> p
             f"Failed to parse {bad} timestamps from '{path}'. Check the 'time' column format."
         )
 
-    # If tz is provided and the index is tz-naive, localize and then drop tz (Forest5 uses tz-naive internally)
     if tz is not None and getattr(idx, "tz", None) is None:
-        idx = idx.tz_localize(tz).tz_convert(None)
+        idx = idx.tz_localize(tz)
+    if getattr(idx, "tz", None) is not None:
+        idx = idx.tz_convert(None)
 
     df.index = idx
-    # basic column check
+
+    # map OHLC aliases to canonical names
+    synonyms: dict[str, list[str]] = {
+        "open": ["open", "o", "op", "open_price"],
+        "high": ["high", "h", "hi"],
+        "low": ["low", "l", "lo"],
+        "close": ["close", "c", "cl", "close_price"],
+    }
+
+    rename: dict[str, str] = {}
+    for target, keys in synonyms.items():
+        for k in keys:
+            if k in df.columns:
+                rename[k] = target
+                break
+
+    df = df.rename(columns=rename)
+
     need = ["open", "high", "low", "close"]
     missing = [c for c in need if c not in df.columns]
     if missing:

--- a/tests/test_read_ohlc_csv_columns.py
+++ b/tests/test_read_ohlc_csv_columns.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from forest5.utils.io import read_ohlc_csv
+
+
+def test_read_ohlc_csv_normalizes_ohlc_columns(tmp_path):
+    df = pd.DataFrame(
+        {
+            "TIME": ["2020-01-01 00:00", "2020-01-01 01:00"],
+            " Open ": [1, 2],
+            "HI": [1, 2],
+            "l": [1, 2],
+            "close_price": [1, 2],
+        }
+    )
+    csv_path = tmp_path / "sample.csv"
+    df.to_csv(csv_path, index=False)
+    out = read_ohlc_csv(csv_path, time_col="TIME")
+    assert list(out.columns) == ["open", "high", "low", "close"]
+    assert isinstance(out.index, pd.DatetimeIndex)
+    assert out.index.name == "time"


### PR DESCRIPTION
## Summary
- Replace bespoke CSV helpers with shared `read_ohlc_csv` utility in CLI
- Expand `read_ohlc_csv` to normalise headers, detect time aliases and OHLC synonyms
- Add regression test ensuring CSV columns are normalised

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1f1c62da88326b331b76fb3b3afdd