### PR TITLE
style: run ruff formatting and fix warnings

### DIFF
--- a/tests/test_mt4_broker_file_bridge.py
+++ b/tests/test_mt4_broker_file_bridge.py
@@ -1,4 +1,8 @@
-import json, time, sys, types, importlib.util
+import json
+import time
+import sys
+import types
+import importlib.util
 from pathlib import Path
 from threading import Thread
 

--- a/tests/test_mt4_broker_hardening.py
+++ b/tests/test_mt4_broker_hardening.py
@@ -1,6 +1,8 @@
-import json, threading, time, importlib
+import json
+import threading
+import time
+import importlib
 from pathlib import Path
-import pytest
 
 def _import_mt4broker():
     """
@@ -48,11 +50,20 @@ def _fake_ea_loop(bridge: Path, stop_evt: threading.Event):
     while not stop_evt.is_set():
         for p in list(cmd.glob("cmd_*.json")):
             try:
-                s = json.loads(p.read_text(encoding="utf-8"))
+                json.loads(p.read_text(encoding="utf-8"))
                 rid = p.stem[4:]  # po 'cmd_'
-                _write_text(res / f"res_{rid}.json",
-                            json.dumps({"id": rid, "status": "filled",
-                                        "ticket": 1, "price": 1.23456, "error": None}))
+                _write_text(
+                    res / f"res_{rid}.json",
+                    json.dumps(
+                        {
+                            "id": rid,
+                            "status": "filled",
+                            "ticket": 1,
+                            "price": 1.23456,
+                            "error": None,
+                        }
+                    ),
+                )
                 p.unlink(missing_ok=True)
             except Exception:
                 # Nie maskujemy błędów modułów – ale w testowej pętli EA


### PR DESCRIPTION
## Summary
- format tests with `ruff --fix`
- remove unused variables and tidy JSON handling in tests

## Testing
- `ruff check tests/test_mt4_broker_file_bridge.py tests/test_mt4_broker_hardening.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5ed659d908326b535a47abd5b45a2