### PR TITLE
feat: apply optional RSI filter in signal factory

### DIFF
--- a/tests/test_signals_factory.py
+++ b/tests/test_signals_factory.py
@@ -36,8 +36,6 @@ def test_compute_signal_does_not_mutate_settings(alias):
     assert (sig != 0).any()  # nosec B101
 
 
-
-
 def test_compute_signal_with_rsi_filter_matches_manual():
     df = generate_ohlc(periods=60, start_price=100.0)
     s = BacktestSettings()
@@ -45,8 +43,8 @@ def test_compute_signal_with_rsi_filter_matches_manual():
 
     sig = compute_signal(df, s)
 
-    base = _ema_cross_signal(df['close'], s.strategy.fast, s.strategy.slow)
-    rsi_series = rsi(df['close'], s.strategy.rsi_period)
+    base = _ema_cross_signal(df["close"], s.strategy.fast, s.strategy.slow)
+    rsi_series = rsi(df["close"], s.strategy.rsi_period)
     candles = candles_signal(df)
     expected = confirm_with_candles(
         apply_rsi_filter(
@@ -58,6 +56,7 @@ def test_compute_signal_with_rsi_filter_matches_manual():
         candles,
     )
     assert sig.equals(expected)
+
 
 def test_compute_signal_macd_cross_basic():
     idx = pd.date_range("2024-01-01", periods=20, freq="D")

--- a/tests/test_signals_factory.py
+++ b/tests/test_signals_factory.py
@@ -2,8 +2,12 @@ import pandas as pd
 import pytest
 
 from forest5.config import BacktestSettings
+
 from forest5.examples.synthetic import generate_ohlc
-from forest5.signals.factory import compute_signal
+from forest5.signals.factory import compute_signal, _ema_cross_signal
+from forest5.core.indicators import rsi
+from forest5.signals.candles import candles_signal
+from forest5.signals.combine import apply_rsi_filter, confirm_with_candles
 
 
 def test_compute_signal_ema_cross_basic():
@@ -31,6 +35,29 @@ def test_compute_signal_does_not_mutate_settings(alias):
     assert set(sig.unique()).issubset({-1, 0, 1})  # nosec B101
     assert (sig != 0).any()  # nosec B101
 
+
+
+
+def test_compute_signal_with_rsi_filter_matches_manual():
+    df = generate_ohlc(periods=60, start_price=100.0)
+    s = BacktestSettings()
+    s.strategy.use_rsi = True
+
+    sig = compute_signal(df, s)
+
+    base = _ema_cross_signal(df['close'], s.strategy.fast, s.strategy.slow)
+    rsi_series = rsi(df['close'], s.strategy.rsi_period)
+    candles = candles_signal(df)
+    expected = confirm_with_candles(
+        apply_rsi_filter(
+            base,
+            rsi_series,
+            s.strategy.rsi_overbought,
+            s.strategy.rsi_oversold,
+        ),
+        candles,
+    )
+    assert sig.equals(expected)
 
 def test_compute_signal_macd_cross_basic():
     idx = pd.date_range("2024-01-01", periods=20, freq="D")


### PR DESCRIPTION
## Summary
- wire apply_rsi_filter into signal generation when strategy.use_rsi is enabled
- cover RSI filtering with a dedicated unit test

## Testing
- `python3 -m ruff check src tests`
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a801208abc832694f808a99d7ba191