### PR TITLE
Add markers for test categories

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,5 +5,7 @@ addopts = -q
 filterwarnings =
     error:.*is deprecated and will be removed.*:FutureWarning
 markers =
-    timeonly: tests for time-only features
-    e2e: end-to-end tests
+    timeonly: testy integracji modelu czasu
+    e2e: end-to-end (PAPER/live)
+    grid: grid-search smoke
+    slow: test dłuższy/cięższy


### PR DESCRIPTION
## Summary
- refine pytest markers: timeonly and e2e descriptions, plus new grid and slow markers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7b4d46a308326bf3d5823076e1e1d