### PR TITLE
Load live example YAML into structured settings

### DIFF
--- a/src/forest5/config/__init__.py
+++ b/src/forest5/config/__init__.py
@@ -9,7 +9,7 @@ _spec = importlib.util.spec_from_file_location(
     "forest5._legacy_config", Path(__file__).resolve().parent.parent / "config.py"
 )
 _legacy = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
-assert _spec.loader is not None
+assert _spec.loader is not None  # nosec B101
 sys.modules[_spec.name] = _legacy  # register before execution for pydantic
 _spec.loader.exec_module(_legacy)  # type: ignore[assignment]
 
@@ -38,7 +38,7 @@ for _name in [
     _cls.__module__ = __name__
     globals()[_name] = _cls
 
-from .loader import load_live_settings
+from .loader import load_live_settings  # noqa: E402
 
 __all__ = [
     "load_live_settings",

--- a/src/forest5/config/loader.py
+++ b/src/forest5/config/loader.py
@@ -21,4 +21,6 @@ def load_live_settings(path: str | Path):
     p = Path(path)
     text = os.path.expandvars(p.read_text(encoding="utf-8"))
     data = yaml.safe_load(text) or {}
+    if hasattr(LiveSettings, "from_dict"):
+        return LiveSettings.from_dict(data)
     return _pydantic_validate(LiveSettings, data)

--- a/tests/test_live_example_yaml_shape.py
+++ b/tests/test_live_example_yaml_shape.py
@@ -1,23 +1,19 @@
 from pathlib import Path
-import yaml
+from forest5.config.loader import load_live_settings
 
 
-def test_live_example_yaml_structure():
-    p = Path("config/live.example.yaml")
-    assert p.exists(), "config/live.example.yaml must exist"
-    cfg = yaml.safe_load(p.read_text())
-    for k in ["broker", "risk", "ai", "time", "decision"]:
-        assert k in cfg, f"Missing '{k}' section"
-
-    broker_type = str(cfg["broker"].get("type", "")).lower()
-    assert broker_type in ("mt4", "paper", "mt5")
-    if broker_type == "mt4":
-        assert "bridge_dir" in cfg["broker"], "mt4 broker requires 'bridge_dir'"
-
-    for key in ["symbol", "volume", "timeframe"]:
-        assert key in cfg["broker"], f"Missing 'broker.{key}'"
-
-    assert "enabled" in cfg["ai"], "Missing 'ai.enabled'"
-    assert isinstance(cfg["ai"]["enabled"], bool), "'ai.enabled' must be boolean"
-
-    assert "min_confluence" in cfg["decision"], "Missing 'decision.min_confluence'"
+def test_live_example_yaml_parses_and_has_fields():
+    s = load_live_settings(Path("config/live.example.yaml"))
+    assert hasattr(s, "broker")  # nosec B101
+    assert hasattr(s, "ai")  # nosec B101
+    assert hasattr(s, "time")  # nosec B101
+    assert hasattr(s, "decision")  # nosec B101
+    assert getattr(s.decision, "min_confluence", None) is not None  # nosec B101
+    assert int(s.decision.min_confluence) >= 1  # nosec B101
+    assert hasattr(s.ai, "context_file")  # nosec B101
+    tm = s.time.model if hasattr(s.time, "model") else None
+    assert tm is not None  # nosec B101
+    assert hasattr(tm, "enabled")  # nosec B101
+    assert hasattr(tm, "path")  # nosec B101
+    assert hasattr(tm, "q_low")  # nosec B101
+    assert hasattr(tm, "q_high")  # nosec B101


### PR DESCRIPTION
## Summary
- Replace live config shape test with parsing validation
- Parse live settings YAML into dataclass models and ignore unknown keys
- Handle nested time model settings and add missing broker timeframe field

## Testing
- `pre-commit run --files tests/test_live_example_yaml_shape.py src/forest5/config/__init__.py src/forest5/config/loader.py src/forest5/config_live.py`
- `pytest tests/test_live_example_yaml_shape.py`

------
https://chatgpt.com/codex/tasks/task_e_68a44a90e7dc8326a956a15565a181ff