### PR TITLE
Allow percent sign parsing in CLI

### DIFF
--- a/src/forest5/utils/argparse_ext.py
+++ b/src/forest5/utils/argparse_ext.py
@@ -14,10 +14,14 @@ class PercentAction(argparse.Action):
         super().__init__(option_strings, dest, **kwargs)
 
     def __call__(self, parser, namespace, value, option_string=None):
+        if isinstance(value, str):
+            value = value.replace("%", "").replace(",", ".")
         try:
             val = float(value)
         except ValueError:
             parser.error(f"{option_string} expects a number")
         if not (self.min_value <= val <= self.max_value):
-            parser.error(f"{option_string} must be between {self.min_value} and {self.max_value}")
+            parser.error(
+                f"{option_string} must be between {self.min_value} and {self.max_value}"
+            )
         setattr(namespace, self.dest, val)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,6 +90,18 @@ def test_percentage_out_of_range_error(capfd):
     assert "between 0.0 and 1.0" in err
 
 
+def test_percent_action_parses_percent_sign():
+    parser = build_parser()
+    args = parser.parse_args(["backtest", "--csv", "dummy.csv", "--risk", "1%"])
+    assert args.risk == 1.0
+
+
+def test_percent_action_parses_comma_percent():
+    parser = build_parser()
+    args = parser.parse_args(["backtest", "--csv", "dummy.csv", "--risk", "0,5%"])
+    assert args.risk == 0.5
+
+
 def test_cli_live(tmp_path, monkeypatch):
     cfg = tmp_path / "config.yaml"
     cfg.write_text("broker:\n  type: mt4\n  symbol: EURUSD\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- preprocess PercentAction values to support `%` and `,`
- test CLI risk option with percent and comma values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a83817152c8326887908c926d0abad