### PR TITLE
Handle timezone-aware time column

### DIFF
--- a/src/forest5/time_only.py
+++ b/src/forest5/time_only.py
@@ -10,6 +10,7 @@ from typing import Dict, Tuple, Literal
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_datetime64_any_dtype
 
 
 @dataclass
@@ -63,8 +64,9 @@ def train(df: pd.DataFrame, q_low: float = 0.1, q_high: float = 0.9) -> TimeOnly
     """
 
     df = df.copy()
-    if not np.issubdtype(df["time"].dtype, np.datetime64):
+    if not is_datetime64_any_dtype(df["time"]):
         df["time"] = pd.to_datetime(df["time"])
+    df["time"] = df["time"].dt.tz_localize(None)
     df["hour"] = df["time"].dt.hour
     gates: Dict[int, Tuple[float, float]] = {}
     for hour, series in df.groupby("hour")["y"]:

--- a/tests/test_time_only.py
+++ b/tests/test_time_only.py
@@ -23,3 +23,11 @@ def test_artifact_round_trip(tmp_path: Path) -> None:
     assert model.quantile_gates == loaded.quantile_gates
     # exercise a decision to ensure load works
     loaded.decide(idx[0], df["y"].iloc[0])
+
+
+def test_train_handles_timezone() -> None:
+    rng = np.random.default_rng(0)
+    idx = pd.date_range("2024-01-01", periods=24, freq="h", tz="UTC")
+    df = pd.DataFrame({"time": idx, "y": rng.normal(size=len(idx))})
+    model = time_only.train(df)
+    assert set(model.quantile_gates.keys()) == set(range(24))


### PR DESCRIPTION
## Summary
- handle datetime columns with timezones by using pandas' dtype check and dropping tz info
- add regression test ensuring training with timezone-aware timestamps works

## Testing
- `pytest tests/test_time_only.py::test_train_handles_timezone -vv`

------
https://chatgpt.com/codex/tasks/task_e_68a7d2f504e083268f2284b59c14b55c