### PR TITLE
feat: add weighted decisions

### DIFF
--- a/scripts/optimize_grid.py
+++ b/scripts/optimize_grid.py
@@ -214,7 +214,9 @@ def main() -> None:
     parser.add_argument("--atr-multiple", type=float, default=2.0)
 
     parser.add_argument("--time-model", type=Path, default=None, help="Ścieżka do modelu czasu.")
-    parser.add_argument("--min-confluence", type=int, default=1, help="Minimalna konfluencja fuzji")
+    parser.add_argument(
+        "--min-confluence", type=float, default=1.0, help="Minimalna konfluencja fuzji"
+    )
 
     parser.add_argument("--start", type=str, default=None, help="Początek zakresu (YYYY-MM-DD).")
     parser.add_argument("--end", type=str, default=None, help="Koniec zakresu (YYYY-MM-DD).")
@@ -254,7 +256,7 @@ def main() -> None:
 
     base.time.model.enabled = bool(args.time_model)
     base.time.model.path = args.time_model
-    base.time.fusion_min_confluence = int(args.min_confluence)
+    base.time.fusion_min_confluence = float(args.min_confluence)
 
     fast_vals = parse_range(args.fast)
     slow_vals = parse_range(args.slow)

--- a/scripts/time_train.py
+++ b/scripts/time_train.py
@@ -28,8 +28,10 @@ def main() -> None:
 
     model = train(df, q_low=args.q_low, q_high=args.q_high)
     Path(args.output).write_text(model.to_json())
-    # ensure model can be loaded back
-    TimeOnlyModel.load(args.output)
+    # ensure model can be loaded back and exposes the decision API
+    loaded = TimeOnlyModel.load(args.output)
+    # exercise the API (decision + weight) on a single sample
+    _ = loaded.decide(df["time"].iloc[0], float(df["y"].iloc[0]))
     print(f"Saved model to {args.output}")
 
 

--- a/src/forest5/backtest/grid.py
+++ b/src/forest5/backtest/grid.py
@@ -78,7 +78,7 @@ def run_grid(
     rsi_oversold: int = 30,
     rsi_overbought: int = 70,
     time_model: Path | None = None,
-    min_confluence: int = 1,
+    min_confluence: float = 1.0,
     n_jobs: int = 1,
     cache_dir: str = ".cache/forest5-grid",
     debug_dir: Path | None = None,
@@ -147,7 +147,7 @@ def run_grid(
         )
         settings.time.model.enabled = bool(time_model)
         settings.time.model.path = time_model
-        settings.time.fusion_min_confluence = int(min_confluence)
+        settings.time.fusion_min_confluence = float(min_confluence)
         res = run_backtest(df, settings)
         end, mdd, cagr = _compute_metrics(res.equity_curve)
         return GridResult(

--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -161,7 +161,7 @@ def cmd_backtest(args: argparse.Namespace) -> int:
 
     settings.time.model.enabled = bool(args.time_model)
     settings.time.model.path = args.time_model
-    settings.time.fusion_min_confluence = int(args.min_confluence)
+    settings.time.fusion_min_confluence = float(args.min_confluence)
 
     res = run_backtest(
         df,
@@ -219,7 +219,7 @@ def cmd_grid(args: argparse.Namespace) -> int:
         rsi_oversold=int(args.rsi_oversold),
         rsi_overbought=int(args.rsi_overbought),
         time_model=args.time_model,
-        min_confluence=int(args.min_confluence),
+        min_confluence=float(args.min_confluence),
         n_jobs=int(args.jobs),
     )
     if args.strategy:
@@ -304,7 +304,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_bt.add_argument("--atr-multiple", type=float, default=2.0)
 
     p_bt.add_argument("--time-model", type=Path, default=None, help="Ścieżka do modelu czasu")
-    p_bt.add_argument("--min-confluence", type=int, default=1, help="Minimalna konfluencja fuzji")
+    p_bt.add_argument(
+        "--min-confluence", type=float, default=1.0, help="Minimalna konfluencja fuzji"
+    )
 
     p_bt.add_argument("--export-equity", default=None, help="Zapisz equity do CSV")
     p_bt.add_argument("--debug-dir", type=Path, default=None, help="Katalog logów debug")
@@ -352,7 +354,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_gr.add_argument("--rsi-overbought", type=int, default=70, choices=range(0, 101))
 
     p_gr.add_argument("--time-model", type=Path, default=None, help="Ścieżka do modelu czasu")
-    p_gr.add_argument("--min-confluence", type=int, default=1, help="Minimalna konfluencja fuzji")
+    p_gr.add_argument(
+        "--min-confluence", type=float, default=1.0, help="Minimalna konfluencja fuzji"
+    )
 
     p_gr.add_argument("--jobs", type=int, default=1, help="Równoległość (1 = sekwencyjnie)")
     p_gr.add_argument("--top", type=int, default=20, help="Ile rekordów wyświetlić")

--- a/src/forest5/config.py
+++ b/src/forest5/config.py
@@ -61,7 +61,7 @@ class BacktestTimeSettings(BaseModel):
     model: BacktestTimeModelSettings = Field(default_factory=BacktestTimeModelSettings)
     q_low: float = 0.1
     q_high: float = 0.9
-    fusion_min_confluence: int = 1
+    fusion_min_confluence: float = 1.0
 
     @field_validator("q_high")
     @classmethod

--- a/src/forest5/config_live.py
+++ b/src/forest5/config_live.py
@@ -42,7 +42,7 @@ class BrokerSettings(BaseModel):
 
 
 class DecisionSettings(BaseModel):
-    min_confluence: int = 1
+    min_confluence: float = 1.0
 
 
 class LiveTimeModelSettings(BaseModel):

--- a/tests/test_cli_grid_options.py
+++ b/tests/test_cli_grid_options.py
@@ -95,4 +95,4 @@ def test_cli_grid_additional_options(tmp_path, monkeypatch):
     assert kw["atr_period"] == 5
     assert kw["atr_multiple"] == 3
     assert kw["time_model"] == model_path
-    assert kw["min_confluence"] == 2
+    assert kw["min_confluence"] == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- add weight-aware decision fusion and propagate confidence to backtest and live trading
- allow fractional confluence thresholds and surface weights in CLI and scripts
- test weight handling across backtest, grid search and live runner

## Testing
- `pre-commit run --files scripts/optimize_grid.py scripts/time_train.py src/forest5/backtest/engine.py src/forest5/backtest/grid.py src/forest5/cli.py src/forest5/config.py src/forest5/config_live.py src/forest5/decision.py src/forest5/live/live_runner.py tests/test_backtest_timeonly_ab.py tests/test_cli_grid_options.py tests/test_live_timeonly_paper_smoke.py tests/test_timeonly_decision_agent.py`
- `pre-commit run --files tests/test_backtest_timeonly_ab.py tests/test_live_timeonly_paper_smoke.py tests/test_timeonly_decision_agent.py`
- `pre-commit run --files tests/test_live_timeonly_paper_smoke.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8ae2261a08326a0f77194e8b1d0fd