### PR TITLE
ci: use actions/setup-python with poetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,33 +14,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup micromamba
-        uses: mamba-org/setup-micromamba@v2
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          environment-file: environment.yml
-          environment-name: forest5
-          cache-environment: true
-          cache-downloads: true
+          python-version: "3.12"
+          cache: "poetry"
+
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install --with dev
 
       - name: Show versions
-        shell: bash -l {0}
         run: |
-          micromamba run -n forest5 python -V
-          micromamba run -n forest5 python -m pip --version
-
-      - name: Install forest5 (editable)
-        shell: bash -l {0}
-        run: micromamba run -n forest5 python -m pip install -e .
-
-      # <<< KLUCZOWY KROK >>> instalujemy dev-narzędzia jawnie
-      - name: Install dev tools (ruff, pytest)
-        shell: bash -l {0}
-        run: micromamba run -n forest5 python -m pip install -U ruff pytest
+          python -V
+          python -m pip --version
+          poetry --version
 
       - name: Lint
-        shell: bash -l {0}
-        run: micromamba run -n forest5 python -m ruff check .
+        run: poetry run ruff check .
 
       - name: Test
-        shell: bash -l {0}
-        run: micromamba run -n forest5 python -m pytest -q
+        run: poetry run pytest -q


### PR DESCRIPTION
## Summary
- replace micromamba environment with actions/setup-python and Poetry
- cache Poetry downloads and install dev dependencies
- run lint and tests with `poetry run`

## Testing
- `python -m pre_commit run --files .github/workflows/ci.yml`
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1ffabedc483269da9709f25ccec08