### PR TITLE
Support colon syntax in span parser

### DIFF
--- a/tests/test_parse_span_or_list.py
+++ b/tests/test_parse_span_or_list.py
@@ -16,6 +16,10 @@ def test_parse_span_list():
     assert _parse_span_or_list("1,4,7") == [1, 4, 7]
 
 
+def test_parse_span_colon_syntax():
+    assert _parse_span_or_list("8:16:1") == [8, 9, 10, 11, 12, 13, 14, 15, 16]
+
+
 def test_parse_span_step_error():
     with pytest.raises(argparse.ArgumentTypeError, match="Step"):
         _parse_span_or_list("1-5:0")


### PR DESCRIPTION
## Summary
- allow `_parse_span_or_list` to parse `lo:hi:step` ranges alongside `lo-hi[:step]`
- clarify error message with supported span formats
- add test for colon range syntax

## Testing
- `pre-commit run --files src/forest5/cli.py`
- `SKIP=bandit pre-commit run --files tests/test_parse_span_or_list.py`
- `pytest tests/test_parse_span_or_list.py`


------
https://chatgpt.com/codex/tasks/task_e_68a839731af88326a442bdf7230a1a7f