### PR TITLE
Remove manual time blocks in favor of time model

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,20 +104,16 @@ risk:
 
 ## Backtest + TimeOnly
 
-Sekcja `time` pozwala łączyć sygnały strategii z modelem czasu oraz blokować wybrane przedziały:
+Sekcja `time` pozwala łączyć sygnały strategii z modelem czasu:
 
 - `time.model.enabled` – włącza model czasu podczas backtestu (`true`/`false`).
 - `time.model.path` – ścieżka do pliku z zapisanym modelem czasu.
-- `time.blocked_hours` – lista godzin (0–23), w których handel jest zablokowany.
-- `time.blocked_weekdays` – lista dni tygodnia (0=pon … 6=niedz), w których handel jest wyłączony.
 - `decision.min_confluence` – minimalna liczba głosów wymaganych do otwarcia pozycji.
 
 Przykładowa konfiguracja:
 
 ```yaml
 time:
-  blocked_hours: [0,1,2,3]
-  blocked_weekdays: [5,6]
   model:
     enabled: true
     path: "models/model_time.json"

--- a/config/live.example.yaml
+++ b/config/live.example.yaml
@@ -21,12 +21,8 @@ decision:
   min_confluence: 2  # number of indicators that must agree; lower values may create false signals
 
 time:
-  enabled: true
-  blocked_hours: [22,23]
-  blocked_weekdays: [5,6]
   model:
     enabled: false  # true when using a trained time filter model
     path: "${FOREST_TIME_MODEL_PATH}"  # e.g., /models/time_model.pkl
     q_low: 0.1
     q_high: 0.9
-

--- a/scripts/optimize_grid.py
+++ b/scripts/optimize_grid.py
@@ -60,13 +60,6 @@ def parse_range(spec: str) -> list[int]:
     return vals
 
 
-def _parse_int_list(spec: str | None) -> list[int]:
-    """Parse comma-separated integers into a list."""
-    if not spec:
-        return []
-    return [int(x.strip()) for x in spec.split(",") if x.strip()]
-
-
 @dataclass(frozen=True)
 class GridPoint:
     fast: int
@@ -222,18 +215,6 @@ def main() -> None:
 
     parser.add_argument("--time-model", type=Path, default=None, help="Ścieżka do modelu czasu.")
     parser.add_argument("--min-confluence", type=int, default=1, help="Minimalna konfluencja fuzji")
-    parser.add_argument(
-        "--blocked-hours",
-        type=_parse_int_list,
-        default=None,
-        help="Zablokowane godziny (0-23), np. 0,1,2",
-    )
-    parser.add_argument(
-        "--blocked-weekdays",
-        type=_parse_int_list,
-        default=None,
-        help="Zablokowane dni tygodnia 0=Mon..6=Sun",
-    )
 
     parser.add_argument("--start", type=str, default=None, help="Początek zakresu (YYYY-MM-DD).")
     parser.add_argument("--end", type=str, default=None, help="Koniec zakresu (YYYY-MM-DD).")
@@ -274,8 +255,6 @@ def main() -> None:
     base.time.model.enabled = bool(args.time_model)
     base.time.model.path = args.time_model
     base.time.fusion_min_confluence = int(args.min_confluence)
-    base.time.blocked_hours = args.blocked_hours or []
-    base.time.blocked_weekdays = args.blocked_weekdays or []
 
     fast_vals = parse_range(args.fast)
     slow_vals = parse_range(args.slow)

--- a/src/forest5/backtest/engine.py
+++ b/src/forest5/backtest/engine.py
@@ -145,21 +145,8 @@ def _trading_loop(
     if settings.time.model.enabled and settings.time.model.path:
         time_model = TimeOnlyModel.load(settings.time.model.path)
 
-    blocked_hours = set(settings.time.blocked_hours)
-    blocked_weekdays = set(settings.time.blocked_weekdays)
-
     for t, price, atr_val, this_sig in zip(df.index, prices, atr_vals, sig_vals):
         this_sig = int(this_sig)
-
-        if t.weekday() in blocked_weekdays or t.hour in blocked_hours:
-            if debug:
-                debug.log("skip_candle", time=str(t), reason="time_block")
-            equity_mtm = rm.equity + position * price
-            rm.record_mark_to_market(equity_mtm)
-            if rm.exceeded_max_dd():
-                log.warning("max_dd_exceeded", time=str(t), equity=equity_mtm)
-                break
-            continue
 
         fused, fuse_reason = _fuse_with_time(
             this_sig,

--- a/src/forest5/backtest/grid.py
+++ b/src/forest5/backtest/grid.py
@@ -79,14 +79,10 @@ def run_grid(
     rsi_overbought: int = 70,
     time_model: Path | None = None,
     min_confluence: int = 1,
-    blocked_hours: list[int] | None = None,
-    blocked_weekdays: list[int] | None = None,
     n_jobs: int = 1,
     cache_dir: str = ".cache/forest5-grid",
     debug_dir: Path | None = None,
 ) -> pd.DataFrame:
-    blocked_hours = blocked_hours or []
-    blocked_weekdays = blocked_weekdays or []
 
     mem = Memory(cache_dir, verbose=0)
     param_lists = {
@@ -152,8 +148,6 @@ def run_grid(
         settings.time.model.enabled = bool(time_model)
         settings.time.model.path = time_model
         settings.time.fusion_min_confluence = int(min_confluence)
-        settings.time.blocked_hours = list(blocked_hours)
-        settings.time.blocked_weekdays = list(blocked_weekdays)
         res = run_backtest(df, settings)
         end, mdd, cagr = _compute_metrics(res.equity_curve)
         return GridResult(

--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -162,8 +162,6 @@ def cmd_backtest(args: argparse.Namespace) -> int:
     settings.time.model.enabled = bool(args.time_model)
     settings.time.model.path = args.time_model
     settings.time.fusion_min_confluence = int(args.min_confluence)
-    settings.time.blocked_hours = args.blocked_hours or []
-    settings.time.blocked_weekdays = args.blocked_weekdays or []
 
     res = run_backtest(
         df,
@@ -222,8 +220,6 @@ def cmd_grid(args: argparse.Namespace) -> int:
         rsi_overbought=int(args.rsi_overbought),
         time_model=args.time_model,
         min_confluence=int(args.min_confluence),
-        blocked_hours=args.blocked_hours or [],
-        blocked_weekdays=args.blocked_weekdays or [],
         n_jobs=int(args.jobs),
     )
     if args.strategy:
@@ -309,18 +305,6 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_bt.add_argument("--time-model", type=Path, default=None, help="Ścieżka do modelu czasu")
     p_bt.add_argument("--min-confluence", type=int, default=1, help="Minimalna konfluencja fuzji")
-    p_bt.add_argument(
-        "--blocked-hours",
-        type=_parse_int_list,
-        default=None,
-        help="Zablokowane godziny (0-23), np. 0,1,2",
-    )
-    p_bt.add_argument(
-        "--blocked-weekdays",
-        type=_parse_int_list,
-        default=None,
-        help="Zablokowane dni tygodnia 0=Mon..6=Sun",
-    )
 
     p_bt.add_argument("--export-equity", default=None, help="Zapisz equity do CSV")
     p_bt.add_argument("--debug-dir", type=Path, default=None, help="Katalog logów debug")
@@ -369,18 +353,6 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_gr.add_argument("--time-model", type=Path, default=None, help="Ścieżka do modelu czasu")
     p_gr.add_argument("--min-confluence", type=int, default=1, help="Minimalna konfluencja fuzji")
-    p_gr.add_argument(
-        "--blocked-hours",
-        type=_parse_int_list,
-        default=None,
-        help="Zablokowane godziny (0-23), np. 0,1,2",
-    )
-    p_gr.add_argument(
-        "--blocked-weekdays",
-        type=_parse_int_list,
-        default=None,
-        help="Zablokowane dni tygodnia 0=Mon..6=Sun",
-    )
 
     p_gr.add_argument("--jobs", type=int, default=1, help="Równoległość (1 = sekwencyjnie)")
     p_gr.add_argument("--top", type=int, default=20, help="Ile rekordów wyświetlić")

--- a/src/forest5/config.py
+++ b/src/forest5/config.py
@@ -43,8 +43,6 @@ class AISettings(BaseModel):
 
 class TimeOnlySettings(BaseModel):
     enabled: bool = False
-    blocked_weekdays: list[int] = Field(default_factory=list)  # 0=Mon..6=Sun
-    blocked_hours: list[int] = Field(default_factory=list)  # 0..23
 
 
 class BacktestTimeModelSettings(BaseModel):
@@ -63,8 +61,6 @@ class BacktestTimeSettings(BaseModel):
     model: BacktestTimeModelSettings = Field(default_factory=BacktestTimeModelSettings)
     q_low: float = 0.1
     q_high: float = 0.9
-    blocked_hours: list[int] = Field(default_factory=list)
-    blocked_weekdays: list[int] = Field(default_factory=list)
     fusion_min_confluence: int = 1
 
     @field_validator("q_high")
@@ -73,22 +69,6 @@ class BacktestTimeSettings(BaseModel):
         q_low = info.data.get("q_low")
         if not (0.0 <= q_low < v <= 1.0):
             raise BacktestConfigError("0.0 <= q_low < q_high <= 1.0")
-        return v
-
-    @field_validator("blocked_weekdays")
-    @classmethod
-    def _check_weekdays(cls, v: list[int]) -> list[int]:
-        invalid = [d for d in v if d < 0 or d > 6]
-        if invalid:
-            raise BacktestConfigError(f"blocked_weekdays must be in range 0-6: {invalid}")
-        return v
-
-    @field_validator("blocked_hours")
-    @classmethod
-    def _check_hours(cls, v: list[int]) -> list[int]:
-        invalid = [h for h in v if h < 0 or h > 23]
-        if invalid:
-            raise BacktestConfigError(f"blocked_hours must be in range 0-23: {invalid}")
         return v
 
 

--- a/src/forest5/config_live.py
+++ b/src/forest5/config_live.py
@@ -66,25 +66,7 @@ class LiveTimeModelSettings(BaseModel):
 
 
 class LiveTimeSettings(BaseModel):
-    blocked_weekdays: list[int] = Field(default_factory=list)
-    blocked_hours: list[int] = Field(default_factory=list)
     model: LiveTimeModelSettings = Field(default_factory=LiveTimeModelSettings)
-
-    @field_validator("blocked_weekdays")
-    @classmethod
-    def _check_weekdays(cls, v: list[int]) -> list[int]:
-        invalid = [d for d in v if d < 0 or d > 6]
-        if invalid:
-            raise ValueError(f"blocked_weekdays must be in range 0-6: {invalid}")
-        return v
-
-    @field_validator("blocked_hours")
-    @classmethod
-    def _check_hours(cls, v: list[int]) -> list[int]:
-        invalid = [h for h in v if h < 0 or h > 23]
-        if invalid:
-            raise ValueError(f"blocked_hours must be in range 0-23: {invalid}")
-        return v
 
 
 class LiveSettings(BaseModel):

--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -241,67 +241,59 @@ def run_live(
                             log.error("max_drawdown_reached", drawdown_pct=dd * 100)
                             break
 
-                        if (
-                            idx.weekday() in settings.time.blocked_weekdays
-                            or idx.hour in settings.time.blocked_hours
-                        ):
-                            log.info("time_blocked", time=str(idx))
-                            if debug:
-                                debug.log("skip_candle", time=str(idx), reason="time_block")
-                        else:
-                            decision, votes, reason = agent.decide(
-                                idx,
-                                sig,
-                                current_bar["close"],
-                                settings.broker.symbol,
-                                context_text,
-                            )
-                            log.info(
+                        decision, votes, reason = agent.decide(
+                            idx,
+                            sig,
+                            current_bar["close"],
+                            settings.broker.symbol,
+                            context_text,
+                        )
+                        log.info(
+                            "decision",
+                            timestamp=time.time(),
+                            symbol=settings.broker.symbol,
+                            action="decision",
+                            side=decision,
+                            qty=(settings.broker.volume if decision in ("BUY", "SELL") else 0),
+                            price=current_bar["close"],
+                            latency_ms=0.0,
+                            error=None,
+                            context={"votes": votes, "reason": reason},
+                        )
+                        if debug:
+                            debug.log(
                                 "decision",
+                                time=str(idx),
+                                decision=decision,
+                                votes=votes,
+                                reason=reason,
+                            )
+                        if decision in ("BUY", "SELL"):
+                            start_ts = time.time()
+                            res = broker.market_order(decision, settings.broker.volume, price)
+                            latency = (time.time() - start_ts) * 1000.0
+                            log.info(
+                                "order_result",
                                 timestamp=time.time(),
                                 symbol=settings.broker.symbol,
-                                action="decision",
+                                action="market_order",
                                 side=decision,
-                                qty=(settings.broker.volume if decision in ("BUY", "SELL") else 0),
-                                price=current_bar["close"],
-                                latency_ms=0.0,
-                                error=None,
-                                context={"votes": votes, "reason": reason},
+                                qty=res.filled_qty,
+                                price=res.avg_price,
+                                latency_ms=latency,
+                                error=res.error,
+                                context={"status": res.status, "id": res.id},
                             )
                             if debug:
                                 debug.log(
-                                    "decision",
+                                    "order",
                                     time=str(idx),
-                                    decision=decision,
-                                    votes=votes,
-                                    reason=reason,
-                                )
-                            if decision in ("BUY", "SELL"):
-                                start_ts = time.time()
-                                res = broker.market_order(decision, settings.broker.volume, price)
-                                latency = (time.time() - start_ts) * 1000.0
-                                log.info(
-                                    "order_result",
-                                    timestamp=time.time(),
-                                    symbol=settings.broker.symbol,
-                                    action="market_order",
                                     side=decision,
                                     qty=res.filled_qty,
                                     price=res.avg_price,
+                                    status=res.status,
                                     latency_ms=latency,
-                                    error=res.error,
-                                    context={"status": res.status, "id": res.id},
                                 )
-                                if debug:
-                                    debug.log(
-                                        "order",
-                                        time=str(idx),
-                                        side=decision,
-                                        qty=res.filled_qty,
-                                        price=res.avg_price,
-                                        status=res.status,
-                                        latency_ms=latency,
-                                    )
 
                         current_bar = {
                             "start": bar_start,

--- a/tests/test_cli_grid_options.py
+++ b/tests/test_cli_grid_options.py
@@ -62,10 +62,6 @@ def test_cli_grid_additional_options(tmp_path, monkeypatch):
             str(model_path),
             "--min-confluence",
             "2",
-            "--blocked-hours",
-            "1,2",
-            "--blocked-weekdays",
-            "0,6",
             "--jobs",
             "1",
             "--top",
@@ -100,5 +96,3 @@ def test_cli_grid_additional_options(tmp_path, monkeypatch):
     assert kw["atr_multiple"] == 3
     assert kw["time_model"] == model_path
     assert kw["min_confluence"] == 2
-    assert kw["blocked_hours"] == [1, 2]
-    assert kw["blocked_weekdays"] == [0, 6]

--- a/tests/test_cli_time_options.py
+++ b/tests/test_cli_time_options.py
@@ -32,10 +32,6 @@ def test_cli_time_only_options(tmp_path, monkeypatch):
             str(csv_path),
             "--time-model",
             str(model_path),
-            "--blocked-hours",
-            "1,2",
-            "--blocked-weekdays",
-            "0,6",
         ]
     )
 
@@ -56,5 +52,3 @@ def test_cli_time_only_options(tmp_path, monkeypatch):
     settings = captured["settings"]
     assert settings.time.model.enabled is True
     assert settings.time.model.path == model_path
-    assert settings.time.blocked_hours == [1, 2]
-    assert settings.time.blocked_weekdays == [0, 6]

--- a/tests/test_live_runner_ai_params.py
+++ b/tests/test_live_runner_ai_params.py
@@ -38,7 +38,7 @@ def test_run_live_passes_ai_params(tmp_path: Path, monkeypatch):
         broker=BrokerSettings(type="paper", bridge_dir=str(tmp_path), symbol="EURUSD", volume=0.01),
         decision=DecisionSettings(min_confluence=1),
         ai=AISettings(enabled=True, model="custom-model", max_tokens=99, context_file=None),
-        time=TimeSettings(blocked_hours=[], blocked_weekdays=[]),
+        time=TimeSettings(),
         risk=RiskSettings(max_drawdown=0.5),
     )
 

--- a/tests/test_live_runner_paper_smoke.py
+++ b/tests/test_live_runner_paper_smoke.py
@@ -35,7 +35,7 @@ def test_run_live_paper(tmp_path: Path, capfd):
         broker=BrokerSettings(type="paper", bridge_dir=str(bridge), symbol="EURUSD", volume=0.01),
         decision=DecisionSettings(min_confluence=1),
         ai=AISettings(enabled=False, model="gpt-4o-mini", max_tokens=64, context_file=None),
-        time=TimeSettings(blocked_hours=[], blocked_weekdays=[]),
+        time=TimeSettings(),
         risk=RiskSettings(max_drawdown=0.5),
     )
     run_live(s, max_steps=2)
@@ -48,7 +48,7 @@ def test_incremental_signal_perf():
         broker=BrokerSettings(type="paper", bridge_dir=".", symbol="EURUSD", volume=0.01),
         decision=DecisionSettings(min_confluence=1),
         ai=AISettings(enabled=False, model="gpt-4o-mini", max_tokens=64, context_file=None),
-        time=TimeSettings(blocked_hours=[], blocked_weekdays=[]),
+        time=TimeSettings(),
         risk=RiskSettings(max_drawdown=0.5),
     )
     N = 200

--- a/tests/test_live_runner_soft_wait.py
+++ b/tests/test_live_runner_soft_wait.py
@@ -67,7 +67,7 @@ def test_run_live_soft_wait(tmp_path: Path, monkeypatch) -> None:
         broker=BrokerSettings(type="paper", bridge_dir=str(bridge), symbol="EURUSD", volume=1),
         decision=DecisionSettings(min_confluence=1),
         ai=AISettings(enabled=False, model="gpt-4o-mini", max_tokens=64, context_file=None),
-        time=TimeSettings(blocked_hours=[], blocked_weekdays=[]),
+        time=TimeSettings(),
         risk=RiskSettings(
             max_drawdown=0.01,
             on_drawdown=OnDrawdownSettings(action="soft_wait"),


### PR DESCRIPTION
## Summary
- drop blocked_hours/blocked_weekdays from config and CLI
- rely solely on TimeOnlyModel in backtest, grid and live runner
- update docs, examples and tests

## Testing
- `pre-commit run --files README.md config/live.example.yaml scripts/optimize_grid.py src/forest5/backtest/engine.py src/forest5/backtest/grid.py src/forest5/cli.py src/forest5/config.py src/forest5/config_live.py src/forest5/live/live_runner.py`
- `SKIP=bandit pre-commit run --files tests/test_cli_grid_options.py tests/test_cli_time_options.py tests/test_config_live.py tests/test_live_runner_ai_params.py tests/test_live_runner_paper_smoke.py tests/test_live_runner_soft_wait.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8ab15b5d883269ff688e5aed93cb4