### PR TITLE
feat: standalone time-only model

### DIFF
--- a/scripts/time_train.py
+++ b/scripts/time_train.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Train and save a TimeOnlyModel from CSV data."""
+"""Train and save a :class:`TimeOnlyModel` from CSV data."""
 
 import argparse
 from pathlib import Path
@@ -10,11 +10,13 @@ from forest5.time_only import TimeOnlyModel, train
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Train TimeOnlyModel and export to JSON")
+    parser = argparse.ArgumentParser(
+        description="Train TimeOnlyModel and export to JSON with metrics"
+    )
     parser.add_argument("--input", required=True, help="CSV file with 'time' and 'y' columns")
     parser.add_argument("--output", required=True, help="Path to save model JSON")
-    parser.add_argument("--q-low", type=float, default=0.1, help="Lower quantile")
-    parser.add_argument("--q-high", type=float, default=0.9, help="Upper quantile")
+    parser.add_argument("--q-low", type=float, default=0.2, help="Lower quantile")
+    parser.add_argument("--q-high", type=float, default=0.8, help="Upper quantile")
     args = parser.parse_args()
 
     input_path = Path(args.input)
@@ -24,13 +26,16 @@ def main() -> None:
     df = pd.read_csv(input_path)
     if not {"time", "y"}.issubset(df.columns):
         raise ValueError("CSV must contain 'time' and 'y' columns")
-    df["time"] = pd.to_datetime(df["time"])
 
-    model = train(df, q_low=args.q_low, q_high=args.q_high)
-    Path(args.output).write_text(model.to_json())
+    model, metrics = train(df, q_low=args.q_low, q_high=args.q_high, return_metrics=True)
+    model.save(args.output)
     # ensure model can be loaded back
     TimeOnlyModel.load(args.output)
     print(f"Saved model to {args.output}")
+    for horizon, m in metrics.items():
+        acc = m["accuracy"]
+        brier = m["brier"]
+        print(f"h{horizon}: acc={acc:.3f} brier={brier:.3f}")
 
 
 if __name__ == "__main__":

--- a/src/forest5/time_only.py
+++ b/src/forest5/time_only.py
@@ -1,125 +1,226 @@
+"""Self-contained time-only model.
+
+This module implements a minimal probability based trading model that relies
+solely on calendar features.  For a set of prediction horizons the model
+estimates the probability of future growth using historical observations and
+forward chaining with an *embargo* equal to the prediction horizon.  From the
+predicted probabilities quantile gates are derived which in turn are used to
+generate BUY/SELL/HOLD decisions together with a position weight.
+
+The module intentionally does not depend on any other project files so it can
+be trained, serialised and loaded in isolation.
+"""
+
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
-import argparse
 import json
 from pathlib import Path
-import tempfile
-from typing import Dict, Tuple, Literal
+from typing import Dict, Tuple, Iterable, Any
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_datetime64_any_dtype
+import tempfile
+
+# ---------------------------------------------------------------------------
+# Model
+
+
+HORIZONS = (1, 4, 6, 24)
+
+
+def _key(ts: pd.Timestamp) -> str:
+    """Encode timestamp into a lookup key."""
+
+    return f"{ts.hour}-{ts.weekday()}"
 
 
 @dataclass
 class TimeOnlyModel:
-    """Simple time-of-day quantile gates.
+    """Store probability tables and quantile gates.
 
-    For each hour of day we store low/high quantile thresholds of the target
-    variable. The decision uses only the timestamp and the observed value.
+    Attributes
+    ----------
+    prob_tables:
+        Mapping ``horizon -> {"hour-weekday": probability}``.
+    quantiles:
+        Mapping ``horizon -> (q_low, q_high)`` used for decision making.
+    metadata:
+        Arbitrary dictionary preserved during serialisation.
     """
 
-    quantile_gates: Dict[int, Tuple[float, float]]
-    q_low: float
-    q_high: float
+    prob_tables: Dict[int, Dict[str, float]]
+    quantiles: Dict[int, Tuple[float, float]]
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
-    def decide(self, ts: datetime, value: float) -> Literal["BUY", "SELL", "WAIT"]:
-        """Return BUY/SELL/WAIT decision based on quantile gates."""
-        hour = ts.hour
-        gates = self.quantile_gates.get(hour)
-        if gates is None:
-            return "WAIT"
-        low, high = gates
-        if value <= low:
-            return "SELL"
-        if value >= high:
-            return "BUY"
-        return "WAIT"
+    # ------------------------------------------------------------------
+    # Prediction and decision helpers
 
