### PR TITLE
Normalize paths in live settings loader

### DIFF
--- a/src/forest5/config/loader.py
+++ b/src/forest5/config/loader.py
@@ -17,6 +17,19 @@ def _is_windows_path_literal(path: str | None) -> bool:
     return WINDOWS_PATH_LITERAL_RE.match(path) is not None
 
 
+def _expand_env_user(v: str) -> str:
+    return os.path.expanduser(os.path.expandvars(v))
+
+
+def _norm_path(v: str | None) -> str | None:
+    if v is None:
+        return None
+    if v == "":
+        return ""
+    p = Path(_expand_env_user(v))
+    return str(p.resolve(strict=False))
+
+
 def _pydantic_validate(model_cls: Type, data: dict):
     if hasattr(model_cls, "model_validate"):
         return model_cls.model_validate(data)  # type: ignore[call-arg]
@@ -29,8 +42,31 @@ def load_live_settings(path: str | Path):
     from ..config_live import LiveSettings
 
     p = Path(path)
-    text = os.path.expandvars(p.read_text(encoding="utf-8"))
+    text = p.read_text(encoding="utf-8")
     data = yaml.safe_load(text) or {}
+
+    broker = data.get("broker")
+    if isinstance(broker, dict):
+        bridge_dir = broker.get("bridge_dir")
+        if not _is_windows_path_literal(bridge_dir):
+            broker["bridge_dir"] = _norm_path(bridge_dir)
+        data["broker"] = broker
+
+    ai = data.get("ai")
+    if isinstance(ai, dict):
+        ctx = _norm_path(ai.get("context_file"))
+        ai["context_file"] = "" if ctx is None else ctx
+        data["ai"] = ai
+
+    time = data.get("time")
+    if isinstance(time, dict):
+        model = time.get("model")
+        if isinstance(model, dict):
+            mpath = _norm_path(model.get("path"))
+            model["path"] = "" if mpath is None else mpath
+            time["model"] = model
+        data["time"] = time
+
     if hasattr(LiveSettings, "from_dict"):
         return LiveSettings.from_dict(data)
     return _pydantic_validate(LiveSettings, data)

--- a/tests/test_config_loader_paths.py
+++ b/tests/test_config_loader_paths.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+import textwrap
+
+from forest5.config.loader import load_live_settings
+
+
+def test_load_live_settings_expands_paths(tmp_path: Path, monkeypatch):
+    ctx = tmp_path / "ctx.txt"
+    ctx.write_text("hi", encoding="utf-8")
+    model = tmp_path / "model.bin"
+    model.write_text("m", encoding="utf-8")
+    bridge = tmp_path / "bridge"
+    bridge.mkdir()
+
+    monkeypatch.setenv("CTX_PATH", str(ctx))
+    monkeypatch.setenv("MODEL_PATH", str(model))
+    monkeypatch.setenv("BRIDGE_PATH", str(bridge))
+
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            """
+            broker:
+              type: mt4
+              bridge_dir: "${BRIDGE_PATH}"
+            ai:
+              context_file: "${CTX_PATH}"
+            time:
+              model:
+                path: "${MODEL_PATH}"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    s = load_live_settings(cfg)
+
+    assert s.ai.context_file == str(ctx)
+    assert str(s.time.model.path) == str(model)
+    assert str(s.broker.bridge_dir) == str(bridge)
+
+
+def test_load_live_settings_none_to_empty(tmp_path: Path):
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            """
+            broker:
+              type: mt4
+            ai:
+              context_file: null
+            time:
+              model:
+                path: null
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    s = load_live_settings(cfg)
+
+    assert s.ai.context_file == ""
+    assert str(getattr(s.time.model, "path", "")) in {"", "."}
+


### PR DESCRIPTION
## Summary
- normalize and expand paths in live settings loader instead of expanding whole file
- ensure optional paths return empty string when unspecified
- add tests for path expansion and empty handling

## Testing
- `pytest` *(fails: 36 errors during collection due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a4699294dc83269dba2428f078085f