### PR TITLE
Normalize strategy name aliases

### DIFF
--- a/src/forest5/signals/factory.py
+++ b/src/forest5/signals/factory.py
@@ -25,6 +25,10 @@ def _ema_cross_signal(close: pd.Series, fast: int, slow: int) -> pd.Series:
 
 def compute_signal(df: pd.DataFrame, settings, price_col: str = "close") -> pd.Series:
     name = getattr(settings.strategy, "name", "ema_cross")
+    if name in {"ema_rsi", "ema-cross+rsi"}:
+        settings.strategy.name = "ema_cross"
+        settings.strategy.use_rsi = True
+        name = "ema_cross"
     if name == "ema_cross":
         return _ema_cross_signal(df[price_col], settings.strategy.fast, settings.strategy.slow)
     raise ValueError(f"Unknown strategy: {name}")

--- a/tests/test_signals_factory.py
+++ b/tests/test_signals_factory.py
@@ -1,3 +1,5 @@
+import pytest
+
 from forest5.config import BacktestSettings
 from forest5.examples.synthetic import generate_ohlc
 from forest5.signals.factory import compute_signal
@@ -9,8 +11,24 @@ def test_compute_signal_ema_cross_basic():
     sig = compute_signal(df, s)
 
     # ta sama długość i indeks co dane
-    assert list(sig.index) == list(df.index)
+    assert list(sig.index) == list(df.index)  # nosec B101
     # dopuszczalne wartości
-    assert set(sig.unique()).issubset({-1, 0, 1})
+    assert set(sig.unique()).issubset({-1, 0, 1})  # nosec B101
     # nie wszystkie zera (powinny zdarzyć się przecięcia)
-    assert (sig != 0).any()
+    assert (sig != 0).any()  # nosec B101
+
+
+@pytest.mark.parametrize("alias", ["ema_rsi", "ema-cross+rsi"])
+def test_compute_signal_normalizes_rsi_alias(alias):
+    df = generate_ohlc(periods=60, start_price=100.0)
+    s = BacktestSettings()
+    s.strategy.name = alias
+    s.strategy.use_rsi = False
+
+    sig = compute_signal(df, s)
+
+    assert s.strategy.name == "ema_cross"  # nosec B101
+    assert s.strategy.use_rsi is True  # nosec B101
+    assert list(sig.index) == list(df.index)  # nosec B101
+    assert set(sig.unique()).issubset({-1, 0, 1})  # nosec B101
+    assert (sig != 0).any()  # nosec B101


### PR DESCRIPTION
## Summary
- normalize `ema_rsi` and `ema-cross+rsi` strategy names to `ema_cross` and enable RSI filter
- add tests covering strategy name normalization

## Testing
- `pre-commit run --files src/forest5/signals/factory.py tests/test_signals_factory.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a42c4ad3d883268bce0494a5ee73a3