### PR TITLE
Validate percentage CLI arguments

### DIFF
--- a/scripts/dx_fx_probe.py
+++ b/scripts/dx_fx_probe.py
@@ -9,6 +9,7 @@ import pandas as pd
 from forest5.config import BacktestSettings, StrategySettings, RiskSettings
 from forest5.utils.validate import ensure_backtest_ready
 from forest5.backtest.engine import run_backtest
+from forest5.utils.argparse_ext import PercentAction
 
 
 def parse_args() -> argparse.Namespace:
@@ -20,9 +21,9 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--atr-period", type=int, default=14)
     ap.add_argument("--atr-multiple", type=float, default=2.0)
     ap.add_argument("--capital", type=float, default=100_000.0)
-    ap.add_argument("--risk", type=float, default=0.01)
-    ap.add_argument("--fee-perc", type=float, default=0.0005)
-    ap.add_argument("--slippage-perc", type=float, default=0.0)
+    ap.add_argument("--risk", action=PercentAction, default=0.01)
+    ap.add_argument("--fee-perc", action=PercentAction, default=0.0005)
+    ap.add_argument("--slippage-perc", action=PercentAction, default=0.0)
     ap.add_argument("--start", type=str, default=None)
     ap.add_argument("--end", type=str, default=None)
     ap.add_argument("--inspect-n", type=int, default=0)

--- a/scripts/dx_fx_probe.pyforest_guard.py
+++ b/scripts/dx_fx_probe.pyforest_guard.py
@@ -5,6 +5,7 @@ import pandas as pd
 from forest5.config import BacktestSettings, StrategySettings, RiskSettings
 from forest5.utils.validate import ensure_backtest_ready
 from forest5.backtest.engine import run_backtest
+from forest5.utils.argparse_ext import PercentAction
 
 
 def main() -> None:
@@ -16,8 +17,8 @@ def main() -> None:
     p.add_argument("--atr-period", type=int, default=14)
     p.add_argument("--atr-multiple", type=float, default=2.0)
     p.add_argument("--capital", type=float, default=100_000.0)
-    p.add_argument("--risk", type=float, default=0.01)
-    p.add_argument("--fee-perc", type=float, default=0.0005)
+    p.add_argument("--risk", action=PercentAction, default=0.01)
+    p.add_argument("--fee-perc", action=PercentAction, default=0.0005)
     p.add_argument("--start")
     p.add_argument("--end")
     p.add_argument("--inspect-n", type=int, default=0)

--- a/scripts/dx_mtm_guard.py
+++ b/scripts/dx_mtm_guard.py
@@ -10,6 +10,7 @@ import pandas as pd
 from forest5.config import BacktestSettings, StrategySettings, RiskSettings
 from forest5.backtest.engine import run_backtest
 from forest5.utils.validate import ensure_backtest_ready
+from forest5.utils.argparse_ext import PercentAction
 
 
 def parse_args():
@@ -19,7 +20,7 @@ def parse_args():
     p.add_argument("--fast", type=int, default=12)
     p.add_argument("--slow", type=int, default=26)
     p.add_argument("--capital", type=float, default=100_000.0)
-    p.add_argument("--risk", type=float, default=0.01)
+    p.add_argument("--risk", action=PercentAction, default=0.01)
     p.add_argument("--atr-period", type=int, default=14)
     p.add_argument("--atr-multiple", type=float, default=2.0)
     p.add_argument("--start")

--- a/scripts/optimize_grid.py
+++ b/scripts/optimize_grid.py
@@ -15,6 +15,7 @@ import pandas as pd
 from forest5.config import BacktestSettings, RiskSettings, StrategySettings
 from forest5.backtest.engine import run_backtest
 from forest5.utils.validate import ensure_backtest_ready
+from forest5.utils.argparse_ext import PercentAction
 
 
 # --------------------------------------------------------------------------------------
@@ -196,15 +197,15 @@ def main() -> None:
     )
     parser.add_argument("--use-rsi", action="store_true", help="Włącz filtr RSI.")
     parser.add_argument("--rsi-period", type=int, default=14)
-    parser.add_argument("--rsi-oversold", type=int, default=30)
-    parser.add_argument("--rsi-overbought", type=int, default=70)
+    parser.add_argument("--rsi-oversold", type=int, default=30, choices=range(0, 101))
+    parser.add_argument("--rsi-overbought", type=int, default=70, choices=range(0, 101))
 
     parser.add_argument("--capital", type=float, default=100_000.0)
     parser.add_argument(
-        "--risk", type=float, default=0.01, help="Udział kapitału ryzykowany na trade."
+        "--risk", action=PercentAction, default=0.01, help="Udział kapitału ryzykowany na trade."
     )
-    parser.add_argument("--fee-perc", type=float, default=0.0005)
-    parser.add_argument("--slippage-perc", type=float, default=0.0)
+    parser.add_argument("--fee-perc", action=PercentAction, default=0.0005)
+    parser.add_argument("--slippage-perc", action=PercentAction, default=0.0)
 
     parser.add_argument("--atr-period", type=int, default=14)
     parser.add_argument("--atr-multiple", type=float, default=2.0)

--- a/scripts/walkforward.py
+++ b/scripts/walkforward.py
@@ -11,6 +11,7 @@ from pandas.tseries.offsets import DateOffset
 # forest5
 from forest5.config import BacktestSettings, StrategySettings, RiskSettings
 from forest5.backtest.engine import run_backtest
+from forest5.utils.argparse_ext import PercentAction
 
 
 # ----------------------------- CSV LOADING ---------------------------------
