### PR TITLE
Fix lint failures in auxiliary scripts and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,20 @@ time:
 Podczas backtestów podobną funkcję pełnią opcje:
 
 ```python
+from forest5.config import BacktestSettings, StrategySettings, RiskSettings
+
+settings = BacktestSettings(
+    symbol="EURUSD",
+    timeframe="1h",
+    strategy=StrategySettings(fast=12, slow=26),
+    risk=RiskSettings(
+        initial_capital=100_000.0,
+        risk_per_trade=0.01,
+        max_drawdown=0.30,
+        fee_perc=0.0005,
+        slippage_perc=0.0,
+    ),
+)
 settings.time.use_time_model = True
 settings.time.time_model_path = "models/model_time.json"
 ```

--- a/scripts/mt4_smoke_test.py
+++ b/scripts/mt4_smoke_test.py
@@ -1,18 +1,59 @@
 #!/usr/bin/env python3
-import os, json, time, uuid, sys, pathlib
-BRIDGE = pathlib.Path(os.environ.get("FOREST_MT4_BRIDGE_DIR","" )).expanduser()
+
+"""Minimal smoke test for the MT4 bridge.
+
+The script drops a single BUY command into the bridge's ``commands`` folder and
+waits for a corresponding response file to appear in ``results``.  It is a
+lightweight check to verify that the Expert Advisor can communicate with this
+Python environment.
+"""
+
+import json
+import os
+import pathlib
+import sys
+import time
+import uuid
+
+
+BRIDGE = pathlib.Path(os.environ.get("FOREST_MT4_BRIDGE_DIR", "")).expanduser()
+
 if not BRIDGE:
-    print("Set FOREST_MT4_BRIDGE_DIR to .../MQL4/Files/forest_bridge", file=sys.stderr); sys.exit(2)
-cmd = BRIDGE/"commands"; res = BRIDGE/"results"
-cmd.mkdir(parents=True, exist_ok=True); res.mkdir(parents=True, exist_ok=True)
+    print(
+        "Set FOREST_MT4_BRIDGE_DIR to .../MQL4/Files/forest_bridge",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+cmd_dir = BRIDGE / "commands"
+res_dir = BRIDGE / "results"
+cmd_dir.mkdir(parents=True, exist_ok=True)
+res_dir.mkdir(parents=True, exist_ok=True)
+
 cid = uuid.uuid4().hex
-cmdp = cmd/f"cmd_{cid}.json"; resp = res/f"res_{cid}.json"
-with cmdp.open("w") as f:
-    json.dump({"id":cid,"action":"BUY","symbol":"EURUSD","volume":0.01,"sl":None,"tp":None}, f)
-print("Sent:", cmdp)
-deadline = time.time()+10
-while time.time()<deadline:
-    if resp.exists():
-        print("Result:", resp.read_text()); sys.exit(0)
+cmd_path = cmd_dir / f"cmd_{cid}.json"
+res_path = res_dir / f"res_{cid}.json"
+
+with cmd_path.open("w") as f:
+    json.dump(
+        {
+            "id": cid,
+            "action": "BUY",
+            "symbol": "EURUSD",
+            "volume": 0.01,
+            "sl": None,
+            "tp": None,
+        },
+        f,
+    )
+
+print("Sent:", cmd_path)
+deadline = time.time() + 10
+while time.time() < deadline:
+    if res_path.exists():
+        print("Result:", res_path.read_text())
+        sys.exit(0)
     time.sleep(0.2)
-print("No EA response. Check MT4 -> Experts/Journal.", file=sys.stderr); sys.exit(1)
+
+print("No EA response. Check MT4 -> Experts/Journal.", file=sys.stderr)
+sys.exit(1)

--- a/tests/test_risk_guard.py
+++ b/tests/test_risk_guard.py
@@ -1,5 +1,3 @@
-import logging
-
 from forest5.live.risk_guard import should_halt_for_drawdown
 from forest5.utils.log import log
 


### PR DESCRIPTION
## Summary
- Refactor MT4 smoke test script with proper formatting and imports
- Remove unused import in risk guard tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a7296982688326ab1f26f967b79c6f