### PR TITLE
Add tests for time-frame normalization edge cases

### DIFF
--- a/tests/test_timeframes.py
+++ b/tests/test_timeframes.py
@@ -5,7 +5,6 @@ import pytest
 def test_normalize_timeframe_variants():
     assert normalize_timeframe("H") == "1h"
     assert normalize_timeframe("1H") == "1h"
-    assert normalize_timeframe("60min") == "1h"
     assert normalize_timeframe("240") == "4h"
 
 
@@ -15,7 +14,11 @@ def test_rare_timeframe_aliases():
     assert normalize_timeframe("1440") == "1d"
 
 
-@pytest.mark.parametrize("bad", ["weird", "", "13", "1X"])
+def test_normalize_timeframe_60min_alias():
+    assert normalize_timeframe("60min") == "1h"
+
+
+@pytest.mark.parametrize("bad", ["weird", "", "13", "1X", "999x"])
 def test_invalid_timeframe(bad):
     with pytest.raises(ValueError):
         normalize_timeframe(bad)


### PR DESCRIPTION
## Summary
- test 60min alias normalizes to 1h
- ensure 999x raises ValueError in normalize_timeframe

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1fae6c0f4832691d2d44ec51f8408