### PR TITLE
Enhance grid search parameterization

### DIFF
--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -34,3 +34,20 @@ def test_grid_parallel_same_result():
         res1.sort_values(["fast", "slow"]).reset_index(drop=True),
         res2.sort_values(["fast", "slow"]).reset_index(drop=True),
     )
+
+
+def test_grid_multiple_parameters():
+    df = generate_ohlc(periods=40, start_price=100.0, freq="D")
+    res = run_grid(
+        df,
+        symbol="SYMB",
+        fast_values=[6, 8],
+        slow_values=[12, 20],
+        risk_values=[0.01, 0.02],
+        rsi_period_values=[14, 21],
+        capital=10_000.0,
+        n_jobs=1,
+    )
+    assert len(res) == 16  # 2*2*2*2 combinations
+    assert set(res["risk"]) == {0.01, 0.02}
+    assert set(res["rsi_period"]) == {14, 21}


### PR DESCRIPTION
## Summary
- generalize `param_grid` to accept an arbitrary dictionary of parameter lists
- extend `run_grid` to handle variable `risk` and `rsi_period` combinations
- add test covering multi-parameter grid generation

## Testing
- `pytest tests/test_grid.py`


------
https://chatgpt.com/codex/tasks/task_e_68a855ea5c388326a6afb947cd8755eb