### PR TITLE
refactor: centralize ema cross signal

### DIFF
--- a/src/forest5/signals/ema.py
+++ b/src/forest5/signals/ema.py
@@ -7,24 +7,14 @@ from forest5.core.indicators import ema
 
 
 def ema_cross_signal(close: pd.Series, fast: int, slow: int) -> pd.Series:
-    """
-    Sygnał krzyżowania EMA.
-    +1 gdy EMA(fast) > EMA(slow) i nastąpiło przebicie od dołu,
-    -1 gdy EMA(fast) < EMA(slow) i nastąpiło przebicie od góry,
-     0 w pozostałych punktach.
-    """
+    """Generuje impuls BUY/SELL na realnej zmianie kierunku krzyżowania EMA."""
     fast_ = ema(close, fast)
     slow_ = ema(close, slow)
-    spread = fast_ - slow_
+    direction = pd.Series(np.where(fast_ > slow_, 1, -1), index=close.index, dtype=int)
 
-    # detekcja przecięć (zmiana znaku spreadu)
-    sign = np.sign(spread)
-    cross = sign.diff().fillna(0)
+    # Brak sygnału na pierwszym barze — wymagamy poprzedniej wartości
+    changed = direction.ne(direction.shift(1)) & direction.shift(1).notna()
 
-    long_sig = (cross > 0) & (sign > 0)  # przejście na dodatnie
-    short_sig = (cross < 0) & (sign < 0)  # przejście na ujemne
-
-    sig = pd.Series(0, index=close.index, dtype="int8")
-    sig[long_sig] = 1
-    sig[short_sig] = -1
-    return sig
+    out = pd.Series(0, index=close.index, dtype=int)
+    out.loc[changed] = direction.loc[changed]
+    return out

--- a/tests/test_signals_factory.py
+++ b/tests/test_signals_factory.py
@@ -4,7 +4,8 @@ import pytest
 from forest5.config import BacktestSettings
 
 from forest5.examples.synthetic import generate_ohlc
-from forest5.signals.factory import compute_signal, _ema_cross_signal
+from forest5.signals.factory import compute_signal
+from forest5.signals.ema import ema_cross_signal
 from forest5.core.indicators import rsi
 from forest5.signals.candles import candles_signal
 from forest5.signals.combine import apply_rsi_filter, confirm_with_candles
@@ -43,7 +44,7 @@ def test_compute_signal_with_rsi_filter_matches_manual():
 
     sig = compute_signal(df, s)
 
-    base = _ema_cross_signal(df["close"], s.strategy.fast, s.strategy.slow)
+    base = ema_cross_signal(df["close"], s.strategy.fast, s.strategy.slow)
     rsi_series = rsi(df["close"], s.strategy.rsi_period)
     candles = candles_signal(df)
     expected = confirm_with_candles(


### PR DESCRIPTION
## Summary
- replace duplicate EMA cross implementations with a single `ema_cross_signal`
- use the shared helper in signal factory
- update tests to reference the consolidated function

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a803ffca3483269aa938ab163d3f2a