### PR TITLE
Ensure threads in tests finish within timeout

### DIFF
--- a/tests/test_mt4_broker.py
+++ b/tests/test_mt4_broker.py
@@ -56,3 +56,4 @@ def test_broker_file_bridge(tmp_path: Path):
     finally:
         stop.set()
         t.join(timeout=1)
+        assert not t.is_alive(), "fake EA thread did not stop"

--- a/tests/test_mt4_broker_file_bridge.py
+++ b/tests/test_mt4_broker_file_bridge.py
@@ -67,6 +67,7 @@ def test_market_order_success(tmp_path: Path):
     t.start()
     result = br.market_order("BUY", 0.1)
     t.join(timeout=1)
+    assert not t.is_alive(), "responder thread did not finish"
     assert result["status"] == "filled"
     assert br.equity() == 1234
     assert br.position_qty() == 1.5

--- a/tests/test_mt4_broker_hardening.py
+++ b/tests/test_mt4_broker_hardening.py
@@ -118,3 +118,4 @@ def test_back_to_back_orders_and_cleanup(tmp_path: Path):
     finally:
         stop.set()
         t.join(timeout=1)
+        assert not t.is_alive(), "EA thread did not stop"


### PR DESCRIPTION
## Summary
- Add explicit assertions after thread joins in MT4 broker tests to confirm helper threads stop

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a783a295f48326b0b6868adfe83706