### PR TITLE
Compute return and metrics after run_backtest

### DIFF
--- a/scripts/dx_fx_probe.py
+++ b/scripts/dx_fx_probe.py
@@ -57,6 +57,10 @@ def main() -> None:
 
     res = run_backtest(df, settings)
 
+    equity = res.equity_curve
+    equity_end = float(equity.iloc[-1]) if not equity.empty else 0.0
+    ret = equity_end / float(settings.risk.initial_capital) - 1.0
+
     # diagnostyka – eksport krzywej equity M2M
     if args.inspect_n and args.inspect_n > 0:
         n = min(args.inspect_n, len(res.equity_curve))
@@ -67,7 +71,8 @@ def main() -> None:
     print(
         json.dumps(
             {
-                "equity_end": float(res.equity_curve.iloc[-1]),
+                "equity_end": equity_end,
+                "ret": ret,
                 "max_dd": float(res.max_dd),
                 "trades": len(res.trades.trades),
                 "event": "backtest_done",

--- a/scripts/dx_mtm_guard.py
+++ b/scripts/dx_mtm_guard.py
@@ -50,9 +50,13 @@ def main():
     )
     res = run_backtest(df, s)
 
+    equity = res.equity_curve
+    equity_end = float(equity.iloc[-1]) if not equity.empty else 0.0
+    ret = equity_end / float(s.risk.initial_capital) - 1.0
+
     bars = len(df)
-    marks = len(res.equity_curve)
-    mean_eq = float(np.mean(res.equity_curve)) if marks else float("nan")
+    marks = len(equity)
+    mean_eq = float(np.mean(equity)) if marks else float("nan")
 
     # Heurystyki
     ok_len = marks in (bars, bars + 1)
@@ -68,7 +72,7 @@ def main():
         ts = pd.RangeIndex(marks)
 
     out = Path(args.out)
-    out_df = pd.DataFrame({"time": ts, "equity": res.equity_curve.values})
+    out_df = pd.DataFrame({"time": ts, "equity": equity.values})
     out_df.to_csv(out, index=False)
 
     summary = {
@@ -77,6 +81,7 @@ def main():
         "ok_len": ok_len,
         "ok_scale": ok_scale,
         "equity_mean": mean_eq,
+        "ret": ret,
         "max_dd": res.max_dd,
         "out": str(out),
     }

--- a/scripts/mtm_trace.py
+++ b/scripts/mtm_trace.py
@@ -18,5 +18,10 @@ s = BacktestSettings(
 )
 
 res = run_backtest(df, s)
-print(f"bars: {len(df)} equity marks: {len(res.equity_curve)}")
-print(res.equity_curve.head(12))
+
+equity = res.equity_curve
+equity_end = float(equity.iloc[-1]) if not equity.empty else 0.0
+ret = equity_end / float(s.risk.initial_capital) - 1.0
+print(f"bars: {len(df)} equity marks: {len(equity)}")
+print(equity.head(12))
+print(f"return: {ret:.6f} max_dd: {res.max_dd:.6f} trades: {len(res.trades.trades)}")

--- a/scripts/optimize_grid.py
+++ b/scripts/optimize_grid.py
@@ -116,11 +116,13 @@ def _run_one(
         atr_multiple=base.atr_multiple,
     )
     res = run_backtest(df, s)
+
+    equity = res.equity_curve
+    equity_end = float(equity.iloc[-1]) if not equity.empty else 0.0
     initial = float(s.risk.initial_capital)
-    equity_end = float(res.equity_curve.iloc[-1])
     ret = equity_end / initial - 1.0
     max_dd = float(res.max_dd)
-    trades = int(len(res.trades.trades))
+    trades = len(res.trades.trades)
     score = ret - dd_penalty * max_dd
     return GridResult(
         fast=gp.fast,

--- a/scripts/walkforward.py
+++ b/scripts/walkforward.py
@@ -232,12 +232,14 @@ def evaluate_df(
     settings: BacktestSettings,
 ) -> Tuple[float, float, int, float]:
     res = run_backtest(df, settings)
-    eq_end = float(res.equity_curve.iloc[-1]) if len(res.equity_curve) else 0.0
+
+    equity = res.equity_curve
+    eq_end = float(equity.iloc[-1]) if not equity.empty else 0.0
     init_cap = float(settings.risk.initial_capital)
     ret = (eq_end / init_cap) - 1.0 if init_cap > 0 else 0.0
     max_dd = float(res.max_dd)
-    trades = len(getattr(res.trades, "trades", getattr(res.trades, "__iter__", [])))
-    return ret, max_dd, int(trades), eq_end
+    trades = len(res.trades.trades)
+    return ret, max_dd, trades, eq_end
 
 
 def pick_best_on_train(

--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -105,9 +105,14 @@ def cmd_backtest(args: argparse.Namespace) -> int:
         atr_multiple=args.atr_multiple,
     )
 
+    equity = res.equity_curve
+    equity_end = float(equity.iloc[-1]) if not equity.empty else 0.0
+    ret = equity_end / float(settings.risk.initial_capital) - 1.0
+
     # stdout: prosty podgląd najważniejszych metryk
     print(
-        f"Equity end: {res.equity_curve.iloc[-1]:.2f} | "
+        f"Equity end: {equity_end:.2f} | "
+        f"Return: {ret:.6f} | "
         f"MaxDD: {res.max_dd:.3f} | Trades: {len(res.trades.trades)}"
     )
 


### PR DESCRIPTION
## Summary
- Calculate equity-based return, drawdown and trade count right after each `run_backtest`
- Use `res.max_dd` and trade count for result rows and JSON probes
- Score grid points with `ret - dd_penalty * max_dd` using freshly computed metrics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a768bfcb34832691c814e4fd51453d