### PR TITLE
Add timeout safeguard to MT4 broker file bridge test

### DIFF
--- a/tests/test_mt4_broker_file_bridge.py
+++ b/tests/test_mt4_broker_file_bridge.py
@@ -39,8 +39,10 @@ def _respond_once(bridge: Path):
     """Wait for a single command file and write corresponding result."""
     cmd_dir = bridge / "commands"
     res_dir = bridge / "results"
-    # Wait until a command file appears
-    while True:
+    # Wait until a command file appears, but abort after a short timeout
+    start = time.time()
+    timeout = 1.5
+    while time.time() - start < timeout:
         cmds = list(cmd_dir.glob("cmd_*.json"))
         if cmds:
             p = cmds[0]
@@ -48,8 +50,9 @@ def _respond_once(bridge: Path):
             rid = data["id"]
             result = {"id": rid, "status": "filled", "ticket": 1, "price": 1.2345}
             (res_dir / f"res_{rid}.json").write_text(json.dumps(result), encoding="utf-8")
-            break
+            return
         time.sleep(0.05)
+    raise AssertionError("No command file appeared within 1.5s")
 
 
 def test_market_order_success(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Add a timeout in the `_respond_once` helper to stop waiting for MT4 command files after 1.5s
- Raises an informative assertion when no command file is detected

## Testing
- `pytest -q tests/test_mt4_broker_file_bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_68a78245fbe08326927b4b2bd6cadc36