### PR TITLE
ci: run lint and type checks with artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,24 @@ jobs:
               import_module(m)
           print("deps-ok")
           PY
+      - name: Lint
+        run: |
+          set -o pipefail
+          ruff check . | tee ruff.txt
+      - name: Type check
+        run: |
+          set -o pipefail
+          mypy src | tee mypy.txt
       - name: Run tests
-        run: pytest -q
+        run: pytest --cov=src --cov-report=xml --junitxml=pytest-junit.xml -q
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports
+          path: |
+            pytest-junit.xml
+            coverage.xml
+            ruff.txt
+            mypy.txt
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- run ruff lint and mypy before tests
- collect pytest coverage and junit reports
- upload test, lint, and type artifacts

## Testing
- `ruff check .`
- `mypy src` *(fails: forest-5.0 is not a valid Python package name)*
- `pytest --cov=src --cov-report=xml --junitxml=pytest-junit.xml -q`

------
https://chatgpt.com/codex/tasks/task_e_68a62f75bc3c8326a0c4182d0fa673af