### PR TITLE
Use append_bar_and_signal stub in soft wait test

### DIFF
--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -39,7 +39,7 @@ def _read_context(path: str | Path, max_bytes: int = 16_384) -> str:
         return ""
 
 
-def _append_bar_and_signal(df: pd.DataFrame, bar: dict, settings: LiveSettings) -> int:
+def append_bar_and_signal(df: pd.DataFrame, bar: dict, settings: LiveSettings) -> int:
     """Append ``bar`` to ``df`` and return only the latest signal.
 
     This updates EMA values incrementally so indicator calculations scale
@@ -92,6 +92,10 @@ def _append_bar_and_signal(df: pd.DataFrame, bar: dict, settings: LiveSettings) 
         candle_ser = pd.Series([candle], index=[idx])
         sig = int(confirm_with_candles(idx_ser, candle_ser).iloc[-1])
     return sig
+
+
+# Backward compatibility
+_append_bar_and_signal = append_bar_and_signal
 
 
 def run_live(
@@ -225,7 +229,7 @@ def run_live(
                         current_bar["close"] = price
                     else:
                         idx = pd.to_datetime(current_bar["start"], unit="s")
-                        sig = _append_bar_and_signal(df, current_bar, settings)
+                        sig = append_bar_and_signal(df, current_bar, settings)
                         log.info("candle_closed", **current_bar)
                         last_candle_ts = time.time()
 

--- a/tests/test_live_runner_soft_wait.py
+++ b/tests/test_live_runner_soft_wait.py
@@ -42,12 +42,7 @@ def test_run_live_soft_wait(tmp_path: Path, monkeypatch) -> None:
         return 1
 
     monkeypatch.setattr(
-        "forest5.live.live_runner.append_bar_and_signal",
-        fake_append_bar_and_signal,
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "forest5.live.live_runner._append_bar_and_signal", fake_append_bar_and_signal
+        "forest5.live.live_runner.append_bar_and_signal", fake_append_bar_and_signal
     )
 
     orig_log = run_live.__globals__["log"].info


### PR DESCRIPTION
## Summary
- Replace compute signal test stub with append_bar_and_signal helper
- Rename `_append_bar_and_signal` to public `append_bar_and_signal` and add backward compatibility alias
- Update live runner to call new helper

## Testing
- `pytest tests/test_live_runner_soft_wait.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a898ed804483268446bc19f5010128