### PR TITLE
Add drawdown guard and improve live runner

### DIFF
--- a/tests/test_live_imports.py
+++ b/tests/test_live_imports.py
@@ -1,0 +1,2 @@
+def test_live_imports() -> None:
+    __import__("forest5.live.live_runner")

--- a/tests/test_live_read_context.py
+++ b/tests/test_live_read_context.py
@@ -13,3 +13,9 @@ def test_read_context_removes_binary_noise(tmp_path: Path) -> None:
     p = tmp_path / "ctx.txt"
     p.write_bytes(b"hello\xffworld")
     assert _read_context(p, 100) == "helloworld"
+
+
+def test_read_context_binary_truncated(tmp_path: Path) -> None:
+    p = tmp_path / "ctx.bin"
+    p.write_bytes(b"abc\xffdefghij")
+    assert _read_context(p, 8) == "abcdefg"

--- a/tests/test_live_runner_paper_smoke.py
+++ b/tests/test_live_runner_paper_smoke.py
@@ -33,7 +33,7 @@ def _mk_bridge(tmpdir: Path) -> Path:
     return bridge
 
 
-def test_run_live_paper(tmp_path: Path):
+def test_run_live_paper(tmp_path: Path, capfd):
     bridge = _mk_bridge(tmp_path)
     s = LiveSettings(
         broker=BrokerSettings(
@@ -45,6 +45,8 @@ def test_run_live_paper(tmp_path: Path):
         risk=RiskSettings(max_drawdown=0.5),
     )
     run_live(s, max_steps=2)
+    out = capfd.readouterr().out
+    assert "idle_timeout_reached" in out
 
 
 def test_incremental_signal_perf():


### PR DESCRIPTION
## Summary
- Add `_read_context` helper with safe UTF-8 decoding and default 16KB limit
- Load time model only when available and disable AI if API key missing
- Guard against excessive drawdown, halting with `max_drawdown_reached`

## Testing
- `pytest tests/test_live_imports.py tests/test_live_read_context.py tests/test_live_runner_paper_smoke.py tests/test_live_runner_soft_wait.py -vv`
- `pytest tests/test_risk_guard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a626b718c48326915baed7144621a1