### PR TITLE
Vectorize MACD sign calculation

### DIFF
--- a/src/forest5/signals/macd.py
+++ b/src/forest5/signals/macd.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 
 from forest5.core.indicators import ema
@@ -15,7 +16,7 @@ def macd_cross_signal(
     macd = ema(close, fast) - ema(close, slow)
     sigl = ema(macd, signal)
     spread = macd - sigl
-    sgn = spread.apply(lambda x: 1 if x > 0 else (-1 if x < 0 else 0))
+    sgn = np.sign(spread.fillna(0)).astype("int8")
     cross = sgn.diff().fillna(0)
 
     out = pd.Series(0, index=close.index, dtype="int8")


### PR DESCRIPTION
## Summary
- Vectorize MACD signal sign detection using `numpy.sign` to avoid per-element iteration
- Add numpy dependency for signal calculation

## Testing
- `pre-commit run --files src/forest5/signals/macd.py`
- `PYTHONPATH=src python - <<'PY'
import pandas as pd
from forest5.signals.macd import macd_cross_signal
from forest5.core.indicators import ema
from forest5.examples.synthetic import generate_ohlc

close = generate_ohlc(periods=60, start_price=100.0)['close']

new = macd_cross_signal(close)

# Old implementation for comparison

def macd_cross_signal_old(close, fast=12, slow=26, signal=9):
    macd = ema(close, fast) - ema(close, slow)
    sigl = ema(macd, signal)
    spread = macd - sigl
    sgn = spread.apply(lambda x: 1 if x > 0 else (-1 if x < 0 else 0))
    cross = sgn.diff().fillna(0)
    out = pd.Series(0, index=close.index, dtype="int8")
    out[(cross > 0) & (sgn > 0)] = 1
    out[(cross < 0) & (sgn < 0)] = -1
    return out

old = macd_cross_signal_old(close)
print('equal:', new.equals(old))
print('new unique values:', sorted(new.unique()))
PY`
- `PYTHONPATH=src pytest tests/test_signals_factory.py tests/test_indicators.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7ba6c57b88326946eccddd4048e84