### PR TITLE
Refactor version handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "forest5"
-version = "5.0.0"
+version = "5.0.0a1"
 description = "Forest 5.0 – modularny framework tradingowy (AT + AI + MT5)"
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"

--- a/src/forest5/__init__.py
+++ b/src/forest5/__init__.py
@@ -3,5 +3,7 @@
 
 from __future__ import annotations
 
+from importlib.metadata import version
+
 __all__ = ["__version__"]
-__version__ = "5.0.0a1"
+__version__ = version("forest5")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,5 +1,12 @@
+from pathlib import Path
+
+import tomllib
+
 from forest5 import __version__
 
 
-def test_version():
-    assert __version__.startswith("5.")
+def test_version_matches_pyproject() -> None:
+    pyproject_version = tomllib.loads(Path("pyproject.toml").read_text())[
+        "tool"
+    ]["poetry"]["version"]
+    assert __version__ == pyproject_version


### PR DESCRIPTION
## Summary
- derive package version from importlib.metadata
- keep version in pyproject.toml as single source of truth
- test that package version matches pyproject metadata

## Testing
- `ruff check src/forest5/__init__.py tests/test_version.py`
- `pip install -e . --no-deps`
- `pip install numpy pandas pyyaml`
- `pip install pydantic joblib structlog scipy setuptools`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a21a49222c83269631d190aa1bf427