### PR TITLE
Expose vote reasoning in DecisionAgent

### DIFF
--- a/src/forest5/decision.py
+++ b/src/forest5/decision.py
@@ -31,27 +31,38 @@ class DecisionAgent:
         self.config = config or DecisionConfig()
         self.ai = SentimentAgent() if self.config.use_ai else None
 
-    def decide(self, ts, tech_signal: int, value: float, symbol: str, context_text: str = "") -> str:
-        votes = [1 if tech_signal > 0 else (-1 if tech_signal < 0 else 0)]
+    def decide(
+        self,
+        ts,
+        tech_signal: int,
+        value: float,
+        symbol: str,
+        context_text: str = "",
+    ) -> tuple[str, dict[str, int], str]:
+        votes = {
+            "tech": 1 if tech_signal > 0 else (-1 if tech_signal < 0 else 0),
+            "time": 0,
+            "ai": 0,
+        }
 
         if self.config.time_model:
             tm_decision = self.config.time_model.decide(ts, value)
             if tm_decision == "WAIT":
-                return "WAIT"
-            votes.append(1 if tm_decision == "BUY" else -1)
+                return "WAIT", votes, "time_wait"
+            votes["time"] = 1 if tm_decision == "BUY" else -1
 
         if self.ai:
             s = self.ai.analyse(context_text, symbol).score
-            votes.append(1 if s > 0 else (-1 if s < 0 else 0))
+            votes["ai"] = 1 if s > 0 else (-1 if s < 0 else 0)
 
-        pos = sum(1 for v in votes if v > 0)
-        neg = sum(1 for v in votes if v < 0)
+        pos = sum(1 for v in votes.values() if v > 0)
+        neg = sum(1 for v in votes.values() if v < 0)
 
         if max(pos, neg) < (self.config.min_confluence or 1):
-            return "WAIT"
+            return "WAIT", votes, "no_consensus"
 
         if pos > neg:
-            return "BUY"
+            return "BUY", votes, "buy_majority"
         if neg > pos:
-            return "SELL"
-        return "WAIT"
+            return "SELL", votes, "sell_majority"
+        return "WAIT", votes, "no_consensus"

