### PR TITLE
Use incremental live signals

### DIFF
--- a/tests/test_live_runner_paper_smoke.py
+++ b/tests/test_live_runner_paper_smoke.py
@@ -1,6 +1,11 @@
 from pathlib import Path
 
-from forest5.live.live_runner import run_live
+import timeit
+
+import pandas as pd
+
+from forest5.live.live_runner import run_live, _append_bar_and_signal
+from forest5.signals.factory import compute_signal
 from forest5.live.settings import (
     LiveSettings,
     BrokerSettings,
@@ -40,3 +45,36 @@ def test_run_live_paper(tmp_path: Path):
         risk=RiskSettings(max_drawdown=0.5),
     )
     run_live(s, max_steps=2)
+
+
+def test_incremental_signal_perf():
+    settings = LiveSettings(
+        broker=BrokerSettings(type="paper", bridge_dir=".", symbol="EURUSD", volume=0.01),
+        decision=DecisionSettings(min_confluence=1),
+        ai=AISettings(enabled=False, model="gpt-4o-mini", max_tokens=64, context_file=None),
+        time=TimeSettings(blocked_hours=[], blocked_weekdays=[]),
+        risk=RiskSettings(max_drawdown=0.5),
+    )
+    N = 200
+
+    def naive() -> None:
+        df = pd.DataFrame(columns=["open", "high", "low", "close"])
+        bar = {"start": 0, "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0}
+        for i in range(N):
+            bar["start"] = i
+            bar["open"] = bar["high"] = bar["low"] = bar["close"] = 1 + 0.0001 * i
+            idx = pd.to_datetime(bar["start"], unit="s")
+            df.loc[idx] = [bar["open"], bar["high"], bar["low"], bar["close"]]
+            compute_signal(df, settings, "close").iloc[-1]
+
+    def incremental() -> None:
+        df = pd.DataFrame(columns=["open", "high", "low", "close"])
+        bar = {"start": 0, "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0}
+        for i in range(N):
+            bar["start"] = i
+            bar["open"] = bar["high"] = bar["low"] = bar["close"] = 1 + 0.0001 * i
+            _append_bar_and_signal(df, bar, settings)
+
+    t_naive = timeit.timeit(naive, number=3)
+    t_inc = timeit.timeit(incremental, number=3)
+    assert t_inc < t_naive


### PR DESCRIPTION
## Summary
- add helper to append bars and compute EMA cross signals incrementally
- update live runner to avoid full DataFrame recomputation
- add performance benchmark verifying incremental signal is faster

## Testing
- `pytest tests/test_live_runner_paper_smoke.py`
- `pytest tests/test_live_runner_soft_wait.py`


------
https://chatgpt.com/codex/tasks/task_e_68a61323bc708326a03692941d2d17f7