### PR TITLE
Avoid mutating settings in signal factory

### DIFF
--- a/src/forest5/backtest/engine.py
+++ b/src/forest5/backtest/engine.py
@@ -30,8 +30,13 @@ def _validate_data(df: pd.DataFrame, price_col: str) -> pd.DataFrame:
 
 def _generate_signal(df: pd.DataFrame, settings: BacktestSettings, price_col: str) -> pd.Series:
     """Generuje serię sygnałów tradingowych."""
+    name = getattr(settings.strategy, "name", "ema_cross")
+    use_rsi = getattr(settings.strategy, "use_rsi", False)
+    if name in {"ema_rsi", "ema-cross+rsi"}:
+        use_rsi = True
+
     sig = compute_signal(df, settings, price_col=price_col).astype(int)
-    if settings.strategy.use_rsi:
+    if use_rsi:
         rr = rsi(df[price_col], settings.strategy.rsi_period)
         sig = sig.where(~rr.ge(settings.strategy.rsi_overbought), other=-1)
         sig = sig.where(~rr.le(settings.strategy.rsi_oversold), other=1)

--- a/src/forest5/signals/factory.py
+++ b/src/forest5/signals/factory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import numpy as np
 import pandas as pd
 
@@ -24,11 +25,16 @@ def _ema_cross_signal(close: pd.Series, fast: int, slow: int) -> pd.Series:
 
 
 def compute_signal(df: pd.DataFrame, settings, price_col: str = "close") -> pd.Series:
-    name = getattr(settings.strategy, "name", "ema_cross")
+    """Generate trading signal without mutating the input settings."""
+
+    strategy = copy.deepcopy(settings.strategy)
+    name = getattr(strategy, "name", "ema_cross")
+    use_rsi = getattr(strategy, "use_rsi", False)
+
     if name in {"ema_rsi", "ema-cross+rsi"}:
-        settings.strategy.name = "ema_cross"
-        settings.strategy.use_rsi = True
         name = "ema_cross"
+        use_rsi = True
+
     if name == "ema_cross":
-        return _ema_cross_signal(df[price_col], settings.strategy.fast, settings.strategy.slow)
+        return _ema_cross_signal(df[price_col], strategy.fast, strategy.slow)
     raise ValueError(f"Unknown strategy: {name}")

--- a/src/forest5/signals/factory.py
+++ b/src/forest5/signals/factory.py
@@ -29,11 +29,9 @@ def compute_signal(df: pd.DataFrame, settings, price_col: str = "close") -> pd.S
 
     strategy = copy.deepcopy(settings.strategy)
     name = getattr(strategy, "name", "ema_cross")
-    use_rsi = getattr(strategy, "use_rsi", False)
 
     if name in {"ema_rsi", "ema-cross+rsi"}:
         name = "ema_cross"
-        use_rsi = True
 
     if name == "ema_cross":
         return _ema_cross_signal(df[price_col], strategy.fast, strategy.slow)

--- a/tests/test_signals_factory.py
+++ b/tests/test_signals_factory.py
@@ -19,7 +19,7 @@ def test_compute_signal_ema_cross_basic():
 
 
 @pytest.mark.parametrize("alias", ["ema_rsi", "ema-cross+rsi"])
-def test_compute_signal_normalizes_rsi_alias(alias):
+def test_compute_signal_does_not_mutate_settings(alias):
     df = generate_ohlc(periods=60, start_price=100.0)
     s = BacktestSettings()
     s.strategy.name = alias
@@ -27,8 +27,8 @@ def test_compute_signal_normalizes_rsi_alias(alias):
 
     sig = compute_signal(df, s)
 
-    assert s.strategy.name == "ema_cross"  # nosec B101
-    assert s.strategy.use_rsi is True  # nosec B101
+    assert s.strategy.name == alias  # nosec B101
+    assert s.strategy.use_rsi is False  # nosec B101
     assert list(sig.index) == list(df.index)  # nosec B101
     assert set(sig.unique()).issubset({-1, 0, 1})  # nosec B101
     assert (sig != 0).any()  # nosec B101

--- a/tests/test_strategy_alias_ema_rsi.py
+++ b/tests/test_strategy_alias_ema_rsi.py
@@ -3,7 +3,7 @@ from forest5.config import BacktestSettings
 from forest5.examples.synthetic import generate_ohlc
 
 
-def test_strategy_alias_enables_rsi_filter() -> None:
+def test_strategy_alias_does_not_mutate_settings() -> None:
     df = generate_ohlc(periods=40, start_price=100.0)
     settings = BacktestSettings()
     settings.strategy.name = "ema_rsi"  # alias for ema_cross with RSI
@@ -11,7 +11,7 @@ def test_strategy_alias_enables_rsi_filter() -> None:
 
     sig = _generate_signal(df, settings, price_col="close")
 
-    assert settings.strategy.name == "ema_cross"
-    assert settings.strategy.use_rsi is True
+    assert settings.strategy.name == "ema_rsi"
+    assert settings.strategy.use_rsi is False
     assert list(sig.index) == list(df.index)  # nosec B101
     assert set(sig.unique()).issubset({-1, 0, 1})  # nosec B101


### PR DESCRIPTION
## Summary
- Avoid mutating strategy settings when generating signals by working with a local copy
- Adjust tests to ensure `compute_signal` and `_generate_signal` do not alter passed settings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7b79b30c88326b656e907404e3eda