### PR TITLE
Clamp TimeOnlyModel denominators for extreme quantiles

### DIFF
--- a/tests/test_time_only_boundaries.py
+++ b/tests/test_time_only_boundaries.py
@@ -6,5 +6,7 @@ from forest5.time_only import TimeOnlyModel
 def test_boundaries_sell_buy() -> None:
     model = TimeOnlyModel(quantile_gates={0: (1.0, 2.0)}, q_low=0.1, q_high=0.9)
     ts = datetime(2024, 1, 1, 0, 0)
-    assert model.decide(ts, 1.0) == "SELL"
-    assert model.decide(ts, 2.0) == "BUY"
+    dec, _ = model.decide(ts, 1.0)
+    assert dec == "SELL"
+    dec, _ = model.decide(ts, 2.0)
+    assert dec == "BUY"

--- a/tests/test_time_only_extreme_quantiles.py
+++ b/tests/test_time_only_extreme_quantiles.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+import math
+import pytest
+
+from forest5.time_only import TimeOnlyModel
+
+
+@pytest.mark.parametrize(
+    ("q_low", "q_high", "value", "decision"),
+    [
+        (0.0, 0.9, 0.5, "SELL"),
+        (0.1, 1.0, 3.0, "BUY"),
+    ],
+)
+def test_extreme_quantiles_produce_finite_weights(q_low, q_high, value, decision) -> None:
+    model = TimeOnlyModel(quantile_gates={0: (1.0, 2.0)}, q_low=q_low, q_high=q_high)
+    ts = datetime(2024, 1, 1, 0, 0)
+    dec, w = model.decide(ts, value)
+    assert dec == decision
+    assert math.isfinite(w)

--- a/tests/test_time_only_integration.py
+++ b/tests/test_time_only_integration.py
@@ -19,13 +19,17 @@ def test_train_decide_and_serialize(tmp_path: Path) -> None:
     model = train(df, q_low=0.25, q_high=0.75)
 
     ts = df["time"].iloc[0]
-    assert model.decide(ts, 0.0) == "SELL"
-    assert model.decide(ts, 2.0) == "WAIT"
-    assert model.decide(ts, 3.0) == "BUY"
+    dec, _ = model.decide(ts, 0.0)
+    assert dec == "SELL"
+    dec, _ = model.decide(ts, 2.0)
+    assert dec == "WAIT"
+    dec, _ = model.decide(ts, 3.0)
+    assert dec == "BUY"
 
     artifact = tmp_path / "time_only.json"
     model.save(artifact)
     loaded = TimeOnlyModel.load(artifact)
 
     assert loaded.quantile_gates == model.quantile_gates
-    assert loaded.decide(ts, 3.0) == "BUY"
+    dec, _ = loaded.decide(ts, 3.0)
+    assert dec == "BUY"

--- a/tests/test_timeonly_sanity.py
+++ b/tests/test_timeonly_sanity.py
@@ -23,6 +23,9 @@ def test_timeonly_save_load_and_decide_roundtrip(tmp_path) -> None:
     loaded = time_only.TimeOnlyModel.load(path)
 
     ts = datetime(2024, 1, 1, 0)
-    assert loaded.decide(ts, 0.5) == "SELL"
-    assert loaded.decide(ts, 2.5) == "BUY"
-    assert loaded.decide(ts, 1.5) == "WAIT"
+    dec, _ = loaded.decide(ts, 0.5)
+    assert dec == "SELL"
+    dec, _ = loaded.decide(ts, 2.5)
+    assert dec == "BUY"
+    dec, _ = loaded.decide(ts, 1.5)
+    assert dec == "WAIT"


### PR DESCRIPTION
## Summary
- clamp decision weight denominators to avoid division by zero at quantile extremes
- test that q_low=0.0 or q_high=1.0 yield finite decision weights

## Testing
- `pre-commit run --files src/forest5/time_only.py tests/test_timeonly_sanity.py tests/test_time_only_integration.py tests/test_time_only_boundaries.py tests/test_time_only_extreme_quantiles.py`
- `pytest tests/test_time_only.py tests/test_timeonly_sanity.py tests/test_time_only_integration.py tests/test_time_only_boundaries.py tests/test_time_only_extreme_quantiles.py tests/test_decision_agent.py tests/test_decision_fusion_min_confluence.py tests/test_decision_fusion_tie.py tests/test_timeonly_decision_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8c87c87088326a34dbfd67ed4b2b2