### PR TITLE
Add TimeOnlyModel wait test for DecisionAgent

### DIFF
--- a/tests/test_decision_agent.py
+++ b/tests/test_decision_agent.py
@@ -5,11 +5,10 @@ from forest5.time_only import TimeOnlyModel
 
 
 def test_decision_agent_waits_when_time_model_waits() -> None:
-    model = TimeOnlyModel({0: (-1.0, 1.0)}, q_low=-1.0, q_high=1.0)
-    config = DecisionConfig(time_model=model)
-    agent = DecisionAgent(config=config)
+    time_model = TimeOnlyModel({0: (-1.0, 1.0)}, q_low=-1.0, q_high=1.0)
+    agent = DecisionAgent(config=DecisionConfig(time_model=time_model))
 
     ts = datetime(2024, 1, 1)  # 00:00
-    decision = agent.decide(ts, tech_signal=1, value=0.0, symbol="EURUSD")
-
-    assert decision == "WAIT"
+    assert (
+        agent.decide(ts, tech_signal=1, value=0.0, symbol="EURUSD") == "WAIT"
+    )


### PR DESCRIPTION
## Summary
- test DecisionAgent waiting when TimeOnlyModel returns WAIT

## Testing
- `pytest tests/test_decision_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2318764248326b203972f2cf08850