### PR TITLE
Support new TimeOnlyModel JSON format

### DIFF
--- a/scripts/optimize_grid.py
+++ b/scripts/optimize_grid.py
@@ -14,6 +14,7 @@ import pandas as pd
 
 from forest5.config import BacktestSettings, RiskSettings, StrategySettings
 from forest5.backtest.engine import run_backtest
+from forest5.time_only import TimeOnlyModel
 from forest5.utils.validate import ensure_backtest_ready
 from forest5.utils.argparse_ext import PercentAction
 
@@ -228,6 +229,10 @@ def main() -> None:
     parser.add_argument("--export", type=str, default=None, help="Zapisz wyniki do CSV.")
 
     args = parser.parse_args()
+
+    # Validate time model early
+    if args.time_model:
+        TimeOnlyModel.load(args.time_model)
 
     # Logging
     logging.basicConfig(

--- a/tests/test_cli_grid_timeonly_smoke.py
+++ b/tests/test_cli_grid_timeonly_smoke.py
@@ -1,4 +1,3 @@
-import json
 import os
 import subprocess  # nosec B404
 import sys
@@ -6,6 +5,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from forest5.time_only import TimeOnlyModel
 
 
 script = Path(__file__).resolve().parents[1] / "scripts" / "optimize_grid.py"
@@ -30,8 +30,8 @@ def test_cli_grid_timeonly_smoke(tmp_path):
     df.to_csv(csv_path, index=False)
 
     model_path = tmp_path / "model_time.json"
-    model = {"quantile_gates": {"0": [0.0, 2.0]}, "q_low": 0.25, "q_high": 0.75}
-    model_path.write_text(json.dumps(model))
+    model = TimeOnlyModel(prob_tables={0: (0.0, 2.0)}, quantiles=(0.25, 0.75))
+    model_path.write_text(model.to_json())
 
     env = os.environ.copy()
     env["PYTHONPATH"] = os.pathsep.join(


### PR DESCRIPTION
## Summary
- switch TimeOnlyModel to `prob_tables` and `quantiles` fields with backward-compatible aliases
- validate `--time-model` artifacts in `optimize_grid.py` by loading them via `TimeOnlyModel`
- build grid smoke-test model JSON using `TimeOnlyModel.to_json`

## Testing
- `pytest tests/test_time_only_boundaries.py tests/test_time_only_integration.py tests/test_backtest_timeonly_ab.py tests/test_timeonly_sanity.py tests/test_time_only.py tests/test_decision_agent.py tests/test_grid_indicators.py tests/test_cli_grid_timeonly_smoke.py` (14 passed)
- `pytest tests/test_cli_grid_timeonly_smoke.py` (1 passed)


------
https://chatgpt.com/codex/tasks/task_e_68a8c4d2637c8326b573b77f429feca3