### PR TITLE
Add debug logger for decision tracking

### DIFF
--- a/src/forest5/backtest/grid.py
+++ b/src/forest5/backtest/grid.py
@@ -83,6 +83,7 @@ def run_grid(
     blocked_weekdays: list[int] | None = None,
     n_jobs: int = 1,
     cache_dir: str = ".cache/forest5-grid",
+    debug_dir: Path | None = None,
 ) -> pd.DataFrame:
     blocked_hours = blocked_hours or []
     blocked_weekdays = blocked_weekdays or []
@@ -108,6 +109,8 @@ def run_grid(
     indicators.atr = mem.cache(indicators.atr)
     indicators.ema = mem.cache(indicators.ema)
 
+    base_debug_dir = Path(debug_dir) if debug_dir else None
+
     @mem.cache
     def _single_run(
         fast: int,
@@ -116,6 +119,13 @@ def run_grid(
         rsi_period_value: int,
         max_dd_value: float,
     ) -> GridResult:
+        run_debug = None
+        if base_debug_dir:
+            name = (
+                f"fast{fast}_slow{slow}_risk{risk_value}_"
+                f"rsi{rsi_period_value}_maxdd{max_dd_value}"
+            )
+            run_debug = base_debug_dir / name
         settings = BacktestSettings(
             symbol=symbol,
             timeframe="1h",
@@ -137,6 +147,7 @@ def run_grid(
             ),
             atr_period=atr_period,
             atr_multiple=atr_multiple,
+            debug_dir=run_debug,
         )
         settings.time.model.enabled = bool(time_model)
         settings.time.model.path = time_model

--- a/src/forest5/config.py
+++ b/src/forest5/config.py
@@ -100,11 +100,19 @@ class BacktestSettings(BaseModel):
     time: BacktestTimeSettings = Field(default_factory=BacktestTimeSettings)
     atr_period: int = 14
     atr_multiple: float = 2.0
+    debug_dir: Path | None = None
 
     @field_validator("timeframe")
     @classmethod
     def _norm_tf(cls, v: str) -> str:
         return normalize_timeframe(v)
+
+    @field_validator("debug_dir", mode="before")
+    @classmethod
+    def _to_path(cls, v: str | Path | None) -> Path | None:
+        if v is None:
+            return None
+        return Path(v)
 
     @classmethod
     def from_file(cls, path: str | Path) -> "BacktestSettings":

--- a/src/forest5/utils/debugger.py
+++ b/src/forest5/utils/debugger.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+class DebugLogger:
+    """Simple JSONL logger for debugging trading decisions."""
+
+    def __init__(self, directory: str | Path) -> None:
+        self.dir = Path(directory)
+        self.dir.mkdir(parents=True, exist_ok=True)
+        self.file = self.dir / "decision_log.jsonl"
+        self._fh = self.file.open("a", encoding="utf-8")
+
+    def log(self, event: str, **data: Any) -> None:
+        entry = {"event": event, **data}
+        json.dump(entry, self._fh, ensure_ascii=False)
+        self._fh.write("\n")
+        self._fh.flush()
+
+    def close(self) -> None:
+        try:
+            self._fh.close()
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- implement `DebugLogger` JSONL logger for debug traces
- add `debug_dir` option across settings and CLI to enable per-run logging
- log signal skips, rejections, and trade actions in backtest and live sessions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8650306a48326ad7c89cd731a9235