@@ -297,13 +298,13 @@ def main() -> None:
 
     ap.add_argument("--use-rsi", action="store_true")
     ap.add_argument("--rsi-period", type=int, default=14)
-    ap.add_argument("--rsi-oversold", type=int, default=30)
-    ap.add_argument("--rsi-overbought", type=int, default=70)
+    ap.add_argument("--rsi-oversold", type=int, default=30, choices=range(0, 101))
+    ap.add_argument("--rsi-overbought", type=int, default=70, choices=range(0, 101))
 
     ap.add_argument("--capital", type=float, default=100_000.0)
-    ap.add_argument("--risk", type=float, default=0.01)
-    ap.add_argument("--fee-perc", type=float, default=0.0005)
-    ap.add_argument("--slippage-perc", type=float, default=0.0)
+    ap.add_argument("--risk", action=PercentAction, default=0.01)
+    ap.add_argument("--fee-perc", action=PercentAction, default=0.0005)
+    ap.add_argument("--slippage-perc", action=PercentAction, default=0.0)
 
     ap.add_argument("--atr-period", type=int, default=14)
     ap.add_argument("--atr-multiple", type=float, default=2.0)

--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -10,6 +10,7 @@ from forest5.config import BacktestSettings
 from forest5.backtest.engine import run_backtest
 from forest5.backtest.grid import run_grid
 from forest5.utils.io import read_ohlc_csv
+from forest5.utils.argparse_ext import PercentAction
 
 
 # ---------------------------- CSV loading helpers ----------------------------
@@ -146,14 +147,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_bt.add_argument("--use-rsi", action="store_true", help="Włącz filtr RSI")
     p_bt.add_argument("--rsi-period", type=int, default=14)
-    p_bt.add_argument("--rsi-oversold", type=float, default=30.0)
-    p_bt.add_argument("--rsi-overbought", type=float, default=70.0)
+    p_bt.add_argument("--rsi-oversold", type=int, default=30, choices=range(0, 101))
+    p_bt.add_argument("--rsi-overbought", type=int, default=70, choices=range(0, 101))
 
     p_bt.add_argument("--capital", type=float, default=100_000.0)
-    p_bt.add_argument("--risk", type=float, default=0.01, help="Ryzyko na trade (0-1)")
-    p_bt.add_argument("--max-dd", type=float, default=0.30, help="Dozwolone obsunięcie")
-    p_bt.add_argument("--fee", type=float, default=0.0005, help="Prowizja %")
-    p_bt.add_argument("--slippage", type=float, default=0.0, help="Poślizg %")
+    p_bt.add_argument("--risk", action=PercentAction, default=0.01, help="Ryzyko na trade (0-1)")
+    p_bt.add_argument("--max-dd", action=PercentAction, default=0.30, help="Dozwolone obsunięcie")
+    p_bt.add_argument("--fee", action=PercentAction, default=0.0005, help="Prowizja %")
+    p_bt.add_argument("--slippage", action=PercentAction, default=0.0, help="Poślizg %")
 
     p_bt.add_argument("--atr-period", type=int, default=14)
     p_bt.add_argument("--atr-multiple", type=float, default=2.0)
@@ -174,7 +175,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_gr.add_argument("--fast-values", required=True, help="Np. 5:20:1 lub 5,8,13")
     p_gr.add_argument("--slow-values", required=True, help="Np. 10:60:2 lub 12,26")
     p_gr.add_argument("--capital", type=float, default=100_000.0)
-    p_gr.add_argument("--risk", type=float, default=0.01)
+    p_gr.add_argument("--risk", action=PercentAction, default=0.01)
     p_gr.add_argument("--jobs", type=int, default=1, help="Równoległość (1 = sekwencyjnie)")
     p_gr.add_argument("--top", type=int, default=20, help="Ile rekordów wyświetlić")
     p_gr.add_argument("--export", default=None, help="Zapis do CSV/Parquet")

--- a/src/forest5/utils/argparse_ext.py
+++ b/src/forest5/utils/argparse_ext.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import argparse
+
+
+class PercentAction(argparse.Action):
+    """Argparse action that validates a percentage in a given range."""
+
+    def __init__(self, option_strings, dest, *, min_value: float = 0.0, max_value: float = 1.0, **kwargs):
+        self.min_value = float(min_value)
+        self.max_value = float(max_value)
+        super().__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, value, option_string=None):
+        try:
+            val = float(value)
+        except ValueError:
+            parser.error(f"{option_string} expects a number")
+        if not (self.min_value <= val <= self.max_value):
+            parser.error(
+                f"{option_string} must be between {self.min_value} and {self.max_value}"
+            )
+        setattr(namespace, self.dest, val)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from forest5.cli import main
+from forest5.cli import build_parser, main
 
 
 def _write_csv(path):
@@ -74,3 +74,11 @@ def test_cli_missing_ohlc_columns(tmp_path):
     bad_csv.write_text("time,open,high,low\n2020-01-01,1,1,1\n")
     with pytest.raises(ValueError, match="CSV missing required columns"):
         main(["backtest", "--csv", str(bad_csv)])
+
+
+def test_percentage_out_of_range_error(capfd):
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["backtest", "--csv", "dummy.csv", "--risk", "2"])
+    err = capfd.readouterr().err
+    assert "between 0.0 and 1.0" in err


### PR DESCRIPTION
## Summary
- add reusable `PercentAction` to check percentage ranges
- apply percentage validation and RSI choices across CLI and helper scripts
- test CLI rejects percentages outside 0-1

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a20347e0788326abaa29802e8877f7