### PR TITLE
Add CLI script for TimeOnlyModel training

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,14 @@ Podczas backtestów podobną funkcję pełnią opcje:
 settings.time.use_time_model = True
 settings.time.time_model_path = "models/model_time.json"
 ```
+
+## Trening modelu czasu
+
+Aby wytrenować prosty model czasu na danych z pliku CSV zawierającego kolumny
+`time` i `y` użyj skryptu `scripts/time_train.py`:
+
+```bash
+python scripts/time_train.py --input demo.csv --output models/model_time.json
+```
+
+Opcje `--q-low` i `--q-high` pozwalają dostroić kwantyle decyzyjne modelu.

--- a/scripts/time_train.py
+++ b/scripts/time_train.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""Train and save a TimeOnlyModel from CSV data."""
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from forest5.time_only import TimeOnlyModel, train
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train TimeOnlyModel and export to JSON")
+    parser.add_argument("--input", required=True, help="CSV file with 'time' and 'y' columns")
+    parser.add_argument("--output", required=True, help="Path to save model JSON")
+    parser.add_argument("--q-low", type=float, default=0.1, help="Lower quantile")
+    parser.add_argument("--q-high", type=float, default=0.9, help="Upper quantile")
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.input, parse_dates=["time"])
+    model = train(df, q_low=args.q_low, q_high=args.q_high)
+    Path(args.output).write_text(model.to_json())
+    # ensure model can be loaded back
+    TimeOnlyModel.load(args.output)
+    print(f"Saved model to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/forest5/time_only.py
+++ b/src/forest5/time_only.py
@@ -38,12 +38,15 @@ class TimeOnlyModel:
         return "WAIT"
 
     def save(self, path: str | Path) -> None:
+        Path(path).write_text(self.to_json())
+
+    def to_json(self) -> str:
         data = {
             "quantile_gates": {str(k): v for k, v in self.quantile_gates.items()},
             "q_low": self.q_low,
             "q_high": self.q_high,
         }
-        Path(path).write_text(json.dumps(data))
+        return json.dumps(data)
 
     @classmethod
     def load(cls, path: str | Path) -> "TimeOnlyModel":


### PR DESCRIPTION
## Summary
- add scripts/time_train.py CLI to train TimeOnlyModel and export JSON
- add TimeOnlyModel.to_json helper and refactor save
- document training script in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pandas pyyaml`
- `pytest tests/test_time_only.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a42e5cd0188326a2a79cdb28fa6968