### PR TITLE
Add tests for candlestick patterns

### DIFF
--- a/tests/test_candles.py
+++ b/tests/test_candles.py
@@ -1,0 +1,35 @@
+import pandas as pd
+
+from forest5.signals.candles import bullish_engulfing, bearish_engulfing, doji
+
+
+def test_bullish_engulfing():
+    df = pd.DataFrame(
+        {
+            "open": [10, 7],
+            "close": [8, 11],
+        }
+    )
+    assert bullish_engulfing(df).tolist() == [0, 1]
+
+
+def test_bearish_engulfing():
+    df = pd.DataFrame(
+        {
+            "open": [8, 11],
+            "close": [10, 7],
+        }
+    )
+    assert bearish_engulfing(df).tolist() == [0, 1]
+
+
+def test_doji():
+    df = pd.DataFrame(
+        {
+            "open": [10, 10],
+            "high": [11, 11],
+            "low": [9, 9],
+            "close": [10.5, 10.05],
+        }
+    )
+    assert doji(df).tolist() == [0, 1]


### PR DESCRIPTION
## Summary
- add unit tests for bullish, bearish engulfing and doji signals

## Testing
- `pre-commit run --files tests/test_candles.py`
- `pytest tests/test_candles.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7c3de22108326b0ace75cfbde4564