### PR TITLE
Add fallback error handling to SentimentAgent.analyse

### DIFF
--- a/src/forest5/ai_agent.py
+++ b/src/forest5/ai_agent.py
@@ -118,3 +118,6 @@ class SentimentAgent:
         except OpenAIError as e:
             logger.error("OpenAI API error: %s", e)
             return Sentiment(0, f"AI error -> neutral: {e}")
+        except Exception as e:
+            logger.error("Unexpected error during AI analysis: %s", e)
+            return Sentiment(0, f"AI unexpected error -> neutral: {e}")


### PR DESCRIPTION
## Summary
- handle unexpected exceptions in SentimentAgent.analyse by logging and returning neutral sentiment

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7bbdf81f4832689ca09a16cef18ee