### PR TITLE
Add tests for decision fusion tie, time model boundaries, and path normalization

### DIFF
--- a/tests/test_config_windows_path.py
+++ b/tests/test_config_windows_path.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+from forest5.config.loader import _norm_path
+
+
+def test_windows_literal_path_unchanged(tmp_path: Path) -> None:
+    base = tmp_path
+    win_path = "C:\\Temp\\model.bin"
+    assert _norm_path(base, win_path) == win_path

--- a/tests/test_decision_fusion_tie.py
+++ b/tests/test_decision_fusion_tie.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from forest5.decision import DecisionAgent, DecisionConfig
+
+
+class DummyTimeModel:
+    def decide(self, ts, value: float) -> str:  # pragma: no cover - simple
+        return "SELL"
+
+
+def test_min_confluence_conflicting_votes_wait() -> None:
+    """Conflicting votes with min_confluence=2 should result in WAIT."""
+    tm = DummyTimeModel()
+    agent = DecisionAgent(config=DecisionConfig(time_model=tm, min_confluence=2))
+    ts = datetime(2024, 1, 1)
+    decision, votes, reason = agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")
+    assert (decision, votes, reason) == (
+        "WAIT",
+        {"tech": 1, "time": -1, "ai": 0},
+        "no_consensus",
+    )

--- a/tests/test_time_only_boundaries.py
+++ b/tests/test_time_only_boundaries.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+from forest5.time_only import TimeOnlyModel
+
+
+def test_boundaries_sell_buy() -> None:
+    model = TimeOnlyModel(quantile_gates={0: (1.0, 2.0)}, q_low=0.1, q_high=0.9)
+    ts = datetime(2024, 1, 1, 0, 0)
+    assert model.decide(ts, 1.0) == "SELL"
+    assert model.decide(ts, 2.0) == "BUY"


### PR DESCRIPTION
## Summary
- test decision fusion tie with min_confluence
- cover TimeOnlyModel boundary conditions
- ensure windows path literals remain unmodified

## Testing
- `pre-commit run --files tests/test_decision_fusion_tie.py tests/test_time_only_boundaries.py tests/test_config_windows_path.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5eebaa6f883268918867f79faf90d