### PR TITLE
Handle timeframe string forms explicitly

### DIFF
--- a/src/forest5/utils/timeframes.py
+++ b/src/forest5/utils/timeframes.py
@@ -94,7 +94,9 @@ def normalize_timeframe(tf: str) -> str:
             cand = f"{num}w"
         else:
             raise ValueError(f"Unsupported unit: {tf}")
-        if cand in _VALID or cand in _TF_MINUTES:
-            return cand if cand in _VALID else next(k for k, v in _TF_MINUTES.items() if k == cand)
+        if cand in _VALID:
+            return cand
+        if cand in _TF_MINUTES:
+            return cand
 
     raise ValueError(f"Nieobsługiwany timeframe: {tf!r}")

--- a/tests/test_timeframes.py
+++ b/tests/test_timeframes.py
@@ -18,6 +18,11 @@ def test_normalize_timeframe_60min_alias():
     assert normalize_timeframe("60min") == "1h"
 
 
+@pytest.mark.parametrize("tf, expected", [("240", "4h"), ("2H", "2h")])
+def test_normalize_timeframe_numeric_and_hour_aliases(tf, expected):
+    assert normalize_timeframe(tf) == expected
+
+
 @pytest.mark.parametrize("bad", ["weird", "", "13", "1X", "999x"])
 def test_invalid_timeframe(bad):
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- Refactor `normalize_timeframe` to check `_VALID` and `_TF_MINUTES` separately
- Add unit tests for numeric and hour timeframe aliases

## Testing
- `pre-commit run --files src/forest5/utils/timeframes.py`
- `SKIP=bandit pre-commit run --files tests/test_timeframes.py`
- `pytest tests/test_timeframes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a217d54ba483269d67cf89ef391735