### PR TITLE
Require explicit symbol for backtests and grids

### DIFF
--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -140,7 +140,7 @@ def cmd_backtest(args: argparse.Namespace) -> int:
         df = load_symbol_csv(args.symbol)
 
     settings = BacktestSettings(
-        symbol=args.symbol or "SYMBOL",
+        symbol=args.symbol,
         strategy={
             "name": "ema_cross",
             "fast": args.fast,
@@ -169,7 +169,7 @@ def cmd_backtest(args: argparse.Namespace) -> int:
     res = run_backtest(
         df,
         settings,
-        symbol=args.symbol or "SYMBOL",
+        symbol=args.symbol,
         price_col="close",
         atr_period=args.atr_period,
         atr_multiple=args.atr_multiple,
@@ -210,7 +210,7 @@ def cmd_grid(args: argparse.Namespace) -> int:
         sys.exit(1)
 
     kwargs = dict(
-        symbol=args.symbol or "SYMB",
+        symbol=args.symbol,
         fast_values=fast_vals,
         slow_values=slow_vals,
         capital=float(args.capital),
@@ -284,14 +284,21 @@ def build_parser() -> argparse.ArgumentParser:
     p_bt = sub.add_parser(
         "backtest", help="Uruchom pojedynczy backtest", formatter_class=SafeHelpFormatter
     )
-    p_bt.add_argument("--csv", required=True, help="Ścieżka do pliku CSV z danymi OHLC")
+    p_bt.add_argument(
+        "--csv",
+        required=False,
+        help=(
+            "Ścieżka do pliku CSV z danymi OHLC (przysłania automatyczne "
+            "wyszukanie w /home/daro/Fxdata/{SYMBOL}_H1.csv)"
+        ),
+    )
     p_bt.add_argument("--time-col", default=None, help="Nazwa kolumny czasu (opcjonalnie)")
     p_bt.add_argument(
         "--sep",
         default=None,
         help="Separator CSV (np. ';'). Brak = autodetekcja",
     )
-    p_bt.add_argument("--symbol", default="SYMBOL", help="Symbol (np. EURUSD)")
+    p_bt.add_argument("--symbol", required=True, help="Symbol (np. EURUSD)")
     p_bt.add_argument("--fast", type=int, default=12, help="Szybka EMA")
     p_bt.add_argument("--slow", type=int, default=26, help="Wolna EMA")
 
@@ -322,14 +329,21 @@ def build_parser() -> argparse.ArgumentParser:
     p_gr = sub.add_parser(
         "grid", help="Przeszukiwanie parametrów", formatter_class=SafeHelpFormatter
     )
-    p_gr.add_argument("--csv", required=True, help="Ścieżka do pliku CSV z danymi OHLC")
+    p_gr.add_argument(
+        "--csv",
+        required=False,
+        help=(
+            "Ścieżka do pliku CSV z danymi OHLC (przysłania automatyczne "
+            "wyszukanie w /home/daro/Fxdata/{SYMBOL}_H1.csv)"
+        ),
+    )
     p_gr.add_argument("--time-col", default=None, help="Nazwa kolumny czasu (opcjonalnie)")
     p_gr.add_argument(
         "--sep",
         default=None,
         help="Separator CSV (np. ';'). Brak = autodetekcja",
     )
-    p_gr.add_argument("--symbol", default="SYMB", help="Symbol (np. EURUSD)")
+    p_gr.add_argument("--symbol", required=True, help="Symbol (np. EURUSD)")
     p_gr.add_argument("--fast-values", required=True, help="Np. 5:20:1 lub 5,8,13")
     p_gr.add_argument("--slow-values", required=True, help="Np. 10:60:2 lub 12,26")
     p_gr.add_argument("--strategy", default=None, help="Nazwa strategii")

--- a/src/forest5/utils/io.py
+++ b/src/forest5/utils/io.py
@@ -138,5 +138,8 @@ def load_symbol_csv(symbol: str, data_dir: Path = DATA_DIR) -> pd.DataFrame:
 
     path = data_dir / f"{symbol}_H1.csv"
     if not path.exists():
-        raise FileNotFoundError(f"CSV for symbol '{symbol}' not found: {path}")
+        raise FileNotFoundError(
+            f"CSV for symbol '{symbol}' not found at {path}. "
+            "Pass --csv to override the default lookup."
+        )
     return read_ohlc_csv(path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,8 @@ def test_cli_backtest(tmp_path, monkeypatch):
     rc = main(
         [
             "backtest",
+            "--symbol",
+            "EURUSD",
             "--csv",
             str(csv_path),
             "--fast",
@@ -45,6 +47,8 @@ def test_cli_grid(tmp_path, monkeypatch):
     rc = main(
         [
             "grid",
+            "--symbol",
+            "EURUSD",
             "--csv",
             str(csv_path),
             "--fast-values",
@@ -62,7 +66,7 @@ def test_cli_grid(tmp_path, monkeypatch):
 
 def test_cli_missing_file():
     with pytest.raises(FileNotFoundError):
-        main(["backtest", "--csv", "no_such_file.csv"])
+        main(["backtest", "--symbol", "EURUSD", "--csv", "no_such_file.csv"])
 
 
 def test_cli_missing_time_column(tmp_path):
@@ -72,33 +76,49 @@ def test_cli_missing_time_column(tmp_path):
         encoding="utf-8",
     )
     with pytest.raises(ValueError, match="Failed to parse"):
-        main(["backtest", "--csv", str(bad_csv), "--time-col", "time"])
+        main(["backtest", "--symbol", "EURUSD", "--csv", str(bad_csv), "--time-col", "time"])
 
 
 def test_cli_missing_ohlc_columns(tmp_path):
     bad_csv = tmp_path / "bad_ohlc.csv"
     bad_csv.write_text("time,open,high,low\n2020-01-01,1,1,1\n", encoding="utf-8")
     with pytest.raises(ValueError, match="CSV missing required columns"):
-        main(["backtest", "--csv", str(bad_csv)])
+        main(["backtest", "--symbol", "EURUSD", "--csv", str(bad_csv)])
 
 
 def test_percentage_out_of_range_error(capfd):
     parser = build_parser()
     with pytest.raises(SystemExit):
-        parser.parse_args(["backtest", "--csv", "dummy.csv", "--risk", "2"])
+        parser.parse_args(["backtest", "--symbol", "EURUSD", "--csv", "dummy.csv", "--risk", "2"])
     err = capfd.readouterr().err
     assert "between 0.0 and 1.0" in err
 
 
 def test_percentage_with_percent_sign():
     parser = build_parser()
-    args = parser.parse_args(["backtest", "--csv", "dummy.csv", "--risk", "1%"])
+    args = parser.parse_args([
+        "backtest",
+        "--symbol",
+        "EURUSD",
+        "--csv",
+        "dummy.csv",
+        "--risk",
+        "1%",
+    ])
     assert args.risk == pytest.approx(0.01)
 
 
 def test_percentage_with_comma_and_percent():
     parser = build_parser()
-    args = parser.parse_args(["backtest", "--csv", "dummy.csv", "--risk", "0,5%"])
+    args = parser.parse_args([
+        "backtest",
+        "--symbol",
+        "EURUSD",
+        "--csv",
+        "dummy.csv",
+        "--risk",
+        "0,5%",
+    ])
     assert args.risk == pytest.approx(0.005)
 
 

--- a/tests/test_cli_grid_options.py
+++ b/tests/test_cli_grid_options.py
@@ -29,6 +29,8 @@ def test_cli_grid_additional_options(tmp_path, monkeypatch):
     args = parser.parse_args(
         [
             "grid",
+            "--symbol",
+            "EURUSD",
             "--csv",
             str(csv_path),
             "--fast-values",

--- a/tests/test_cli_time_options.py
+++ b/tests/test_cli_time_options.py
@@ -28,6 +28,8 @@ def test_cli_time_only_options(tmp_path, monkeypatch):
     args = parser.parse_args(
         [
             "backtest",
+            "--symbol",
+            "EURUSD",
             "--csv",
             str(csv_path),
             "--time-model",


### PR DESCRIPTION
## Summary
- Make `--symbol` mandatory and `--csv` optional for backtest and grid CLI commands
- Describe automatic CSV lookup in `/home/daro/Fxdata/{SYMBOL}_H1.csv`
- Clarify missing file error to note default lookup and override

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8e2e884888326b4a0e07cff5c761b