### PR TITLE
test: verify CLI time options

### DIFF
--- a/tests/test_cli_time_options.py
+++ b/tests/test_cli_time_options.py
@@ -1,0 +1,60 @@
+import pandas as pd
+from types import SimpleNamespace
+
+from forest5.cli import build_parser, cmd_backtest
+
+
+def _write_csv(path):
+    idx = pd.date_range("2020-01-01", periods=3, freq="h")
+    df = pd.DataFrame(
+        {
+            "time": idx,
+            "open": [1, 1.1, 1.2],
+            "high": [1.1, 1.2, 1.3],
+            "low": [0.9, 1.0, 1.1],
+            "close": [1.0, 1.1, 1.2],
+        }
+    )
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_cli_time_only_options(tmp_path, monkeypatch):
+    csv_path = _write_csv(tmp_path / "data.csv")
+    model_path = tmp_path / "time_model.onnx"
+    model_path.touch()
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "backtest",
+            "--csv",
+            str(csv_path),
+            "--time-model",
+            str(model_path),
+            "--blocked-hours",
+            "1,2",
+            "--blocked-weekdays",
+            "0,6",
+        ]
+    )
+
+    captured = {}
+
+    def fake_run_backtest(df, settings, symbol, price_col, atr_period, atr_multiple):
+        captured["settings"] = settings
+        return SimpleNamespace(
+            equity_curve=pd.Series([1.0]),
+            max_dd=0.0,
+            trades=SimpleNamespace(trades=[]),
+        )
+
+    monkeypatch.setattr("forest5.cli.run_backtest", fake_run_backtest)
+
+    cmd_backtest(args)
+
+    settings = captured["settings"]
+    assert settings.time.use_time_model is True
+    assert settings.time.time_model_path == model_path
+    assert settings.time.blocked_hours == [1, 2]
+    assert settings.time.blocked_weekdays == [0, 6]


### PR DESCRIPTION
## Summary
- test CLI parsing of time model and blocked lists

## Testing
- `pytest tests/test_cli_time_options.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a75ffebc108326ac03178548347cdf