### PR TITLE
Validate time model path in backtest command

### DIFF
--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -129,6 +129,10 @@ def _parse_int_list(spec: str | None) -> list[int]:
 def cmd_backtest(args: argparse.Namespace) -> int:
     df = load_ohlc_csv(args.csv, time_col=args.time_col, sep=args.sep)
 
+    if args.time_model and not os.path.exists(args.time_model):
+        print(f"Plik modelu czasu nie istnieje: {args.time_model}")
+        sys.exit(1)
+
     settings = BacktestSettings(
         symbol=args.symbol or "SYMBOL",
         strategy={

--- a/tests/test_cli_time_options.py
+++ b/tests/test_cli_time_options.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from types import SimpleNamespace
+import pytest
 
 from forest5.cli import build_parser, cmd_backtest
 
@@ -58,3 +59,20 @@ def test_cli_time_only_options(tmp_path, monkeypatch):
     assert settings.time.model.path == model_path
     assert settings.time.blocked_hours == [1, 2]
     assert settings.time.blocked_weekdays == [0, 6]
+
+
+def test_cli_time_model_missing(tmp_path, capsys):
+    csv_path = _write_csv(tmp_path / "data.csv")
+    model_path = tmp_path / "missing.onnx"
+
+    parser = build_parser()
+    args = parser.parse_args(
+        ["backtest", "--csv", str(csv_path), "--time-model", str(model_path)]
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_backtest(args)
+    assert exc.value.code == 1
+
+    out = capsys.readouterr().out
+    assert f"Plik modelu czasu nie istnieje: {model_path}" in out


### PR DESCRIPTION
## Summary
- ensure `backtest` command exits with error when time model file is missing
- add regression test for missing time model and import pytest

## Testing
- `pytest tests/test_cli_time_options.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a84ca833948326be7442122fc15114