### PR TITLE
Correct sell fee calculation to use executed quantity

### DIFF
--- a/src/forest5/live/router.py
+++ b/src/forest5/live/router.py
@@ -77,10 +77,10 @@ class PaperBroker:
             return OrderResult(self._id, "rejected", 0.0, 0.0, "qty <= 0")
 
         side_u = side.upper()
-        notional = px * qty
-        fee = self._fee(notional)
 
         if side_u == "BUY":
+            notional = px * qty
+            fee = self._fee(notional)
             # kupno: zmniejsza cash o koszt i fee, zwiększa pozycję
             self._cash -= notional + fee
             new_qty = self._pos + qty
@@ -94,7 +94,9 @@ class PaperBroker:
             sell_qty = min(qty, self._pos)
             if sell_qty <= 0:
                 return OrderResult(self._id, "rejected", 0.0, 0.0, "no position to sell")
-            self._cash += px * sell_qty - fee
+            notional = px * sell_qty
+            fee = self._fee(notional)
+            self._cash += notional - fee
             self._pos -= sell_qty
             if self._pos == 0.0:
                 self._avg = 0.0

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,3 +1,5 @@
+import pytest
+
 from forest5.live.router import PaperBroker
 
 
@@ -23,3 +25,14 @@ def test_rejects_without_price_or_connection():
     assert r.error is not None
     b.connect()
     assert b.market_order("BUY", 1).status == "rejected"  # no price
+
+
+def test_sell_fee_uses_executed_qty():
+    b = PaperBroker(fee_perc=0.1)
+    b.connect()
+    b.set_price(100.0)
+    b.market_order("BUY", 5)
+    b.set_price(100.0)
+    r = b.market_order("SELL", 10)
+    assert r.filled_qty == 5
+    assert b.equity() == pytest.approx(99_900.0)


### PR DESCRIPTION
## Summary
- adjust PaperBroker.market_order to compute sell notional and fee from executed quantity
- cover partial position sells with regression test ensuring correct fee calculation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5fcf6f31083269c171a0361b695d8