### PR TITLE
Handle idle timeout in live runner

### DIFF
--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -77,11 +77,12 @@ def run_live(
     current_bar: dict | None = None
     last_price: float | None = None
     steps = 0
-    last_candle_ts: float | None = None
+    # Track when the last candle was processed to detect idle periods
+    last_candle_ts = time.time()
 
     try:
         while True:
-            if last_candle_ts is not None and time.time() - last_candle_ts > timeout:
+            if time.time() - last_candle_ts > timeout:
                 log.info("idle timeout reached")
                 break
 
@@ -97,9 +98,7 @@ def run_live(
                         continue
 
                     ts = float(tick.get("time", time.time()))
-                    price = float(
-                        tick.get("bid") or tick.get("price") or tick.get("ask")
-                    )
+                    price = float(tick.get("bid") or tick.get("price") or tick.get("ask"))
                     last_price = price
                     log.info("tick: %s", tick)
 
@@ -155,9 +154,7 @@ def run_live(
                             )
                             log.info("decision: %s", decision)
                             if decision in ("BUY", "SELL"):
-                                res = broker.market_order(
-                                    decision, settings.broker.volume, price
-                                )
+                                res = broker.market_order(decision, settings.broker.volume, price)
                                 log.info("order result: %s", res)
 
                         current_bar = {

--- a/tests/test_live_runner_paper_smoke.py
+++ b/tests/test_live_runner_paper_smoke.py
@@ -89,14 +89,6 @@ def test_live_runner_exits_on_idle_timeout(tmp_path: Path):
         risk=RiskSettings(),
     )
 
-    tick_file = bridge / "ticks" / "tick.json"
-
-    def write_tick(tick: dict) -> None:
-        tmp = tick_file.with_suffix(".tmp")
-        tmp.write_text(json.dumps(tick), encoding="utf-8")
-        tmp.replace(tick_file)
-        os.utime(tick_file, (tick["time"], tick["time"]))
-
     errors: list[Exception] = []
 
     def runner() -> None:
@@ -107,9 +99,6 @@ def test_live_runner_exits_on_idle_timeout(tmp_path: Path):
 
     t = threading.Thread(target=runner)
     t.start()
-    time.sleep(0.1)
-    # write a tick to close the first candle
-    write_tick({"time": 1_000_000_060, "bid": 101})
     t.join(timeout=5)
 
     assert not t.is_alive(), "run_live did not exit on idle timeout"


### PR DESCRIPTION
## Summary
- track timestamp of last processed candle and exit when idle timeout exceeded
- add test ensuring run_live stops if no new ticks arrive within timeout

## Testing
- `pre-commit run --files src/forest5/live/live_runner.py tests/test_live_runner_paper_smoke.py`
- `pytest tests/test_live_runner_paper_smoke.py -k 'test_live_runner_paper_smoke or test_live_runner_exits_on_idle_timeout' -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4271f69d48326ade532eac62ba418