### PR TITLE
Replace numerology settings with time-only settings

### DIFF
--- a/src/forest5/config.py
+++ b/src/forest5/config.py
@@ -33,7 +33,7 @@ class AISettings(BaseModel):
     max_tokens: int = 256
 
 
-class NumerologySettings(BaseModel):
+class TimeOnlySettings(BaseModel):
     enabled: bool = False
     blocked_weekdays: list[int] = Field(default_factory=list)  # 0=Mon..6=Sun
     blocked_hours: list[int] = Field(default_factory=list)  # 0..23


### PR DESCRIPTION
## Summary
- replace unused NumerologySettings with TimeOnlySettings for scheduling gates

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a2303de2e8832680c7791f26ec98ef