### PR TITLE
Implement idle timeout handling in live runner

### DIFF
--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -24,6 +24,21 @@ def run_live(
     max_steps: int | None = None,
     timeout: float = 2.0,
 ) -> None:
+    """Run the live trading loop.
+
+    The loop processes incoming ticks, closes candles, and makes trading
+    decisions. It will exit early if no new candles are processed within
+    ``timeout`` seconds.
+
+    Parameters
+    ----------
+    settings:
+        Configuration for the live run.
+    max_steps:
+        Optional limit on number of candles to process.
+    timeout:
+        Seconds to wait for a new candle before stopping.
+    """
     btype = settings.broker.type.lower()
     if btype == "mt4":
         try:

--- a/tests/test_live_runner_paper_smoke.py
+++ b/tests/test_live_runner_paper_smoke.py
@@ -98,9 +98,13 @@ def test_live_runner_exits_on_idle_timeout(tmp_path: Path):
             errors.append(exc)
 
     t = threading.Thread(target=runner)
+    start = time.time()
     t.start()
     t.join(timeout=5)
+    elapsed = time.time() - start
 
     assert not t.is_alive(), "run_live did not exit on idle timeout"
+    # Give a small cushion above the requested timeout to account for scheduling
+    assert elapsed < 3, f"run_live took too long: {elapsed} sec"
     if errors:
         raise errors[0]


### PR DESCRIPTION
## Summary
- Document `run_live` timeout behaviour and detail parameters
- Add explicit timing check in paper smoke test to ensure idle timeout exit

## Testing
- `pytest tests/test_live_runner_paper_smoke.py::test_live_runner_paper_smoke tests/test_live_runner_paper_smoke.py::test_live_runner_exits_on_idle_timeout -q`


------
https://chatgpt.com/codex/tasks/task_e_68a42a9e124883269c7c99b3377fb980