### PR TITLE
Use append_bar_and_signal stub in soft wait test

### DIFF
--- a/tests/test_live_runner_soft_wait.py
+++ b/tests/test_live_runner_soft_wait.py
@@ -39,8 +39,13 @@ def test_run_live_soft_wait(tmp_path: Path, monkeypatch) -> None:
             bar["low"],
             bar["close"],
         ]
-        return pd.Series([1], index=df.index)
+        return 1
 
+    monkeypatch.setattr(
+        "forest5.live.live_runner.append_bar_and_signal",
+        fake_append_bar_and_signal,
+        raising=False,
+    )
     monkeypatch.setattr(
         "forest5.live.live_runner._append_bar_and_signal", fake_append_bar_and_signal
     )


### PR DESCRIPTION
## Summary
- Replace compute-signal stub with `append_bar_and_signal` stub that appends bar data and returns constant signal
- Monkeypatch both public and private append-bar helpers for compatibility in `test_run_live_soft_wait`

## Testing
- `PYTHONPATH=src pytest tests/test_live_runner_soft_wait.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8967fc6e083268e5c69dd9894cb4d