### PR TITLE
Add typing tools to dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,6 @@ flake8>=7.1
 bandit>=1.8.6
 pip-audit>=2.9.0
 pytest-cov>=6.2.1
+mypy
+pandas-stubs
+types-PyYAML


### PR DESCRIPTION
## Summary
- include mypy and type stubs in development requirements

## Testing
- `pip install -r requirements-dev.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5e54798ec8326bbf0631f6b54ad85