### PR TITLE
Add structured logging schema and unify live trading logs

### DIFF
--- a/docs/15_logging_schema.json
+++ b/docs/15_logging_schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Logging Event Schema",
+  "type": "object",
+  "properties": {
+    "timestamp": {"type": "string", "format": "date-time"},
+    "level": {"type": "string"},
+    "symbol": {"type": "string"},
+    "action": {"type": "string"},
+    "side": {"type": "string"},
+    "qty": {"type": "number"},
+    "price": {"type": "number"},
+    "latency_ms": {"type": "number"},
+    "error": {"type": ["string", "null"]},
+    "context": {"type": ["object", "null"]}
+  },
+  "required": [
+    "timestamp",
+    "level",
+    "symbol",
+    "action",
+    "side",
+    "qty",
+    "price",
+    "latency_ms",
+    "error",
+    "context"
+  ]
+}

--- a/src/forest5/live/mt4_broker.py
+++ b/src/forest5/live/mt4_broker.py
@@ -132,17 +132,14 @@ class MT4Broker(OrderRouter):
             log.info(
                 "order_result",
                 timestamp=time.time(),
-                mode="live",
                 symbol=self.symbol,
                 action="market_order",
                 side=side.upper(),
-                qty=qty,
+                qty=0.0,
                 price=price,
                 latency_ms=0.0,
-                decision=side.upper(),
-                votes=None,
-                reason="not connected",
                 error=res.error,
+                context={"status": res.status, "id": res.id},
             )
             return res
 
@@ -174,17 +171,14 @@ class MT4Broker(OrderRouter):
         log.info(
             "order_sent",
             timestamp=start_ts,
-            mode="live",
             symbol=self.symbol,
             action="market_order",
             side=side.upper(),
             qty=qty,
             price=price,
             latency_ms=send_latency_ms,
-            decision=side.upper(),
-            votes=None,
-            reason=None,
             error=None,
+            context={"id": uid},
         )
 
         res = self._wait_for_result(uid, qty)
@@ -192,17 +186,14 @@ class MT4Broker(OrderRouter):
         log.info(
             "order_result",
             timestamp=time.time(),
-            mode="live",
             symbol=self.symbol,
             action="market_order",
             side=side.upper(),
-            qty=qty,
+            qty=res.filled_qty,
             price=res.avg_price,
             latency_ms=total_latency_ms,
-            decision=side.upper(),
-            votes=None,
-            reason=None,
             error=res.error,
+            context={"status": res.status, "id": res.id},
         )
         return res
 


### PR DESCRIPTION
## Summary
- document logging fields for live trading events
- log trading decisions and order results with structured fields
- unify MT4 broker logging to new schema

## Testing
- `ruff check src/forest5/live/live_runner.py src/forest5/live/mt4_broker.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a62d6a8930832694344a77ddc10f41