### PR TITLE
Add time model options to grid optimizer

### DIFF
--- a/scripts/optimize_grid.py
+++ b/scripts/optimize_grid.py
@@ -60,6 +60,13 @@ def parse_range(spec: str) -> list[int]:
     return vals
 
 
+def _parse_int_list(spec: str | None) -> list[int]:
+    """Parse comma-separated integers into a list."""
+    if not spec:
+        return []
+    return [int(x.strip()) for x in spec.split(",") if x.strip()]
+
+
 @dataclass(frozen=True)
 class GridPoint:
     fast: int
@@ -104,6 +111,7 @@ def _run_one(
         timeframe=base.timeframe,
         strategy=stg,
         risk=base.risk,
+        time=base.time,
         atr_period=base.atr_period,
         atr_multiple=base.atr_multiple,
     )
@@ -210,6 +218,21 @@ def main() -> None:
     parser.add_argument("--atr-period", type=int, default=14)
     parser.add_argument("--atr-multiple", type=float, default=2.0)
 
+    parser.add_argument("--time-model", type=Path, default=None, help="Ścieżka do modelu czasu.")
+    parser.add_argument("--min-confluence", type=int, default=1, help="Minimalna konfluencja fuzji")
+    parser.add_argument(
+        "--blocked-hours",
+        type=_parse_int_list,
+        default=None,
+        help="Zablokowane godziny (0-23), np. 0,1,2",
+    )
+    parser.add_argument(
+        "--blocked-weekdays",
+        type=_parse_int_list,
+        default=None,
+        help="Zablokowane dni tygodnia 0=Mon..6=Sun",
+    )
+
     parser.add_argument("--start", type=str, default=None, help="Początek zakresu (YYYY-MM-DD).")
     parser.add_argument("--end", type=str, default=None, help="Koniec zakresu (YYYY-MM-DD).")
 
@@ -245,6 +268,12 @@ def main() -> None:
         atr_period=int(args.atr_period),
         atr_multiple=float(args.atr_multiple),
     )
+
+    base.time.use_time_model = bool(args.time_model)
+    base.time.time_model_path = args.time_model
+    base.time.fusion_min_confluence = int(args.min_confluence)
+    base.time.blocked_hours = args.blocked_hours or []
+    base.time.blocked_weekdays = args.blocked_weekdays or []
 
     fast_vals = parse_range(args.fast)
     slow_vals = parse_range(args.slow)


### PR DESCRIPTION
## Summary
- allow specifying time-based filters (model path, confluence, blocked hours/weekdays) in grid optimization
- forward configured time settings to each backtest run

## Testing
- `pre-commit run --files scripts/optimize_grid.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a765f6fbb48326a8f3ec4eee5b2749