### PR TITLE
feat: add live settings loader

### DIFF
--- a/src/forest5/config/__init__.py
+++ b/src/forest5/config/__init__.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+# Backwards compatibility: re-export settings from the legacy config.py
+import importlib.util
+import sys
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "forest5._legacy_config", Path(__file__).resolve().parent.parent / "config.py"
+)
+_legacy = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
+assert _spec.loader is not None
+sys.modules[_spec.name] = _legacy  # register before execution for pydantic
+_spec.loader.exec_module(_legacy)  # type: ignore[assignment]
+
+# Ensure pydantic models are fully built
+for _model in (
+    _legacy.StrategySettings,
+    _legacy.RiskSettings,
+    _legacy.AISettings,
+    _legacy.TimeOnlySettings,
+    _legacy.BacktestTimeSettings,
+    _legacy.BacktestSettings,
+):
+    if hasattr(_model, "model_rebuild"):
+        _model.model_rebuild()
+
+# Re-export models and adjust __module__ for pickling
+for _name in [
+    "StrategySettings",
+    "RiskSettings",
+    "AISettings",
+    "TimeOnlySettings",
+    "BacktestTimeSettings",
+    "BacktestSettings",
+]:
+    _cls = getattr(_legacy, _name)
+    _cls.__module__ = __name__
+    globals()[_name] = _cls
+
+from .loader import load_live_settings
+
+__all__ = [
+    "load_live_settings",
+    "StrategySettings",
+    "RiskSettings",
+    "AISettings",
+    "TimeOnlySettings",
+    "BacktestTimeSettings",
+    "BacktestSettings",
+]

--- a/src/forest5/config/loader.py
+++ b/src/forest5/config/loader.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+import yaml
+
+from typing import Type
+
+
+def _pydantic_validate(model_cls: Type, data: dict):
+    if hasattr(model_cls, "model_validate"):
+        return model_cls.model_validate(data)  # type: ignore[call-arg]
+    if hasattr(model_cls, "parse_obj"):
+        return model_cls.parse_obj(data)  # type: ignore[attr-defined]
+    return model_cls(**data)
+
+
+def load_live_settings(path: str | Path):
+    from ..config_live import LiveSettings
+
+    p = Path(path)
+    text = os.path.expandvars(p.read_text(encoding="utf-8"))
+    data = yaml.safe_load(text) or {}
+    return _pydantic_validate(LiveSettings, data)


### PR DESCRIPTION
## Summary
- add config loader to parse YAML into `LiveSettings`
- expose loader and legacy config models from new `forest5.config` package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a447d12f3483269649453327b958d1