### PR TITLE
Add Streamlit UI app with sidebar navigation

### DIFF
--- a/src/forest5/ui/__init__.py
+++ b/src/forest5/ui/__init__.py
@@ -1,0 +1,1 @@
+"""User interface package for Forest 5 using Streamlit."""

--- a/src/forest5/ui/app.py
+++ b/src/forest5/ui/app.py
@@ -1,0 +1,35 @@
+"""Streamlit application for Forest 5 UI."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+
+def _page_home() -> None:
+    """Display the home page."""
+    st.title("Forest 5 UI")
+    st.write("Witaj w aplikacji Forest 5!")
+
+
+def _page_about() -> None:
+    """Display information about the application."""
+    st.title("O aplikacji")
+    st.write("To demo interfejsu z wykorzystaniem Streamlit.")
+
+
+PAGE_MAP = {
+    "Strona główna": _page_home,
+    "O aplikacji": _page_about,
+}
+
+
+def main() -> None:
+    """Run the Streamlit application."""
+    st.sidebar.title("Nawigacja")
+    selection = st.sidebar.radio("Przejdź do", list(PAGE_MAP))
+    page = PAGE_MAP[selection]
+    page()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `ui` package and simple Streamlit app with sidebar navigation between pages

## Testing
- `poetry run ruff check src/forest5/ui/app.py src/forest5/ui/__init__.py`
- `poetry run black src/forest5/ui/app.py src/forest5/ui/__init__.py`
- `poetry run pytest -q`
- `poetry run streamlit run src/forest5/ui/app.py --server.headless true --server.port 8501`

------
https://chatgpt.com/codex/tasks/task_e_68a247912ecc8326aed2649fb0cf3f8c