### PR TITLE
Add optional AI vote to backtest fusion

### DIFF
--- a/tests/test_backtest_time_fusion.py
+++ b/tests/test_backtest_time_fusion.py
@@ -33,3 +33,14 @@ def test_conflict_returns_neutral() -> None:
 def test_passthrough_without_time_model() -> None:
     ts = datetime(2024, 1, 1)
     assert _fuse_with_time(-1, ts, 1.0, None, 1) == -1
+
+
+def test_ai_vote_satisfies_min_confluence() -> None:
+    ts = datetime(2024, 1, 1)
+    assert _fuse_with_time(1, ts, 1.0, None, 2) == 0
+    assert _fuse_with_time(1, ts, 1.0, None, 2, 1) == 1
+
+
+def test_ai_conflict_returns_neutral() -> None:
+    ts = datetime(2024, 1, 1)
+    assert _fuse_with_time(1, ts, 1.0, None, 1, -1) == 0


### PR DESCRIPTION
## Summary
- extend `_fuse_with_time` to accept an optional AI decision and include it in confluence counting
- wire new parameter through trading loop
- test fusion logic with and without AI votes

## Testing
- `black src/forest5/backtest/engine.py tests/test_backtest_time_fusion.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7a3be1ecc8326b9a1ddb062615e03