### PR TITLE
Simplify package initialization

### DIFF
--- a/src/forest5/__init__.py
+++ b/src/forest5/__init__.py
@@ -1,18 +1,5 @@
-# src/forest5/__init__.py
-"""Forest 5.0 – zestaw narzędzi do researchu i backtestów."""
+"""Forest 5.0 package."""
 
-from __future__ import annotations
+__all__ = []
+__version__ = "0.0.0"
 
-from importlib.metadata import PackageNotFoundError, version
-from pathlib import Path
-import tomllib
-
-try:
-    __version__ = version("forest5")
-except PackageNotFoundError:
-    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
-    __version__ = tomllib.loads(pyproject.read_text())["tool"]["poetry"]["version"]
-
-from . import time_only
-
-__all__ = ["__version__", "time_only"]


### PR DESCRIPTION
## Summary
- reduce `forest5` package `__init__` to a lightweight stub

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install numpy pandas pydantic pyyaml` *(fails: Could not find a version that satisfies the requirement numpy due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68a46c2c9ff88326a2ef7abed35ddc53