### PR TITLE
Refactor timeframe parsing helpers and extend tests

### DIFF
--- a/src/forest5/utils/timeframes.py
+++ b/src/forest5/utils/timeframes.py
@@ -47,22 +47,38 @@ _TF_MINUTES = {
 }
 
 
-def normalize_timeframe(tf: str) -> str:
-    """Znormalizuj zapis TF do postaci 'Xm'/'Xh'/'Xd' (np. 'H' -> '1h', '60min' -> '1h')."""
-    raw = tf.strip()
-    if raw in _ALIASES:
-        return _ALIASES[raw]
+def _alias_to_tf(raw: str) -> str | None:
+    """Zwróć znormalizowane TF dla prostych aliasów, gdy występują."""
 
-    s = raw.lower().replace(" ", "")
-    if s in _VALID:
-        return s
+    return _ALIASES.get(raw.strip())
 
-    # "60", "240" (minuty)
+
+def _minutes_to_tf(s: str) -> str | None:
+    """Zwróć TF na podstawie liczby minut zapisanej jako string."""
+
     if s.isdigit():
         minutes = int(s)
         for k, v in _TF_MINUTES.items():
             if v == minutes:
                 return k
+    return None
+
+
+def normalize_timeframe(tf: str) -> str:
+    """Znormalizuj zapis TF do postaci 'Xm'/'Xh'/'Xd' (np. 'H' -> '1h', '60min' -> '1h')."""
+
+    raw = tf.strip()
+    alias = _alias_to_tf(raw)
+    if alias:
+        return alias
+
+    s = raw.lower().replace(" ", "")
+    if s in _VALID:
+        return s
+
+    numeric = _minutes_to_tf(s)
+    if numeric:
+        return numeric
 
     # "1H", "15M" itp.
     m = re.fullmatch(r"(\d+)([mhdwMHDW])", s)

--- a/tests/test_timeframes.py
+++ b/tests/test_timeframes.py
@@ -9,6 +9,13 @@ def test_normalize_timeframe_variants():
     assert normalize_timeframe("240") == "4h"
 
 
-def test_invalid_timeframe():
+def test_rare_timeframe_aliases():
+    assert normalize_timeframe("M") == "1m"
+    assert normalize_timeframe("1D") == "1d"
+    assert normalize_timeframe("1440") == "1d"
+
+
+@pytest.mark.parametrize("bad", ["weird", "", "13", "1X"])
+def test_invalid_timeframe(bad):
     with pytest.raises(ValueError):
-        normalize_timeframe("weird")
+        normalize_timeframe(bad)


### PR DESCRIPTION
## Summary
- refactor timeframe normalization by extracting alias resolution and minute conversion into helpers
- add tests covering rare timeframe aliases and invalid inputs

## Testing
- `pre-commit run --files src/forest5/utils/timeframes.py tests/test_timeframes.py`
- `pytest tests/test_timeframes.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1f41a74f883268ea0345f53ac84ac