### PR TITLE
Initialize logger at entry points

### DIFF
--- a/src/forest5/backtest/engine.py
+++ b/src/forest5/backtest/engine.py
@@ -9,13 +9,16 @@ import pandas as pd
 from ..config import BacktestSettings
 from ..utils.debugger import DebugLogger
 from ..core.indicators import atr, ema, rsi
-from ..utils.log import log
+from ..utils.log import setup_logger
 from ..utils.validate import ensure_backtest_ready
 from forest5.signals.factory import compute_signal
 from .risk import RiskManager
 from .tradebook import TradeBook
 from ..time_only import TimeOnlyModel
 from ..signals.fusion import _to_sign
+
+
+log = setup_logger()
 
 
 @dataclass

--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -16,6 +16,7 @@ from forest5.backtest.grid import run_grid
 from forest5.live.live_runner import run_live
 from forest5.utils.io import read_ohlc_csv
 from forest5.utils.argparse_ext import PercentAction
+from forest5.utils.log import setup_logger
 
 
 class SafeHelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter):
@@ -399,6 +400,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    setup_logger()
     parser = build_parser()
     args = parser.parse_args(argv)
     if not hasattr(args, "func"):

--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -15,10 +15,13 @@ from ..signals.factory import compute_signal
 from ..signals.candles import candles_signal
 from ..signals.combine import confirm_with_candles
 from ..utils.timeframes import _TF_MINUTES
-from ..utils.log import log
+from ..utils.log import setup_logger
 from ..utils.debugger import DebugLogger
 from .router import OrderRouter
 from .risk_guard import should_halt_for_drawdown
+
+
+log = setup_logger()
 
 
 def _read_context(path: str | Path, max_bytes: int = 16_384) -> str:

--- a/src/forest5/live/mt4_broker.py
+++ b/src/forest5/live/mt4_broker.py
@@ -8,7 +8,10 @@ from pathlib import Path
 from typing import Optional
 
 from .router import OrderRouter, OrderResult
-from ..utils.log import log
+from ..utils.log import setup_logger
+
+
+log = setup_logger()
 
 
 class MT4Broker(OrderRouter):

--- a/src/forest5/utils/log.py
+++ b/src/forest5/utils/log.py
@@ -18,9 +18,7 @@ def setup_logger(level: str = "INFO"):
         Configured logger instance.
     """
 
-    logging.basicConfig(
-        format="%(message)s", level=getattr(logging, level.upper(), logging.INFO)
-    )
+    logging.basicConfig(format="%(message)s", level=getattr(logging, level.upper(), logging.INFO))
     processors = [
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.add_log_level,

--- a/src/forest5/utils/log.py
+++ b/src/forest5/utils/log.py
@@ -5,7 +5,22 @@ import structlog
 
 
 def setup_logger(level: str = "INFO"):
-    logging.basicConfig(format="%(message)s", level=getattr(logging, level.upper(), logging.INFO))
+    """Configure and return a structlog logger.
+
+    Parameters
+    ----------
+    level:
+        Logging level name, e.g. ``"INFO"`` or ``"DEBUG"``.
+
+    Returns
+    -------
+    structlog.stdlib.BoundLogger
+        Configured logger instance.
+    """
+
+    logging.basicConfig(
+        format="%(message)s", level=getattr(logging, level.upper(), logging.INFO)
+    )
     processors = [
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.add_log_level,
@@ -16,4 +31,5 @@ def setup_logger(level: str = "INFO"):
     return structlog.get_logger()
 
 
-log = setup_logger()
+# The module no longer exposes a global ``log`` instance. Call ``setup_logger``
+# from application entry points to create one.

--- a/tests/test_risk_guard.py
+++ b/tests/test_risk_guard.py
@@ -1,5 +1,7 @@
 from forest5.live.risk_guard import should_halt_for_drawdown
-from forest5.utils.log import log
+from forest5.utils.log import setup_logger
+
+log = setup_logger()
 
 
 def test_should_halt_for_drawdown_basic() -> None:


### PR DESCRIPTION
## Summary
- remove global logger instance and keep only setup_logger factory
- initialize logging in CLI, backtest engine, and live modules
- update risk guard tests for new logger setup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a87bb82be88326be97655e926088dd