--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -158,7 +158,7 @@ def run_live(
                             log.info("time_blocked", time=str(idx))
                         else:
                             sig = int(compute_signal(df, settings, "close").iloc[-1])
-                            decision = agent.decide(
+                            decision, votes, reason = agent.decide(
                                 idx,
                                 sig,
                                 current_bar["close"],
@@ -170,6 +170,8 @@ def run_live(
                                 time=str(idx),
                                 symbol=settings.broker.symbol,
                                 decision=decision,
+                                votes=votes,
+                                reason=reason,
                             )
                             if decision in ("BUY", "SELL"):
                                 broker.market_order(decision, settings.broker.volume, price)

--- a/tests/test_decision_agent.py
+++ b/tests/test_decision_agent.py
@@ -9,9 +9,10 @@ def test_decision_agent_waits_when_time_model_waits() -> None:
     agent = DecisionAgent(config=DecisionConfig(time_model=time_model))
 
     ts = datetime(2024, 1, 1)  # 00:00
-    assert (
-        agent.decide(ts, tech_signal=1, value=0.0, symbol="EURUSD") == "WAIT"
-    )
+    decision, votes, reason = agent.decide(ts, tech_signal=1, value=0.0, symbol="EURUSD")
+    assert decision == "WAIT"
+    assert votes == {"tech": 1, "time": 0, "ai": 0}
+    assert reason == "time_wait"
 
 
 def test_decision_agent_majority_and_tie() -> None:
@@ -19,17 +20,42 @@ def test_decision_agent_majority_and_tie() -> None:
     agent = DecisionAgent(config=DecisionConfig(time_model=time_model))
     ts = datetime(2024, 1, 1)
 
-    assert agent.decide(ts, tech_signal=1, value=2.0, symbol="EURUSD") == "BUY"
-    assert agent.decide(ts, tech_signal=-1, value=-2.0, symbol="EURUSD") == "SELL"
-    assert agent.decide(ts, tech_signal=1, value=-2.0, symbol="EURUSD") == "WAIT"
+    decision, votes, reason = agent.decide(ts, tech_signal=1, value=2.0, symbol="EURUSD")
+    assert (decision, votes, reason) == (
+        "BUY",
+        {"tech": 1, "time": 1, "ai": 0},
+        "buy_majority",
+    )
+    decision, votes, reason = agent.decide(ts, tech_signal=-1, value=-2.0, symbol="EURUSD")
+    assert (decision, votes, reason) == (
+        "SELL",
+        {"tech": -1, "time": -1, "ai": 0},
+        "sell_majority",
+    )
+    decision, votes, reason = agent.decide(ts, tech_signal=1, value=-2.0, symbol="EURUSD")
+    assert (decision, votes, reason) == (
+        "WAIT",
+        {"tech": 1, "time": -1, "ai": 0},
+        "no_consensus",
+    )
 
 
 def test_decision_agent_respects_confluence_threshold() -> None:
     ts = datetime(2024, 1, 1)
     agent = DecisionAgent(config=DecisionConfig(min_confluence=2))
 
-    assert agent.decide(ts, tech_signal=1, value=0.0, symbol="EURUSD") == "WAIT"
+    decision, votes, reason = agent.decide(ts, tech_signal=1, value=0.0, symbol="EURUSD")
+    assert (decision, votes, reason) == (
+        "WAIT",
+        {"tech": 1, "time": 0, "ai": 0},
+        "no_consensus",
+    )
 
     time_model = TimeOnlyModel({0: (-1.0, 1.0)}, q_low=-1.0, q_high=1.0)
     agent2 = DecisionAgent(config=DecisionConfig(time_model=time_model, min_confluence=2))
-    assert agent2.decide(ts, tech_signal=1, value=2.0, symbol="EURUSD") == "BUY"
+    decision, votes, reason = agent2.decide(ts, tech_signal=1, value=2.0, symbol="EURUSD")
+    assert (decision, votes, reason) == (
+        "BUY",
+        {"tech": 1, "time": 1, "ai": 0},
+        "buy_majority",
+    )

--- a/tests/test_decision_fusion_min_confluence.py
+++ b/tests/test_decision_fusion_min_confluence.py
@@ -15,13 +15,28 @@ def test_wait_short_circuit() -> None:
     tm = DummyTimeModel("WAIT")
     agent = DecisionAgent(config=DecisionConfig(time_model=tm, min_confluence=2))
     ts = datetime(2024, 1, 1)
-    assert agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD") == "WAIT"
+    decision, votes, reason = agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")
+    assert (decision, votes, reason) == (
+        "WAIT",
+        {"tech": 1, "time": 0, "ai": 0},
+        "time_wait",
+    )
 
 
 def test_min_confluence_requires_both_votes() -> None:
     tm = DummyTimeModel("BUY")
     agent = DecisionAgent(config=DecisionConfig(time_model=tm, min_confluence=2))
     ts = datetime(2024, 1, 1)
-    assert agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD") == "BUY"
-    assert agent.decide(ts, tech_signal=0, value=1.0, symbol="EURUSD") == "WAIT"
+    decision, votes, reason = agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")
+    assert (decision, votes, reason) == (
+        "BUY",
+        {"tech": 1, "time": 1, "ai": 0},
+        "buy_majority",
+    )
+    decision, votes, reason = agent.decide(ts, tech_signal=0, value=1.0, symbol="EURUSD")
+    assert (decision, votes, reason) == (
+        "WAIT",
+        {"tech": 0, "time": 1, "ai": 0},
+        "no_consensus",
+    )
 


### PR DESCRIPTION
## Summary
- return `(decision, votes, reason)` from `DecisionAgent.decide`
- log vote map and reason in live runner
- expand tests for majority, tie, and time model WAIT scenarios

## Testing
- `pytest tests/test_decision_agent.py tests/test_decision_fusion_min_confluence.py tests/test_live_runner_paper_smoke.py tests/test_ai_agent.py tests/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5ab5f0418832686562fcc7a321191