-    def save(self, path: str | Path) -> None:
-        Path(path).write_text(self.to_json())
+    def predict_proba(self, ts: datetime) -> Dict[int, float]:
+        """Return probability of growth for each horizon."""
+
+        key = _key(pd.Timestamp(ts))
+        return {h: self.prob_tables.get(h, {}).get(key, 0.5) for h in self.prob_tables}
+
+    def decide(self, ts: datetime) -> Dict[str, Any]:
+        """Return decision and weight for the strongest horizon.
+
+        The returned dictionary contains:
+
+        ``decision``
+            One of ``"BUY"``, ``"SELL"`` or ``"HOLD"``.
+        ``weight``
+            Position weight in ``[0, 1]``.
+        ``horizon``
+            Horizon in hours which produced the decision.
+        ``probs``
+            Raw probability predictions per horizon.
+        """
+
+        probs = self.predict_proba(ts)
+        candidates = {}
+        for h, p in probs.items():
+            q_low, q_high = self.quantiles[h]
+            if p >= q_high:
+                candidates[h] = ("BUY", (p - q_high) / (1 - q_high))
+            elif p <= q_low:
+                candidates[h] = ("SELL", (q_low - p) / q_low)
+            else:
+                candidates[h] = ("HOLD", 0.0)
+
+        horizon, (decision, weight) = max(candidates.items(), key=lambda kv: abs(kv[1][1]))
+        return {"decision": decision, "weight": weight, "horizon": horizon, "probs": probs}
+
+    # ------------------------------------------------------------------
+    # Serialisation helpers
 
     def to_json(self) -> str:
+        """Serialise model to JSON string."""
+
         data = {
-            "quantile_gates": {str(k): v for k, v in self.quantile_gates.items()},
-            "q_low": self.q_low,
-            "q_high": self.q_high,
+            "prob_tables": self.prob_tables,
+            "quantiles": {str(h): v for h, v in self.quantiles.items()},
+            "metadata": self.metadata,
         }
         return json.dumps(data)
 
+    def save(self, path: str | Path) -> None:
+        """Persist model to *path*."""
+
+        Path(path).write_text(self.to_json())
+
+    @classmethod
+    def from_json(cls, s: str) -> "TimeOnlyModel":
+        """Create model from JSON string."""
+
+        data = json.loads(s)
+        quantiles = {int(k): tuple(v) for k, v in data["quantiles"].items()}
+        prob_tables = {
+            int(h): {k: float(p) for k, p in tbl.items()} for h, tbl in data["prob_tables"].items()
+        }
+        return cls(prob_tables=prob_tables, quantiles=quantiles, metadata=data.get("metadata", {}))
+
     @classmethod
     def load(cls, path: str | Path) -> "TimeOnlyModel":
