### PR TITLE
Add default symbol CSV loader and auto-fetch paths

### DIFF
--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -13,7 +13,7 @@ from forest5.config import BacktestSettings, load_live_settings
 from forest5.backtest.engine import run_backtest
 from forest5.backtest.grid import run_grid
 from forest5.live.live_runner import run_live
-from forest5.utils.io import read_ohlc_csv
+from forest5.utils.io import read_ohlc_csv, load_symbol_csv
 from forest5.utils.argparse_ext import PercentAction
 from forest5.utils.log import setup_logger
 
@@ -134,7 +134,10 @@ def _parse_float_list(spec: str | None) -> list[float]:
 
 
 def cmd_backtest(args: argparse.Namespace) -> int:
-    df = load_ohlc_csv(args.csv, time_col=args.time_col, sep=args.sep)
+    if args.csv:
+        df = load_ohlc_csv(args.csv, time_col=args.time_col, sep=args.sep)
+    else:
+        df = load_symbol_csv(args.symbol)
 
     settings = BacktestSettings(
         symbol=args.symbol or "SYMBOL",
@@ -192,7 +195,10 @@ def cmd_backtest(args: argparse.Namespace) -> int:
 
 
 def cmd_grid(args: argparse.Namespace) -> int:
-    df = load_ohlc_csv(args.csv, time_col=args.time_col, sep=args.sep)
+    if args.csv:
+        df = load_ohlc_csv(args.csv, time_col=args.time_col, sep=args.sep)
+    else:
+        df = load_symbol_csv(args.symbol)
 
     fast_vals = list(_parse_span_or_list(args.fast_values))
     slow_vals = list(_parse_span_or_list(args.slow_values))

--- a/src/forest5/utils/io.py
+++ b/src/forest5/utils/io.py
@@ -108,3 +108,35 @@ def read_ohlc_csv(
     df = df[cols].apply(pd.to_numeric, errors="coerce").dropna()
 
     return df.sort_index()
+
+
+# Default directory for historical CSV data used by helper functions.
+DATA_DIR = Path("/home/daro/Fxdata")
+
+
+def load_symbol_csv(symbol: str, data_dir: Path = DATA_DIR) -> pd.DataFrame:
+    """Load OHLC data for ``symbol`` from ``data_dir``.
+
+    Parameters
+    ----------
+    symbol:
+        Trading symbol, e.g. ``"EURUSD"``.
+    data_dir:
+        Directory containing ``<symbol>_H1.csv`` files. Defaults to
+        :data:`DATA_DIR`.
+
+    Returns
+    -------
+    pd.DataFrame
+        Data loaded via :func:`read_ohlc_csv`.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the expected CSV file does not exist.
+    """
+
+    path = data_dir / f"{symbol}_H1.csv"
+    if not path.exists():
+        raise FileNotFoundError(f"CSV for symbol '{symbol}' not found: {path}")
+    return read_ohlc_csv(path)


### PR DESCRIPTION
## Summary
- add `load_symbol_csv` with configurable data directory
- use `load_symbol_csv` when no `--csv` path is provided in backtest and grid commands

## Testing
- `pre-commit run --files src/forest5/utils/io.py src/forest5/cli.py` *(failed: CalledProcessError: command: ('/root/.cache/pre-commit/repogh12edp4/py_env-python3.12/bin/python', '-mpip', 'install', '.') return code: -15)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8d6c59eec832694676fc3d35af913