### PR TITLE
Fix ambiguous variable name in debugger test

### DIFF
--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -1,0 +1,15 @@
+import json
+from forest5.utils.debugger import DebugLogger
+
+
+def test_debug_logger(tmp_path):
+    logger = DebugLogger(tmp_path)
+    logger.log("foo", value=1)
+    logger.log("bar", value=2)
+    log_file = tmp_path / "decision_log.jsonl"
+    lines = [json.loads(line) for line in log_file.read_text(encoding="utf-8").splitlines()]
+    assert lines == [
+        {"event": "foo", "value": 1},
+        {"event": "bar", "value": 2},
+    ]
+    logger.close()


### PR DESCRIPTION
## Summary
- clarify loop variable naming in debug logger test

## Testing
- `make lint`
- `pytest tests/test_debugger.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8707ed53083269986b3b9a9256e0b