### PR TITLE
Add MACD cross strategy support

### DIFF
--- a/src/forest5/config.py
+++ b/src/forest5/config.py
@@ -10,9 +10,10 @@ from .utils.timeframes import normalize_timeframe
 
 
 class StrategySettings(BaseModel):
-    name: Literal["ema_cross"] = "ema_cross"
+    name: Literal["ema_cross", "macd_cross"] = "ema_cross"
     fast: int = 12
     slow: int = 26
+    signal: int = 9
     use_rsi: bool = False
     rsi_period: int = 14
     rsi_overbought: int = 70

--- a/src/forest5/config_live.py
+++ b/src/forest5/config_live.py
@@ -13,9 +13,10 @@ from .config.loader import _norm_path
 
 @dataclass
 class StrategySettings:
-    name: Literal["ema_cross"] = "ema_cross"
+    name: Literal["ema_cross", "macd_cross"] = "ema_cross"
     fast: int = 12
     slow: int = 26
+    signal: int = 9
     use_rsi: bool = False
     rsi_period: int = 14
     rsi_overbought: int = 70

--- a/src/forest5/signals/factory.py
+++ b/src/forest5/signals/factory.py
@@ -7,6 +7,7 @@ import pandas as pd
 from ..core.indicators import ema
 from .candles import candles_signal
 from .combine import confirm_with_candles
+from .macd import macd_cross_signal
 
 
 def _ema_cross_signal(close: pd.Series, fast: int, slow: int) -> pd.Series:
@@ -37,6 +38,15 @@ def compute_signal(df: pd.DataFrame, settings, price_col: str = "close") -> pd.S
 
     if name == "ema_cross":
         base = _ema_cross_signal(df[price_col], strategy.fast, strategy.slow)
+        candles = candles_signal(df)
+        return confirm_with_candles(base, candles)
+    if name == "macd_cross":
+        base = macd_cross_signal(
+            df[price_col],
+            strategy.fast,
+            strategy.slow,
+            getattr(strategy, "signal", 9),
+        )
         candles = candles_signal(df)
         return confirm_with_candles(base, candles)
     raise ValueError(f"Unknown strategy: {name}")

--- a/tests/test_signals_factory.py
+++ b/tests/test_signals_factory.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 
 from forest5.config import BacktestSettings
@@ -7,14 +8,11 @@ from forest5.signals.factory import compute_signal
 
 def test_compute_signal_ema_cross_basic():
     df = generate_ohlc(periods=60, start_price=100.0)
-    s = BacktestSettings()  # domyślnie ema_cross
+    s = BacktestSettings()  # default ema_cross
     sig = compute_signal(df, s)
 
-    # ta sama długość i indeks co dane
     assert list(sig.index) == list(df.index)  # nosec B101
-    # dopuszczalne wartości
     assert set(sig.unique()).issubset({-1, 0, 1})  # nosec B101
-    # nie wszystkie zera (powinny zdarzyć się przecięcia)
     assert (sig != 0).any()  # nosec B101
 
 
@@ -32,3 +30,35 @@ def test_compute_signal_does_not_mutate_settings(alias):
     assert list(sig.index) == list(df.index)  # nosec B101
     assert set(sig.unique()).issubset({-1, 0, 1})  # nosec B101
     assert (sig != 0).any()  # nosec B101
+
+
+def test_compute_signal_macd_cross_basic():
+    idx = pd.date_range("2024-01-01", periods=20, freq="D")
+    prices = [1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1, 2, 3, 4, 5, 4, 3, 2, 1, 2]
+    df = pd.DataFrame(
+        {"open": prices, "high": prices, "low": prices, "close": prices},
+        index=idx,
+    )
+
+    s = BacktestSettings()
+    s.strategy.name = "macd_cross"
+    s.strategy.fast = 3
+    s.strategy.slow = 6
+    s.strategy.signal = 3
+
+    sig = compute_signal(df, s)
+
+    assert list(sig.index) == list(df.index)  # nosec B101
+    assert set(sig.unique()).issubset({-1, 0, 1})  # nosec B101
+    assert 1 in sig.values  # nosec B101
+    assert -1 in sig.values  # nosec B101
+
+
+def test_compute_signal_unknown_strategy_raises():
+    df = generate_ohlc(periods=20, start_price=100.0)
+    s = BacktestSettings()
+    s.strategy.name = "foobar"
+
+    with pytest.raises(ValueError, match="Unknown strategy"):
+        compute_signal(df, s)
+

--- a/tests/test_signals_factory.py
+++ b/tests/test_signals_factory.py
@@ -61,4 +61,3 @@ def test_compute_signal_unknown_strategy_raises():
 
     with pytest.raises(ValueError, match="Unknown strategy"):
         compute_signal(df, s)
-


### PR DESCRIPTION
## Summary
- extend signals factory to dispatch to a configurable `macd_cross` strategy
- allow selecting `macd_cross` with `fast`, `slow`, and `signal` periods in config objects
- test MACD cross generation and unknown strategy errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7c9bdba188326af92436f34bbfee5