### PR TITLE
Preserve extra columns and validate volume in ensure_backtest_ready

### DIFF
--- a/src/forest5/utils/validate.py
+++ b/src/forest5/utils/validate.py
@@ -8,6 +8,7 @@ def ensure_backtest_ready(df: pd.DataFrame, price_col: str = "close") -> pd.Data
     - Upewnia się, że mamy kolumny OHLC
     - Ustawia indeks czasu (tz-naive) z aliasów: time/date/datetime/timestamp
     - Sortuje, usuwa duplikaty, nazywa indeks 'time'
+    - Zachowuje dodatkowe kolumny, w tym opcjonalny 'volume'
     """
     df = df.copy()
     required = {"open", "high", "low", "close"}
@@ -39,5 +40,10 @@ def ensure_backtest_ready(df: pd.DataFrame, price_col: str = "close") -> pd.Data
     for col in ("open", "high", "low", "close"):
         df[col] = pd.to_numeric(df[col], errors="coerce")
     df = df.dropna(subset=["open", "high", "low", "close"])
+
+    # Opcjonalny wolumen: konwersja i czyszczenie braków
+    if "volume" in df.columns:
+        df["volume"] = pd.to_numeric(df["volume"], errors="coerce")
+        df = df.dropna(subset=["volume"])
 
     return df

--- a/tests/test_validate_volume.py
+++ b/tests/test_validate_volume.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from forest5.utils.validate import ensure_backtest_ready
+
+
+def test_volume_optional_and_preserved():
+    df = pd.DataFrame(
+        {
+            "time": ["2020-01-01 00:00", "2020-01-01 01:00", "2020-01-01 02:00"],
+            "open": [1, 1, 1],
+            "high": [1, 1, 1],
+            "low": [1, 1, 1],
+            "close": [1, 1, 1],
+            "volume": [100, "200", None],
+            "extra": [10, 20, 30],
+        }
+    )
+    out = ensure_backtest_ready(df)
+    assert "volume" in out.columns
+    assert "extra" in out.columns
+    assert len(out) == 2
+    assert pd.api.types.is_numeric_dtype(out["volume"])


### PR DESCRIPTION
## Summary
- Keep all original columns when validating backtest data
- Optionally coerce and clean the `volume` column
- Add regression test ensuring `volume` and extra columns survive validation

## Testing
- `pytest -q`
- `pytest tests/test_validate_volume.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68a7d8a1aadc8326be74f77d54263197