### PR TITLE
ci: add lint and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,28 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  push:
+  pull_request:
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-      - name: Install package (editable) + dev deps
+          python-version: "3.11"
+
+      - name: Install dependencies
         run: |
           pip install -e .
           pip install -r requirements-dev.txt
-      - name: Sanity imports
-        run: |
-          python - <<'PY'
-          from importlib import import_module
-          for m in ("yaml","numpy","pandas","pytest","structlog","joblib","pydantic"):
-              import_module(m)
-          print("deps-ok")
-          PY
-      - name: Run tests
-        run: pytest -q
+
+      - name: Lint
+        run: make lint
+
+      - name: Test
+        run: make test
+


### PR DESCRIPTION
## Summary
- run CI on push and pull request using Python 3.11
- install development dependencies
- run `make lint` and `make test`

## Testing
- `make lint`
- `make test` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a78034e5fc8326af6d0c967b3936b5