-        data = json.loads(Path(path).read_text())
-        gates = {int(k): tuple(v) for k, v in data["quantile_gates"].items()}
-        return cls(quantile_gates=gates, q_low=data["q_low"], q_high=data["q_high"])
+        """Load model from *path*."""
+
+        return cls.from_json(Path(path).read_text())
 
 
-def train(df: pd.DataFrame, q_low: float = 0.1, q_high: float = 0.9) -> TimeOnlyModel:
-    """Train quantile gates on the provided dataframe.
+# ---------------------------------------------------------------------------
+# Training
 
-    The dataframe must contain `time` (datetime-like) and `y` columns where `y`
-    is the target variable used for the decision.
+
+def train(
+    df: pd.DataFrame,
+    horizons: Iterable[int] = HORIZONS,
+    q_low: float = 0.2,
+    q_high: float = 0.8,
+    return_metrics: bool = False,
+) -> TimeOnlyModel | Tuple[TimeOnlyModel, Dict[int, Dict[str, float]]]:
+    """Train a :class:`TimeOnlyModel`.
+
+    Parameters
+    ----------
+    df:
+        Input dataframe with columns ``time`` and ``y``.
+    horizons:
+        Iterable of integer horizons in hours.
+    q_low / q_high:
+        Quantile thresholds used to derive trading signals.
+    return_metrics:
+        If ``True`` the function returns ``(model, metrics)`` where ``metrics``
+        contains accuracy and Brier score for each horizon.
     """
 
     df = df.copy()
-    if not is_datetime64_any_dtype(df["time"]):
-        df["time"] = pd.to_datetime(df["time"])
-    df["time"] = df["time"].dt.tz_localize(None)
+    df["time"] = pd.to_datetime(df["time"]).dt.tz_localize(None)
+    df.sort_values("time", inplace=True)
     df["hour"] = df["time"].dt.hour
-    gates: Dict[int, Tuple[float, float]] = {}
-    for hour, series in df.groupby("hour")["y"]:
-        gates[int(hour)] = (float(series.quantile(q_low)), float(series.quantile(q_high)))
-    return TimeOnlyModel(quantile_gates=gates, q_low=q_low, q_high=q_high)
+    df["weekday"] = df["time"].dt.weekday
+    df["key"] = df["hour"].astype(str) + "-" + df["weekday"].astype(str)
+
+    prob_tables: Dict[int, Dict[str, float]] = {}
+    quantiles: Dict[int, Tuple[float, float]] = {}
+    metrics: Dict[int, Dict[str, float]] = {}
+
+    for h in horizons:
+        target = (df["y"].shift(-h) > df["y"]).astype(float)
+        df[f"target_{h}"] = target
+
+        grouped = df.groupby("key")
+        wins = grouped[f"target_{h}"].transform(lambda s: s.fillna(0).cumsum()).shift(h)
+        total = grouped.cumcount().shift(h)
+        prob = wins / total
+        prob[total == 0] = 0.5
+        df[f"prob_{h}"] = prob
+
+        valid = ~target.isna()
+        preds = prob[valid]
+        act = target[valid]
+
+        ql = float(np.nanquantile(preds, q_low)) if len(preds.dropna()) else 0.0
+        qh = float(np.nanquantile(preds, q_high)) if len(preds.dropna()) else 1.0
+        quantiles[h] = (ql, qh)
+
+        if return_metrics:
+            acc = float(((preds > 0.5) == (act > 0.5)).mean())
+            brier = float(np.mean((preds - act) ** 2))
+            metrics[h] = {"accuracy": acc, "brier": brier}
+
+        wins_final = grouped[f"target_{h}"].sum(min_count=1)
+        total_final = grouped[f"target_{h}"].count()
+        prob_tables[h] = {k: float(wins_final[k] / total_final[k]) for k in wins_final.index}
+
+    model = TimeOnlyModel(
+        prob_tables=prob_tables,
+        quantiles=quantiles,
+        metadata={"horizons": list(horizons), "q_low": q_low, "q_high": q_high},
+    )
+    return (model, metrics) if return_metrics else model
+
+
+# ---------------------------------------------------------------------------
+# Utilities
 
 
 def self_test() -> bool:
-    """Run a lightweight self-test.
-
-    The test trains a model on random data, saves artifacts to a temporary
-    location and loads them back verifying the round-trip.
-    """
+    """Run a lightweight self-test for development purposes."""
 
     rng = np.random.default_rng(0)
-    idx = pd.date_range("2024-01-01", periods=48, freq="h")
+    idx = pd.date_range("2024-01-01", periods=100, freq="h")
     df = pd.DataFrame({"time": idx, "y": rng.normal(size=len(idx))})
-    model = train(df)
-    with tempfile.TemporaryDirectory() as tmpdir:
-        path = Path(tmpdir) / "time_only.json"
-        model.save(path)
-        loaded = TimeOnlyModel.load(path)
-    if model.quantile_gates != loaded.quantile_gates:
-        raise ValueError("Quantile gates mismatch after serialization")
-    # exercise decision logic on a single sample
-    loaded.decide(idx[0], df["y"].iloc[0])
+    model, metrics = train(df, return_metrics=True)
+
+    with tempfile.NamedTemporaryFile("w", delete=True) as fh:
+        fh.write(model.to_json())
+        fh.flush()
+        _ = TimeOnlyModel.load(fh.name)
+
+    model.decide(idx[0])
+    _ = metrics
     return True
 
 
-def _run_cli() -> int:
-    """Console entry-point for training or running the self-test."""
-
-    p = argparse.ArgumentParser("time-only")
-    p.add_argument("csv", nargs="?", help="CSV with time,y columns")
-    p.add_argument("--out", help="Where to save artifacts")
-    p.add_argument("--q-low", type=float, default=0.1)
-    p.add_argument("--q-high", type=float, default=0.9)
-    p.add_argument("--self-test", action="store_true", help="run module self-test")
-    args = p.parse_args()
-
-    if args.self_test:
-        ok = self_test()
-        print("self-test: OK" if ok else "self-test: FAILED")
-        return 0 if ok else 1
-
-    if not args.csv or not args.out:
-        p.error("csv and --out are required unless --self-test is used")
-
-    df = pd.read_csv(args.csv, parse_dates=["time"])
-    model = train(df, args.q_low, args.q_high)
-    model.save(args.out)
-    print(f"Saved artifacts -> {args.out}")
-    return 0
-
-
-__all__ = ["TimeOnlyModel", "train", "self_test", "_run_cli"]
+__all__ = ["TimeOnlyModel", "train", "self_test"]

--- a/tests/test_time_only_module.py
+++ b/tests/test_time_only_module.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from forest5.time_only import TimeOnlyModel, train, self_test
+
+
+def test_self_test_runs() -> None:
+    assert self_test()  # nosec B101
+
+
+def test_train_decide_and_serialize(tmp_path: Path) -> None:
+    rng = np.random.default_rng(0)
+    idx = pd.date_range("2024-01-01", periods=200, freq="h")
+    df = pd.DataFrame({"time": idx, "y": rng.normal(size=len(idx))})
+
+    model, metrics = train(df, return_metrics=True)
+    assert metrics and set(model.prob_tables)  # nosec B101
+
+    ts = idx[-1]
+    decision = model.decide(ts)
+    assert set(decision) == {"decision", "weight", "horizon", "probs"}  # nosec B101
+
+    artifact = tmp_path / "time_only.json"
+    model.save(artifact)
+    loaded = TimeOnlyModel.load(artifact)
+    assert loaded.decide(ts)["decision"] in {"BUY", "SELL", "HOLD"}  # nosec B101


### PR DESCRIPTION
## Summary
- replace time-only baseline with self-contained probability model using calendar features only
- support multi-horizon forecasts and quantile-based BUY/SELL/HOLD decisions
- provide training script and lightweight tests

## Testing
- `pre-commit run --files scripts/time_train.py src/forest5/time_only.py tests/test_time_only_module.py`
- `pytest tests/test_time_only_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8a338dc8c832683fb15df6b3e0009