### PR TITLE
test: ensure decision agent waits on blocked Monday

### DIFF
--- a/tests/test_decision_agent.py
+++ b/tests/test_decision_agent.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+from forest5.decision import DecisionAgent, DecisionConfig
+from forest5.numerology import NumerologyRules
+
+
+def test_decision_agent_wait_on_blocked_weekday() -> None:
+    rules = NumerologyRules(enabled=True, blocked_weekdays=[0])
+    config = DecisionConfig(numerology=rules)
+    agent = DecisionAgent(config=config)
+
+    ts = datetime(2024, 1, 1)  # Monday
+    decision = agent.decide(ts, tech_signal=1, instrument="EURUSD")
+
+    assert decision == "WAIT"


### PR DESCRIPTION
## Summary
- add test verifying DecisionAgent returns WAIT when NumerologyRules block Monday

## Testing
- `pytest tests/test_decision_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1f9c86bd88326adfc268113ca4248