### PR TITLE
Rename instrument argument to symbol

### DIFF
--- a/src/forest5/ai_agent.py
+++ b/src/forest5/ai_agent.py
@@ -39,14 +39,14 @@ class SentimentAgent:
                 self._client = None
                 self._mode = "none"
 
-    def analyse(self, context: str, instrument: str) -> Sentiment:
+    def analyse(self, context: str, symbol: str) -> Sentiment:
         if not self.enabled or self._client is None:
             return Sentiment(0, "AI disabled or no key; neutral filter.")
 
         prompt = (
             "Determine market sentiment "
             "(-1 bearish / 0 neutral / +1 bullish). "
-            "Instrument: {instrument}. Context:\n{ctx}\n"
+            "Symbol: {symbol}. Context:\n{ctx}\n"
             "Answer as JSON with keys: score, reason."
         )
 
@@ -58,7 +58,7 @@ class SentimentAgent:
                         {
                             "role": "user",
                             "content": prompt.format(
-                                instrument=instrument,
+                                symbol=symbol,
                                 ctx=context,
                             ),
                         }
@@ -73,7 +73,7 @@ class SentimentAgent:
                         {
                             "role": "user",
                             "content": prompt.format(
-                                instrument=instrument,
+                                symbol=symbol,
                                 ctx=context,
                             ),
                         }

--- a/src/forest5/decision.py
+++ b/src/forest5/decision.py
@@ -31,14 +31,14 @@ class DecisionAgent:
         self.config = config or DecisionConfig()
         self.ai = SentimentAgent() if self.config.use_ai else None
 
-    def decide(self, ts, tech_signal: int, instrument: str, context_text: str = "") -> str:
+    def decide(self, ts, tech_signal: int, symbol: str, context_text: str = "") -> str:
         # filtr numerologiczny
         if not is_trade_allowed(ts, self.config.numerology):
             return "WAIT"
 
         votes = [tech_signal]
         if self.ai:
-            s = self.ai.analyse(context_text, instrument).score
+            s = self.ai.analyse(context_text, symbol).score
             votes.append(s)
 
         score = sum(1 if v > 0 else (-1 if v < 0 else 0) for v in votes)

--- a/tests/test_ai_agent.py
+++ b/tests/test_ai_agent.py
@@ -13,30 +13,30 @@ class DummyOpenAIClient:
         return {"choices": [{"message": {"content": '{"score": 1, "reason": "ok"}'}}]}
 
 
-def test_analyse_injects_instrument() -> None:
+def test_analyse_injects_symbol() -> None:
     client = DummyOpenAIClient()
     agent = SentimentAgent()
     agent.enabled = True
     agent._client = client
     agent._mode = "legacy"
 
-    instrument = "EURUSD"
+    symbol = "EURUSD"
     ctx = "some context"
-    result = agent.analyse(ctx, instrument)
+    result = agent.analyse(ctx, symbol)
 
-    assert instrument in client.captured
+    assert symbol in client.captured
     assert isinstance(result, Sentiment)
 
 
-def test_decision_agent_passes_instrument(monkeypatch) -> None:
+def test_decision_agent_passes_symbol(monkeypatch) -> None:
     from forest5.decision import DecisionAgent, DecisionConfig
 
     class DummyAI:
         def __init__(self) -> None:
             self.args: tuple[str, str] | None = None
 
-        def analyse(self, context: str, instrument: str) -> Sentiment:
-            self.args = (context, instrument)
+        def analyse(self, context: str, symbol: str) -> Sentiment:
+            self.args = (context, symbol)
             return Sentiment(0, "")
 
     config = DecisionConfig(use_ai=True)
@@ -44,5 +44,5 @@ def test_decision_agent_passes_instrument(monkeypatch) -> None:
     dummy = DummyAI()
     agent.ai = dummy
 
-    agent.decide(0, 1, "EURUSD", "ctx")
+    agent.decide(0, 1, symbol="EURUSD", context_text="ctx")
     assert dummy.args == ("ctx", "EURUSD")

--- a/tests/test_decision_agent.py
+++ b/tests/test_decision_agent.py
@@ -10,6 +10,6 @@ def test_decision_agent_wait_on_blocked_weekday() -> None:
     agent = DecisionAgent(config=config)
 
     ts = datetime(2024, 1, 1)  # Monday
-    decision = agent.decide(ts, tech_signal=1, instrument="EURUSD")
+    decision = agent.decide(ts, tech_signal=1, symbol="EURUSD")
 
     assert decision == "WAIT"


### PR DESCRIPTION
## Summary
- rename SentimentAgent.analyse and DecisionAgent.decide parameters from `instrument` to `symbol`
- update internal usage and prompts
- adjust test cases to use `symbol`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a20193789083268300642a70e77023