### PR TITLE
Add type hints and narrow exception handling

### DIFF
--- a/src/forest5/config/loader.py
+++ b/src/forest5/config/loader.py
@@ -5,7 +5,10 @@ import os
 import re
 import yaml
 
-from typing import Type
+from typing import Any, TYPE_CHECKING, Type
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ..config_live import LiveSettings
 
 
 WINDOWS_PATH_LITERAL_RE = re.compile(r"^[A-Za-z]:\\")
@@ -34,15 +37,15 @@ def _norm_path(base_dir: Path, v: str | None) -> str | None:
     return str(p.resolve(strict=False))
 
 
-def _pydantic_validate(model_cls: Type, data: dict):
+def _pydantic_validate(model_cls: Type, data: dict) -> Any:
     if hasattr(model_cls, "model_validate"):
-        return model_cls.model_validate(data)  # type: ignore[call-arg]
+        return model_cls.model_validate(data)
     if hasattr(model_cls, "parse_obj"):
-        return model_cls.parse_obj(data)  # type: ignore[attr-defined]
+        return model_cls.parse_obj(data)
     return model_cls(**data)
 
 
-def load_live_settings(path: str | Path):
+def load_live_settings(path: str | Path) -> "LiveSettings":
     from ..config_live import LiveSettings
 
     p = Path(path)

--- a/src/forest5/decision.py
+++ b/src/forest5/decision.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import pandas as pd
+
 from .ai_agent import SentimentAgent
 from .live.router import OrderRouter, PaperBroker
 from .time_only import TimeOnlyModel
@@ -33,7 +35,7 @@ class DecisionAgent:
 
     def decide(
         self,
-        ts,
+        ts: pd.Timestamp,
         tech_signal: int,
         value: float,
         symbol: str,

--- a/src/forest5/live/mt4_broker.py
+++ b/src/forest5/live/mt4_broker.py
@@ -115,7 +115,7 @@ class MT4Broker(OrderRouter):
                     time.sleep(min(delay, max(0, deadline - time.time())))
                     delay = min(delay * 2, 1.0)
                     continue
-                except Exception as exc:  # pragma: no cover - defensive
+                except (OSError, ValueError, TypeError) as exc:  # pragma: no cover - defensive
                     log.exception("invalid_result", path=str(res_path), error=str(exc))
                     time.sleep(min(delay, max(0, deadline - time.time())))
                     continue
@@ -168,7 +168,7 @@ class MT4Broker(OrderRouter):
             if tmp_path.exists():
                 try:
                     tmp_path.unlink()
-                except Exception:
+                except OSError:
                     pass
         send_latency_ms = (time.time() - start_ts) * 1000.0
         log.info(
@@ -215,7 +215,7 @@ class MT4Broker(OrderRouter):
         except FileNotFoundError:
             log.warning("position_file_missing", path=str(pos_file))
             return 0.0
-        except Exception:  # pragma: no cover - defensive
+        except (OSError, json.JSONDecodeError, ValueError, TypeError):  # pragma: no cover - defensive
             log.exception("position_file_error")
             return 0.0
 
@@ -227,7 +227,7 @@ class MT4Broker(OrderRouter):
         except FileNotFoundError:
             log.warning("account_file_missing", path=str(acc_file))
             return 0.0
-        except Exception:  # pragma: no cover - defensive
+        except (OSError, json.JSONDecodeError, ValueError, TypeError):  # pragma: no cover - defensive
             log.exception("account_file_error")
             return 0.0
 


### PR DESCRIPTION
## Summary
- tighten live trade runner context loading and broker setup with typed interfaces and specific error handling
- annotate decision agent timestamp handling using pandas types
- refine MT4 broker file operations with explicit exception classes
- add type-aware config loader utilities and return type for live settings loader

## Testing
- `pytest -q`
- `mypy --explicit-package-bases src/forest5/live/live_runner.py src/forest5/live/mt4_broker.py src/forest5/decision.py src/forest5/config/loader.py` *(fails: missing stubs and untyped code)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ea6cde3c832692a58748189f9c0d