### PR TITLE
ci: cache pip deps and add timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,20 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install package (editable) + dev deps
         run: |
           pip install -e .


### PR DESCRIPTION
## Summary
- cache pip dependencies in CI to speed up runs
- enforce a 15-minute timeout on the build job

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a788ace5388326aed229500931604b