### PR TITLE
test: cover grid indicators with time model

### DIFF
--- a/tests/test_grid_indicators.py
+++ b/tests/test_grid_indicators.py
@@ -1,0 +1,28 @@
+import json
+
+
+from forest5.backtest.grid import run_grid
+from forest5.examples.synthetic import generate_ohlc
+
+
+def test_grid_with_rsi_and_time_model(tmp_path):
+    df = generate_ohlc(periods=40, start_price=100.0, freq="h")
+    model_path = tmp_path / "model_time.json"
+    model = {"quantile_gates": {"0": [0.0, 2.0]}, "q_low": 0.25, "q_high": 0.75}
+    model_path.write_text(json.dumps(model))
+
+    res = run_grid(
+        df,
+        symbol="SYMB",
+        fast_values=[5],
+        slow_values=[10],
+        atr_period=5,
+        atr_multiple=1.5,
+        use_rsi=True,
+        time_model=model_path,
+        cache_dir=str(tmp_path / "cache"),
+        n_jobs=1,
+    )
+
+    assert not res.empty
+    assert {"equity_end", "max_dd", "cagr", "rar"}.issubset(res.columns)


### PR DESCRIPTION
## Summary
- add regression test for `run_grid` using RSI, ATR params and a time model

## Testing
- `pre-commit run --files tests/test_grid_indicators.py`
- `python3 -m pytest tests/test_grid_indicators.py`


------
https://chatgpt.com/codex/tasks/task_e_68a853cd17f88326bb389ab009e07c8a