### PR TITLE
feat: parallel grid with indicator caching

### DIFF
--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,5 +1,6 @@
 from forest5.backtest.grid import run_grid
 from forest5.examples.synthetic import generate_ohlc
+import pandas as pd
 
 
 def test_grid_small():
@@ -16,3 +17,20 @@ def test_grid_small():
     assert {"fast", "slow", "equity_end", "max_dd", "cagr", "rar"}.issubset(res.columns)
     assert len(res) == 1
     assert res["equity_end"].iloc[0] > 0
+
+
+def test_grid_parallel_same_result():
+    df = generate_ohlc(periods=40, start_price=100.0, freq="D")
+    kwargs = dict(
+        symbol="SYMB",
+        fast_values=[6, 8],
+        slow_values=[12, 20],
+        capital=10_000.0,
+        risk=0.01,
+    )
+    res1 = run_grid(df, n_jobs=1, **kwargs)
+    res2 = run_grid(df, n_jobs=2, **kwargs)
+    pd.testing.assert_frame_equal(
+        res1.sort_values(["fast", "slow"]).reset_index(drop=True),
+        res2.sort_values(["fast", "slow"]).reset_index(drop=True),
+    )


### PR DESCRIPTION
## Summary
- speed up `run_grid` using joblib.Parallel
- cache ATR and EMA computations to reuse repeated parameters
- test grid results match under parallel execution

## Testing
- `pre-commit run --files src/forest5/backtest/grid.py tests/test_grid.py`
- `pytest -q`
- `python - <<'PY'
import time
from forest5.examples.synthetic import generate_ohlc
from forest5.backtest.grid import run_grid

df = generate_ohlc(periods=5000, start_price=100.0, freq="D")
fast = list(range(5,25,2))
slow = list(range(30,70,5))
start = time.time(); run_grid(df, "SYM", fast, slow, n_jobs=1, cache_dir=".cache/bench1"); serial = time.time() - start
start = time.time(); run_grid(df, "SYM", fast, slow, n_jobs=4, cache_dir=".cache/bench2"); parallel = time.time() - start
print(f"serial: {serial:.4f}s, parallel: {parallel:.4f}s")
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a20a3de7408326bcaa0cef25df1910