### PR TITLE
Refine decision fusion with confluence

### DIFF
--- a/tests/test_decision_fusion_min_confluence.py
+++ b/tests/test_decision_fusion_min_confluence.py
@@ -40,3 +40,65 @@ def test_min_confluence_requires_both_votes() -> None:
         "no_consensus",
     )
 
+
+def test_min_confluence_sell_and_conflict_without_ai() -> None:
+    ts = datetime(2024, 1, 1)
+    tm_sell = DummyTimeModel("SELL")
+    agent_sell = DecisionAgent(config=DecisionConfig(time_model=tm_sell, min_confluence=2))
+    decision, votes, reason = agent_sell.decide(ts, tech_signal=-1, value=1.0, symbol="EURUSD")
+    assert (decision, votes, reason) == (
+        "SELL",
+        {"tech": -1, "time": -1, "ai": 0},
+        "sell_majority",
+    )
+    tm_buy = DummyTimeModel("BUY")
+    agent_conflict = DecisionAgent(config=DecisionConfig(time_model=tm_buy, min_confluence=2))
+    decision, votes, reason = agent_conflict.decide(ts, tech_signal=-1, value=1.0, symbol="EURUSD")
+    assert (decision, votes, reason) == (
+        "WAIT",
+        {"tech": -1, "time": 1, "ai": 0},
+        "no_consensus",
+    )
+
+
+class DummySentiment:
+    def __init__(self, score: float) -> None:
+        self.score = score
+
+
+class DummyAI:
+    def __init__(self, score: float) -> None:
+        self._score = score
+
+    def analyse(self, context: str, symbol: str) -> DummySentiment:  # pragma: no cover - trivial
+        return DummySentiment(self._score)
+
+
+def test_min_confluence_with_ai() -> None:
+    ts = datetime(2024, 1, 1)
+    agent = DecisionAgent(config=DecisionConfig(use_ai=True, min_confluence=2))
+
+    agent.ai = DummyAI(1.0)
+    decision, votes, reason = agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")
+    assert (decision, votes, reason) == (
+        "BUY",
+        {"tech": 1, "time": 0, "ai": 1},
+        "buy_majority",
+    )
+
+    agent.ai = DummyAI(-1.0)
+    decision, votes, reason = agent.decide(ts, tech_signal=-1, value=1.0, symbol="EURUSD")
+    assert (decision, votes, reason) == (
+        "SELL",
+        {"tech": -1, "time": 0, "ai": -1},
+        "sell_majority",
+    )
+
+    agent.ai = DummyAI(-1.0)
+    decision, votes, reason = agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")
+    assert (decision, votes, reason) == (
+        "WAIT",
+        {"tech": 1, "time": 0, "ai": -1},
+        "no_consensus",
+    )
+


### PR DESCRIPTION
## Summary
- Track positive and negative votes per signal and enforce minimum confluence with tie as WAIT
- Add comprehensive min-confluence tests covering sell paths and AI-assisted decisions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a62907a7408326a0bac555d35972f9