### PR TITLE
Copy input DataFrame during validation

### DIFF
--- a/src/forest5/utils/validate.py
+++ b/src/forest5/utils/validate.py
@@ -9,6 +9,7 @@ def ensure_backtest_ready(df: pd.DataFrame, price_col: str = "close") -> pd.Data
     - Ustawia indeks czasu (tz-naive) z aliasów: time/date/datetime/timestamp
     - Sortuje, usuwa duplikaty, nazywa indeks 'time'
     """
+    df = df.copy()
     required = {"open", "high", "low", "close"}
     if not required.issubset(set(df.columns)):
         raise ValueError(f"CSV must contain columns: {sorted(required)}")
@@ -24,7 +25,6 @@ def ensure_backtest_ready(df: pd.DataFrame, price_col: str = "close") -> pd.Data
             raise ValueError(
                 "DataFrame must have DatetimeIndex or one of: 'time', 'date', 'datetime', 'timestamp'."
             )
-        df = df.copy()
         df[time_col] = pd.to_datetime(df[time_col], utc=False, errors="coerce")
         df = df.set_index(time_col)
 

--- a/tests/test_validate_ready.py
+++ b/tests/test_validate_ready.py
@@ -17,3 +17,18 @@ def test_validate_accepts_time_column_and_makes_index():
     assert isinstance(out.index, pd.DatetimeIndex)
     assert out.index.is_monotonic_increasing
     assert set(["open", "high", "low", "close"]).issubset(out.columns)
+
+
+def test_validate_does_not_modify_input_df():
+    df = pd.DataFrame(
+        {
+            "time": ["2020-01-01 00:00", "2020-01-01 01:00"],
+            "open": [1.1, 1.2],
+            "high": [1.2, 1.3],
+            "low": [1.0, 1.1],
+            "close": [1.15, 1.25],
+        }
+    )
+    original = df.copy()
+    ensure_backtest_ready(df, price_col="close")
+    pd.testing.assert_frame_equal(df, original)


### PR DESCRIPTION
## Summary
- avoid mutating callers by copying DataFrame in `ensure_backtest_ready`
- test that validation keeps original DataFrame unchanged

## Testing
- `pre-commit run --files src/forest5/utils/validate.py tests/test_validate_ready.py`
- `pytest tests/test_validate_ready.py tests/test_validate_time_aliases_dupes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a60ee3c8248326914ed5efdf1ce040