### PR TITLE
chore: streamline CI install steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install package
-        run: pip install -e .
-      - name: Install dev dependencies
-        run: pip install -r requirements-dev.txt
+      - name: Install package (editable) + dev deps
+        run: |
+          pip install -e .
+          pip install -r requirements-dev.txt
       - name: Sanity imports
         run: |
           python - <<'PY'
           from importlib import import_module
-          for m in ("yaml","numpy","pandas","pytest","structlog","joblib"):
+          for m in ("yaml","numpy","pandas","pytest","structlog","joblib","pydantic"):
               import_module(m)
           print("deps-ok")
           PY


### PR DESCRIPTION
## Summary
- consolidate package and dev dependency installation into single CI step
- include pydantic in sanity import checks

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a446103e748326a3a98c4ccdc9b1e5