### PR TITLE
chore: add Black check to lint and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,7 @@ jobs:
               import_module(m)
           print("deps-ok")
           PY
+      - name: Run lint
+        run: make lint
       - name: Run tests
         run: pytest -q

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ WF_OUT   ?= $(OUTDIR)/walkforward.csv
 all: lint test
 
 lint:
+	black --check .
 	$(PY) -m ruff check .
 
 test:

--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -247,9 +247,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_bt.add_argument("--atr-multiple", type=float, default=2.0)
 
     p_bt.add_argument("--time-model", type=Path, default=None, help="Ścieżka do modelu czasu")
-    p_bt.add_argument(
-        "--min-confluence", type=int, default=1, help="Minimalna konfluencja fuzji"
-    )
+    p_bt.add_argument("--min-confluence", type=int, default=1, help="Minimalna konfluencja fuzji")
     p_bt.add_argument(
         "--blocked-hours",
         type=_parse_int_list,

--- a/src/forest5/config/loader.py
+++ b/src/forest5/config/loader.py
@@ -63,9 +63,7 @@ def load_live_settings(path: str | Path) -> "LiveSettings":
             broker["bridge_dir"] = _resolve_from_yaml(cfg_dir, b_raw)
         else:
             env_bridge = os.getenv("FOREST_MT4_BRIDGE_DIR")
-            broker["bridge_dir"] = (
-                _resolve_from_yaml(cfg_dir, env_bridge) if env_bridge else None
-            )
+            broker["bridge_dir"] = _resolve_from_yaml(cfg_dir, env_bridge) if env_bridge else None
         data["broker"] = broker
 
     ai = data.get("ai")

--- a/src/forest5/config_live.py
+++ b/src/forest5/config_live.py
@@ -101,7 +101,9 @@ class LiveSettings:
                 if k in keys:
                     field_info = keys[k]
                     field_type = getattr(
-                        field_info, "type", getattr(field_info, "annotation", getattr(field_info, "outer_type_", None))
+                        field_info,
+                        "type",
+                        getattr(field_info, "annotation", getattr(field_info, "outer_type_", None)),
                     )
                     if isinstance(v, dict) and field_type is not None:
                         result[k] = _filter(field_type, v)

--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -127,11 +127,7 @@ def run_live(
 
     time_model: TimeOnlyModel | None = None
     tm_path = settings.time.model.path
-    if (
-        settings.time.model.enabled
-        and tm_path
-        and Path(tm_path).exists()
-    ):
+    if settings.time.model.enabled and tm_path and Path(tm_path).exists():
         try:
             time_model = TimeOnlyModel.load(tm_path)
         except (OSError, json.JSONDecodeError, KeyError):  # pragma: no cover - defensive
@@ -243,11 +239,7 @@ def run_live(
                                 symbol=settings.broker.symbol,
                                 action="decision",
                                 side=decision,
-                                qty=(
-                                    settings.broker.volume
-                                    if decision in ("BUY", "SELL")
-                                    else 0
-                                ),
+                                qty=(settings.broker.volume if decision in ("BUY", "SELL") else 0),
                                 price=current_bar["close"],
                                 latency_ms=0.0,
                                 error=None,
@@ -255,9 +247,7 @@ def run_live(
                             )
                             if decision in ("BUY", "SELL"):
                                 start_ts = time.time()
-                                res = broker.market_order(
-                                    decision, settings.broker.volume, price
-                                )
+                                res = broker.market_order(decision, settings.broker.volume, price)
                                 latency = (time.time() - start_ts) * 1000.0
                                 log.info(
                                     "order_result",

--- a/src/forest5/live/mt4_broker.py
+++ b/src/forest5/live/mt4_broker.py
@@ -108,7 +108,9 @@ class MT4Broker(OrderRouter):
                     ticket = data.get("ticket", 0)
                     err = data.get("error")
                     filled = qty if status == "filled" else 0.0
-                    return OrderResult(int(ticket) if isinstance(ticket, int) else 0, status, filled, price, err)
+                    return OrderResult(
+                        int(ticket) if isinstance(ticket, int) else 0, status, filled, price, err
+                    )
                 except json.JSONDecodeError:
                     attempt += 1
                     log.warning("invalid_json_result", path=str(res_path), attempt=attempt)
@@ -124,9 +126,7 @@ class MT4Broker(OrderRouter):
         return OrderResult(0, "rejected", 0.0, 0.0, "timeout")
 
     # ------------------------------------------------------------------
-    def market_order(
-        self, side: str, qty: float, price: Optional[float] = None
-    ) -> OrderResult:
+    def market_order(self, side: str, qty: float, price: Optional[float] = None) -> OrderResult:
         if not self._connected:
             res = OrderResult(0, "rejected", 0.0, 0.0, "not connected")
             log.info(
@@ -206,7 +206,12 @@ class MT4Broker(OrderRouter):
         except FileNotFoundError:
             log.warning("position_file_missing", path=str(pos_file))
             return 0.0
-        except (OSError, json.JSONDecodeError, ValueError, TypeError):  # pragma: no cover - defensive
+        except (
+            OSError,
+            json.JSONDecodeError,
+            ValueError,
+            TypeError,
+        ):  # pragma: no cover - defensive
             log.exception("position_file_error")
             return 0.0
 
@@ -218,7 +223,12 @@ class MT4Broker(OrderRouter):
         except FileNotFoundError:
             log.warning("account_file_missing", path=str(acc_file))
             return 0.0
-        except (OSError, json.JSONDecodeError, ValueError, TypeError):  # pragma: no cover - defensive
+        except (
+            OSError,
+            json.JSONDecodeError,
+            ValueError,
+            TypeError,
+        ):  # pragma: no cover - defensive
             log.exception("account_file_error")
             return 0.0
 

--- a/src/forest5/live/settings.py
+++ b/src/forest5/live/settings.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from ..config_live import LiveSettings, BrokerSettings, DecisionSettings, LiveTimeSettings as TimeSettings
+from ..config_live import (
+    LiveSettings,
+    BrokerSettings,
+    DecisionSettings,
+    LiveTimeSettings as TimeSettings,
+)
 from ..config import AISettings, RiskSettings
 
 __all__ = [

--- a/src/forest5/utils/argparse_ext.py
+++ b/src/forest5/utils/argparse_ext.py
@@ -6,7 +6,9 @@ import argparse
 class PercentAction(argparse.Action):
     """Argparse action that validates a percentage in a given range."""
 
-    def __init__(self, option_strings, dest, *, min_value: float = 0.0, max_value: float = 1.0, **kwargs):
+    def __init__(
+        self, option_strings, dest, *, min_value: float = 0.0, max_value: float = 1.0, **kwargs
+    ):
         self.min_value = float(min_value)
         self.max_value = float(max_value)
         super().__init__(option_strings, dest, **kwargs)
@@ -17,7 +19,5 @@ class PercentAction(argparse.Action):
         except ValueError:
             parser.error(f"{option_string} expects a number")
         if not (self.min_value <= val <= self.max_value):
-            parser.error(
-                f"{option_string} must be between {self.min_value} and {self.max_value}"
-            )
+            parser.error(f"{option_string} must be between {self.min_value} and {self.max_value}")
         setattr(namespace, self.dest, val)

--- a/src/forest5/utils/io.py
+++ b/src/forest5/utils/io.py
@@ -62,9 +62,7 @@ def read_ohlc_csv(
                 break
 
     if time_col and time_col in df.columns:
-        idx = pd.to_datetime(
-            df[time_col], errors="coerce", utc=False, format="mixed"
-        )
+        idx = pd.to_datetime(df[time_col], errors="coerce", utc=False, format="mixed")
         df = df.drop(columns=[time_col])
     else:
         idx = pd.to_datetime(df.index, errors="coerce", utc=False, format="mixed")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,36 +23,40 @@ def _write_csv(path):
 def test_cli_backtest(tmp_path, monkeypatch):
     csv_path = _write_csv(tmp_path / "data.csv")
     monkeypatch.chdir(tmp_path)
-    rc = main([
-        "backtest",
-        "--csv",
-        str(csv_path),
-        "--fast",
-        "2",
-        "--slow",
-        "3",
-        "--atr-period",
-        "1",
-    ])
+    rc = main(
+        [
+            "backtest",
+            "--csv",
+            str(csv_path),
+            "--fast",
+            "2",
+            "--slow",
+            "3",
+            "--atr-period",
+            "1",
+        ]
+    )
     assert rc == 0
 
 
 def test_cli_grid(tmp_path, monkeypatch):
     csv_path = _write_csv(tmp_path / "data.csv")
     monkeypatch.chdir(tmp_path)
-    rc = main([
-        "grid",
-        "--csv",
-        str(csv_path),
-        "--fast-values",
-        "2",
-        "--slow-values",
-        "3",
-        "--jobs",
-        "1",
-        "--top",
-        "1",
-    ])
+    rc = main(
+        [
+            "grid",
+            "--csv",
+            str(csv_path),
+            "--fast-values",
+            "2",
+            "--slow-values",
+            "3",
+            "--jobs",
+            "1",
+            "--top",
+            "1",
+        ]
+    )
     assert rc == 0
 
 

--- a/tests/test_decision_fusion_min_confluence.py
+++ b/tests/test_decision_fusion_min_confluence.py
@@ -101,4 +101,3 @@ def test_min_confluence_with_ai() -> None:
         {"tech": 1, "time": 0, "ai": -1},
         "no_consensus",
     )
-

--- a/tests/test_live_runner_paper_smoke.py
+++ b/tests/test_live_runner_paper_smoke.py
@@ -24,21 +24,15 @@ def _mk_bridge(tmpdir: Path) -> Path:
         '{"symbol":"EURUSD","bid":1.0,"ask":1.0,"time":0}',
         encoding="utf-8",
     )
-    (bridge / "state" / "account.json").write_text(
-        '{"equity":10000}', encoding="utf-8"
-    )
-    (bridge / "state" / "position_EURUSD.json").write_text(
-        '{"qty":0}', encoding="utf-8"
-    )
+    (bridge / "state" / "account.json").write_text('{"equity":10000}', encoding="utf-8")
+    (bridge / "state" / "position_EURUSD.json").write_text('{"qty":0}', encoding="utf-8")
     return bridge
 
 
 def test_run_live_paper(tmp_path: Path, capfd):
     bridge = _mk_bridge(tmp_path)
     s = LiveSettings(
-        broker=BrokerSettings(
-            type="paper", bridge_dir=str(bridge), symbol="EURUSD", volume=0.01
-        ),
+        broker=BrokerSettings(type="paper", bridge_dir=str(bridge), symbol="EURUSD", volume=0.01),
         decision=DecisionSettings(min_confluence=1),
         ai=AISettings(enabled=False, model="gpt-4o-mini", max_tokens=64, context_file=None),
         time=TimeSettings(blocked_hours=[], blocked_weekdays=[]),

--- a/tests/test_live_runner_soft_wait.py
+++ b/tests/test_live_runner_soft_wait.py
@@ -20,12 +20,8 @@ def _mk_bridge(tmpdir: Path) -> Path:
     bridge = tmpdir / "forest_bridge"
     for sub in ("ticks", "state", "commands", "results"):
         (bridge / sub).mkdir(parents=True, exist_ok=True)
-    (bridge / "state" / "account.json").write_text(
-        '{"equity":10000}', encoding="utf-8"
-    )
-    (bridge / "state" / "position_EURUSD.json").write_text(
-        '{"qty":0}', encoding="utf-8"
-    )
+    (bridge / "state" / "account.json").write_text('{"equity":10000}', encoding="utf-8")
+    (bridge / "state" / "position_EURUSD.json").write_text('{"qty":0}', encoding="utf-8")
     return bridge
 
 
@@ -38,9 +34,7 @@ def test_run_live_soft_wait(tmp_path: Path, monkeypatch) -> None:
     def fake_compute_signal(df: pd.DataFrame, settings, price_col: str = "close") -> pd.Series:
         return pd.Series([1] * len(df), index=df.index)
 
-    monkeypatch.setattr(
-        "forest5.live.live_runner.compute_signal", fake_compute_signal
-    )
+    monkeypatch.setattr("forest5.live.live_runner.compute_signal", fake_compute_signal)
 
     orig_log = run_live.__globals__["log"].info
 
@@ -61,9 +55,7 @@ def test_run_live_soft_wait(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(Path, "exists", exists)
 
     settings = LiveSettings(
-        broker=BrokerSettings(
-            type="paper", bridge_dir=str(bridge), symbol="EURUSD", volume=1
-        ),
+        broker=BrokerSettings(type="paper", bridge_dir=str(bridge), symbol="EURUSD", volume=1),
         decision=DecisionSettings(min_confluence=1),
         ai=AISettings(enabled=False, model="gpt-4o-mini", max_tokens=64, context_file=None),
         time=TimeSettings(blocked_hours=[], blocked_weekdays=[]),

--- a/tests/test_mt4_broker_file_bridge.py
+++ b/tests/test_mt4_broker_file_bridge.py
@@ -17,17 +17,13 @@ live_pkg = types.ModuleType("forest5.live")
 live_pkg.__path__ = [str(LIVE_DIR)]
 sys.modules.setdefault("forest5.live", live_pkg)
 
-spec_router = importlib.util.spec_from_file_location(
-    "forest5.live.router", LIVE_DIR / "router.py"
-)
+spec_router = importlib.util.spec_from_file_location("forest5.live.router", LIVE_DIR / "router.py")
 router_module = importlib.util.module_from_spec(spec_router)
 assert spec_router.loader is not None
 sys.modules["forest5.live.router"] = router_module
 spec_router.loader.exec_module(router_module)
 
-spec = importlib.util.spec_from_file_location(
-    "forest5.live.mt4_broker", LIVE_DIR / "mt4_broker.py"
-)
+spec = importlib.util.spec_from_file_location("forest5.live.mt4_broker", LIVE_DIR / "mt4_broker.py")
 mt4_module = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 sys.modules["forest5.live.mt4_broker"] = mt4_module
@@ -59,8 +55,8 @@ def test_market_order_success(tmp_path: Path):
     br = MT4Broker(bridge_dir=bridge, symbol="EURUSD", timeout_sec=1.0)
     br.connect()
     # prepare state files for equity and position
-    (bridge / "state" / "account.json").write_text("{\"equity\":1234}", encoding="utf-8")
-    (bridge / "state" / "position_EURUSD.json").write_text("{\"qty\":1.5}", encoding="utf-8")
+    (bridge / "state" / "account.json").write_text('{"equity":1234}', encoding="utf-8")
+    (bridge / "state" / "position_EURUSD.json").write_text('{"qty":1.5}', encoding="utf-8")
     # start helper thread to respond to command
     t = Thread(target=_respond_once, args=(bridge,), daemon=True)
     t.start()
@@ -85,7 +81,7 @@ def test_position_and_equity(tmp_path: Path):
     bridge = tmp_path / "bridge"
     br = MT4Broker(bridge_dir=bridge, symbol="EURUSD")
     br.connect()
-    (bridge / "state" / "account.json").write_text("{\"equity\":999}", encoding="utf-8")
-    (bridge / "state" / "position_EURUSD.json").write_text("{\"qty\":2.0}", encoding="utf-8")
+    (bridge / "state" / "account.json").write_text('{"equity":999}', encoding="utf-8")
+    (bridge / "state" / "position_EURUSD.json").write_text('{"qty":2.0}', encoding="utf-8")
     assert br.equity() == 999
     assert br.position_qty() == 2.0

--- a/tests/test_strategy_alias_ema_rsi.py
+++ b/tests/test_strategy_alias_ema_rsi.py
@@ -15,4 +15,3 @@ def test_strategy_alias_enables_rsi_filter() -> None:
     assert settings.strategy.use_rsi is True
     assert list(sig.index) == list(df.index)  # nosec B101
     assert set(sig.unique()).issubset({-1, 0, 1})  # nosec B101
-

--- a/tests/test_time_only_integration.py
+++ b/tests/test_time_only_integration.py
@@ -29,4 +29,3 @@ def test_train_decide_and_serialize(tmp_path: Path) -> None:
 
     assert loaded.quantile_gates == model.quantile_gates
     assert loaded.decide(ts, 3.0) == "BUY"
-

--- a/tests/test_trading_loop_benchmark.py
+++ b/tests/test_trading_loop_benchmark.py
@@ -26,9 +26,7 @@ def _old_trading_loop(df, sig, rm, tb, position, price_col, atr_multiple):
             position = 0.0
 
         if this_sig > 0 and position <= 0.0:
-            qty = rm.position_size(
-                price=price, atr=float(row["atr"]), atr_multiple=atr_multiple
-            )
+            qty = rm.position_size(price=price, atr=float(row["atr"]), atr_multiple=atr_multiple)
             if qty > 0.0:
                 rm.buy(price, qty)
                 tb.add(t, price, qty, "BUY")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,7 +6,7 @@ from forest5 import __version__
 
 
 def test_version_matches_pyproject() -> None:
-    pyproject_version = tomllib.loads(
-        Path("pyproject.toml").read_text(encoding="utf-8")
-    )["tool"]["poetry"]["version"]
+    pyproject_version = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["tool"][
+        "poetry"
+    ]["version"]
     assert __version__ == pyproject_version


### PR DESCRIPTION
## Summary
- run `black --check` before `ruff` in `make lint`
- execute `make lint` in CI to enforce formatting
- format existing Python files with Black

## Testing
- `make lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a78a6698d883269a15aa6651a12116