### PR TITLE
Add on_drawdown risk configuration

### DIFF
--- a/src/forest5/backtest/risk.py
+++ b/src/forest5/backtest/risk.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List
 
+from ..config import OnDrawdownSettings
+
 
 @dataclass
 class RiskManager:
@@ -11,6 +13,7 @@ class RiskManager:
     max_drawdown: float = 0.30
     fee_perc: float = 0.0005
     slippage_perc: float = 0.0
+    on_drawdown: OnDrawdownSettings | dict = field(default_factory=OnDrawdownSettings)
 
     _cash: float = field(default=0.0, init=False)
     _position: float = field(default=0.0, init=False)  # qty (long-only w testach)
@@ -19,6 +22,8 @@ class RiskManager:
     _peak: float = field(init=False)
 
     def __post_init__(self) -> None:
+        if isinstance(self.on_drawdown, dict):
+            self.on_drawdown = OnDrawdownSettings(**self.on_drawdown)
         self._cash = float(self.initial_capital)
         self._peak = float(self.initial_capital)
         # baseline – 1 punkt na starcie

--- a/src/forest5/config.py
+++ b/src/forest5/config.py
@@ -19,12 +19,17 @@ class StrategySettings(BaseModel):
     rsi_oversold: int = 30
 
 
+class OnDrawdownSettings(BaseModel):
+    action: Literal["halt", "soft_wait"] = "halt"
+
+
 class RiskSettings(BaseModel):
     initial_capital: float = 100_000.0
     risk_per_trade: float = 0.01
     max_drawdown: float = 0.30
     fee_perc: float = 0.0005
     slippage_perc: float = 0.0
+    on_drawdown: OnDrawdownSettings = Field(default_factory=OnDrawdownSettings)
 
 
 class AISettings(BaseModel):

--- a/src/forest5/config/__init__.py
+++ b/src/forest5/config/__init__.py
@@ -17,6 +17,7 @@ _spec.loader.exec_module(_legacy)  # type: ignore[assignment]
 for _model in (
     _legacy.StrategySettings,
     _legacy.RiskSettings,
+    _legacy.OnDrawdownSettings,
     _legacy.AISettings,
     _legacy.TimeOnlySettings,
     _legacy.BacktestTimeSettings,
@@ -29,6 +30,7 @@ for _model in (
 for _name in [
     "StrategySettings",
     "RiskSettings",
+    "OnDrawdownSettings",
     "AISettings",
     "TimeOnlySettings",
     "BacktestTimeSettings",
@@ -44,6 +46,7 @@ __all__ = [
     "load_live_settings",
     "StrategySettings",
     "RiskSettings",
+    "OnDrawdownSettings",
     "AISettings",
     "TimeOnlySettings",
     "BacktestTimeSettings",

--- a/src/forest5/config_live.py
+++ b/src/forest5/config_live.py
@@ -95,7 +95,19 @@ class LiveSettings:
                 keys = cls.__fields__
             else:
                 return section
-            return {k: v for k, v in section.items() if k in keys}
+
+            result = {}
+            for k, v in section.items():
+                if k in keys:
+                    field_info = keys[k]
+                    field_type = getattr(
+                        field_info, "type", getattr(field_info, "annotation", getattr(field_info, "outer_type_", None))
+                    )
+                    if isinstance(v, dict) and field_type is not None:
+                        result[k] = _filter(field_type, v)
+                    else:
+                        result[k] = v
+            return result
 
         return cls(
             broker=BrokerSettings(**_filter(BrokerSettings, data.get("broker", {}))),


### PR DESCRIPTION
## Summary
- add `OnDrawdownSettings` model and expose via `RiskSettings`
- ensure live config loader retains nested settings
- allow `RiskManager` to accept `on_drawdown`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5badecbe08326af147123c2eb52ff