### PR TITLE
Handle WAIT time signal in fuse_signals

### DIFF
--- a/src/forest5/signals/fusion.py
+++ b/src/forest5/signals/fusion.py
@@ -1,10 +1,67 @@
 from __future__ import annotations
 
+from typing import Literal
+
 
 def _to_sign(value: int | float) -> int:
-    """Convert numeric values to -1, 0 or 1."""
+    """Convert numeric values to ``-1``, ``0`` or ``1``."""
     if value > 0:
         return 1
     if value < 0:
         return -1
     return 0
+
+
+def fuse_signals(
+    tech_sig: int,
+    time_sig: Literal["BUY", "SELL", "WAIT"] | None = None,
+    *,
+    ai: int | None = None,
+    min_conf: int = 1,
+) -> tuple[int, str]:
+    """Fuse technical, time and optional AI signals into a single decision.
+
+    Parameters
+    ----------
+    tech_sig:
+        Technical signal: ``-1`` (sell), ``0`` (neutral) or ``1`` (buy).
+    time_sig:
+        Time model decision: ``"BUY"``, ``"SELL"`` or ``"WAIT"``. ``None``
+        skips time-based voting.
+    ai:
+        Optional AI vote. Any non-``None`` value participates in the vote.
+    min_conf:
+        Minimum number of positive or negative votes required to produce a
+        directional decision.
+
+    Returns
+    -------
+    tuple[int, str]
+        The fused signal (``-1``/``0``/``1``) and a short reason string.
+    """
+
+    votes = {"tech": _to_sign(tech_sig), "time": 0, "ai": 0}
+    pos = {"tech": int(votes["tech"] > 0), "time": 0, "ai": 0}
+    neg = {"tech": int(votes["tech"] < 0), "time": 0, "ai": 0}
+
+    if time_sig is not None:
+        if time_sig == "WAIT":
+            return 0, "time_wait"
+        votes["time"] = _to_sign(1 if time_sig == "BUY" else -1)
+        pos["time"] = int(votes["time"] > 0)
+        neg["time"] = int(votes["time"] < 0)
+
+    if ai is not None:
+        votes["ai"] = _to_sign(ai)
+        pos["ai"] = int(votes["ai"] > 0)
+        neg["ai"] = int(votes["ai"] < 0)
+
+    pos_total = sum(pos.values())
+    neg_total = sum(neg.values())
+    if max(pos_total, neg_total) < max(min_conf, 1):
+        return 0, "no_consensus"
+    if pos_total > neg_total:
+        return 1, "buy_majority"
+    if neg_total > pos_total:
+        return -1, "sell_majority"
+    return 0, "no_consensus"

--- a/tests/test_signal_fusion.py
+++ b/tests/test_signal_fusion.py
@@ -1,0 +1,18 @@
+import pytest
+
+from forest5.signals.fusion import fuse_signals
+
+
+@pytest.mark.parametrize(
+    "tech_sig,time_sig,ai_vote,expected,reason",
+    [
+        # time model waits -> short-circuit regardless of AI vote
+        (1, "WAIT", 1, 0, "time_wait"),
+        (1, "WAIT", -1, 0, "time_wait"),
+    ],
+)
+def test_time_wait_short_circuit(tech_sig, time_sig, ai_vote, expected, reason):
+    fused, why = fuse_signals(tech_sig, time_sig, ai=ai_vote)
+    assert fused == expected
+    assert why == reason
+


### PR DESCRIPTION
## Summary
- add `fuse_signals` utility to merge technical, time and AI votes
- cover WAIT time signal with tests ensuring it short-circuits with reason `time_wait`

## Testing
- `pytest tests/test_signal_fusion.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7c14764e083269723d605d9e798cf