### PR TITLE
Refactor time model decision handling

### DIFF
--- a/tests/test_timeonly_decision_agent.py
+++ b/tests/test_timeonly_decision_agent.py
@@ -10,8 +10,8 @@ class FakeTimeModel:
         self.decision = decision
         self.weight = weight
 
-    def decide(self, ts, value):  # pragma: no cover - simple fake
-        return self.decision, self.weight
+    def decide(self, ts):  # pragma: no cover - simple fake
+        return {"decision": self.decision, "weight": self.weight}
 
 
 @pytest.mark.timeonly
@@ -22,6 +22,7 @@ class FakeTimeModel:
         ("BUY", 1, "BUY"),
         ("SELL", -1, "SELL"),
         ("BUY", -1, "SELL"),  # tech signal stronger
+        ("HOLD", 1, "BUY"),
     ],
 )
 def test_timeonly_decision_agent(time_sig: str, tech_sig: int, expected: str) -> None:
@@ -30,5 +31,7 @@ def test_timeonly_decision_agent(time_sig: str, tech_sig: int, expected: str) ->
     agent = DecisionAgent(config=DecisionConfig(min_confluence=1.0, time_model=fake))
     res = agent.decide(ts, tech_signal=tech_sig, value=100.0, symbol="EURUSD")
     assert res.decision == expected
-    exp_weight = 0.0 if expected == "WAIT" else (0.5 if time_sig == expected else 1.0)
+    exp_weight = 0.0 if expected == "WAIT" else (
+        0.5 if time_sig == expected and time_sig != "HOLD" else 1.0
+    )
     assert res.weight == pytest.approx(exp_weight)


### PR DESCRIPTION
## Summary
- call time model's decide with timestamp and interpret dict result
- handle HOLD as a neutral vote
- adjust decision agent tests for dict-based time model output

## Testing
- `pytest tests/test_decision_agent.py tests/test_timeonly_decision_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8b46946288326a991af0a37739f00