### PR TITLE
Document drawdown action in risk settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,28 @@ settings = LiveSettings(
 run_live(settings, max_steps=10)
 ```
 
+## Zarządzanie ryzykiem
+
+### `risk.on_drawdown.action`
+
+Parametr `risk.on_drawdown.action` określa reakcję systemu po osiągnięciu
+progu `risk.max_drawdown`.
+
+- `"halt"` – natychmiast wstrzymuje handel po przekroczeniu maksymalnego
+  obsunięcia kapitału (wymagany ręczny restart).
+- `"soft_wait"` – pauzuje otwieranie nowych pozycji do czasu, aż kapitał
+  powróci powyżej zadanego progu.
+
+Przykład konfiguracji:
+
+```yaml
+risk:
+  risk_per_trade: 0.005
+  max_drawdown: 0.20
+  on_drawdown:
+    action: "halt"  # lub "soft_wait"
+```
+
 ## Backtest + TimeOnly
 
 Sekcja `time` pozwala łączyć sygnały strategii z modelem czasu oraz blokować wybrane przedziały:

--- a/config/live.example.yaml
+++ b/config/live.example.yaml
@@ -8,6 +8,8 @@ broker:
 risk:
   risk_per_trade: 0.005
   max_drawdown: 0.20
+  on_drawdown:
+    action: "halt"  # or "soft_wait"
 
 ai:
   enabled: false


### PR DESCRIPTION
## Summary
- document `risk.on_drawdown.action` with `halt` and `soft_wait` options in README
- extend `live.example.yaml` risk block with `on_drawdown.action`

## Testing
- `pytest tests/test_config.py tests/test_risk.py tests/test_risk_guard.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5beebcc088326a1ccdc7a2fa562dd