### PR TITLE
test: stub append bar and signal in live runner soft wait test

### DIFF
--- a/tests/test_live_runner_soft_wait.py
+++ b/tests/test_live_runner_soft_wait.py
@@ -42,8 +42,7 @@ def test_run_live_soft_wait(tmp_path: Path, monkeypatch) -> None:
         return pd.Series([1], index=df.index)
 
     monkeypatch.setattr(
-        "forest5.live.live_runner.append_bar_and_signal",
-        fake_append_bar_and_signal
+        "forest5.live.live_runner.append_bar_and_signal", fake_append_bar_and_signal
     )
 
     orig_log = run_live.__globals__["log"].info

--- a/tests/test_live_runner_soft_wait.py
+++ b/tests/test_live_runner_soft_wait.py
@@ -39,10 +39,11 @@ def test_run_live_soft_wait(tmp_path: Path, monkeypatch) -> None:
             bar["low"],
             bar["close"],
         ]
-        return 1
+        return pd.Series([1], index=df.index)
 
     monkeypatch.setattr(
-        "forest5.live.live_runner.append_bar_and_signal", fake_append_bar_and_signal
+        "forest5.live.live_runner.append_bar_and_signal",
+        fake_append_bar_and_signal
     )
 
     orig_log = run_live.__globals__["log"].info


### PR DESCRIPTION
## Summary
- replace soft wait test stub with fake_append_bar_and_signal that updates candles and returns a pandas Series
- monkeypatch `append_bar_and_signal` to use the new stub

## Testing
- `pytest tests/test_live_runner_soft_wait.py`


------
https://chatgpt.com/codex/tasks/task_e_68a89bb4dca48326832628a095b670a7