### PR TITLE
Expose AI model options for DecisionAgent

### DIFF
--- a/src/forest5/decision.py
+++ b/src/forest5/decision.py
@@ -13,6 +13,8 @@ from .signals.fusion import _to_sign
 @dataclass
 class DecisionConfig:
     use_ai: bool = False
+    ai_model: str = "gpt-4o-mini"
+    ai_max_tokens: int = 256
     time_model: TimeOnlyModel | None = None
     min_confluence: int = 1  # min sygnałów (techniczny zawsze = 1)
 
@@ -32,7 +34,13 @@ class DecisionAgent:
     ) -> None:
         self.router = router or PaperBroker()
         self.config = config or DecisionConfig()
-        self.ai = SentimentAgent() if self.config.use_ai else None
+        self.ai = (
+            SentimentAgent(
+                model=self.config.ai_model, max_tokens=self.config.ai_max_tokens
+            )
+            if self.config.use_ai
+            else None
+        )
 
     def decide(
         self,

--- a/src/forest5/decision.py
+++ b/src/forest5/decision.py
@@ -35,9 +35,7 @@ class DecisionAgent:
         self.router = router or PaperBroker()
         self.config = config or DecisionConfig()
         self.ai = (
-            SentimentAgent(
-                model=self.config.ai_model, max_tokens=self.config.ai_max_tokens
-            )
+            SentimentAgent(model=self.config.ai_model, max_tokens=self.config.ai_max_tokens)
             if self.config.use_ai
             else None
         )

--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -162,6 +162,8 @@ def run_live(
         router=broker,
         config=DecisionConfig(
             use_ai=use_ai,
+            ai_model=settings.ai.model,
+            ai_max_tokens=settings.ai.max_tokens,
             time_model=time_model,
             min_confluence=settings.decision.min_confluence,
         ),

--- a/tests/test_live_runner_ai_params.py
+++ b/tests/test_live_runner_ai_params.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from forest5.live.live_runner import run_live
+from forest5.live.settings import (
+    LiveSettings,
+    BrokerSettings,
+    DecisionSettings,
+    AISettings,
+    TimeSettings,
+    RiskSettings,
+)
+
+
+class DummySentimentAgent:
+    def __init__(self, model: str, max_tokens: int):
+        self.model = model
+        self.max_tokens = max_tokens
+        self.enabled = True
+
+    def analyse(self, context: str, symbol: str):
+        from forest5.ai_agent import Sentiment
+
+        return Sentiment(0, "")
+
+
+def test_run_live_passes_ai_params(tmp_path: Path, monkeypatch):
+    captured: dict[str, int | str] = {}
+
+    def _sentiment_agent(model: str, max_tokens: int):
+        captured["model"] = model
+        captured["max_tokens"] = max_tokens
+        return DummySentimentAgent(model, max_tokens)
+
+    monkeypatch.setattr("forest5.decision.SentimentAgent", _sentiment_agent)
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    settings = LiveSettings(
+        broker=BrokerSettings(type="paper", bridge_dir=str(tmp_path), symbol="EURUSD", volume=0.01),
+        decision=DecisionSettings(min_confluence=1),
+        ai=AISettings(enabled=True, model="custom-model", max_tokens=99, context_file=None),
+        time=TimeSettings(blocked_hours=[], blocked_weekdays=[]),
+        risk=RiskSettings(max_drawdown=0.5),
+    )
+
+    run_live(settings, max_steps=0, timeout=0)
+
+    assert captured == {"model": "custom-model", "max_tokens": 99}


### PR DESCRIPTION
## Summary
- allow configuring AI model and token limit in `DecisionConfig`
- wire `LiveSettings.ai` values to `DecisionAgent`
- cover AI parameter passing in live runner tests

## Testing
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_68a8852030448326a85ac24595ce15b8