### PR TITLE
refactor: replace broad exception handling

### DIFF
--- a/tests/test_ai_agent.py
+++ b/tests/test_ai_agent.py
@@ -87,4 +87,4 @@ def test_analyse_handles_malformed_json() -> None:
     result = agent.analyse("ctx", "EURUSD")
 
     assert result.score == 0
-    assert "AI error" in result.reason
+    assert "AI parse error" in result.reason


### PR DESCRIPTION
## Summary
- use targeted ImportError handling for OpenAI SDKs and log failures
- return neutral sentiment on JSON parse or OpenAI API errors with detailed logs
- tighten test exception handling and adjust assertions for new messages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a76f4766b883269cea385337894a3c