### PR TITLE
test(router): ensure market order requires connection

### DIFF
--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -18,6 +18,8 @@ def test_paper_broker_basic_flow():
 
 def test_rejects_without_price_or_connection():
     b = PaperBroker()
-    assert b.market_order("BUY", 1).status == "rejected"  # not connected
+    r = b.market_order("BUY", 1, 1.2)
+    assert r.status == "rejected"
+    assert r.error is not None
     b.connect()
     assert b.market_order("BUY", 1).status == "rejected"  # no price


### PR DESCRIPTION
## Summary
- extend router tests to validate market order rejection when not connected

## Testing
- `pytest tests/test_router.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1fc984ba883269ed5fb9ac4c662b5