### PR TITLE
chore: drop unused Iterable import

### DIFF
--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import argparse
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Optional
 
 import pandas as pd
 


### PR DESCRIPTION
## Summary
- remove unused Iterable import in CLI module

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a77e4056548326ba53b6580b368d5f