### PR TITLE
feat: add h1 ema rsi atr strategy settings

### DIFF
--- a/src/forest5/config/strategy.py
+++ b/src/forest5/config/strategy.py
@@ -1,14 +1,31 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+
+class H1EmaRsiAtrParams(BaseModel):
+    """Parameter container for the ``h1_ema_rsi_atr`` strategy."""
+
+    ema_fast: int = 21
+    ema_slow: int = 55
+    atr_period: int = 14
+    rsi_period: int = 14
+
+
+class H1EmaRsiAtrSettings(BaseModel):
+    """Settings for the ``h1_ema_rsi_atr`` strategy."""
+
+    name: Literal["h1_ema_rsi_atr"] = "h1_ema_rsi_atr"
+    compat_int: int | None = None
+    params: H1EmaRsiAtrParams = Field(default_factory=H1EmaRsiAtrParams)
 
 
 class BaseStrategySettings(BaseModel):
     """Common strategy configuration shared between backtest and live settings."""
 
-    name: Literal["ema_cross", "macd_cross"] = "ema_cross"
+    name: Literal["ema_cross", "macd_cross", "h1_ema_rsi_atr"] = "ema_cross"
     fast: int = 12
     slow: int = 26
     signal: int = 9
@@ -16,6 +33,8 @@ class BaseStrategySettings(BaseModel):
     rsi_period: int = 14
     rsi_overbought: int = 70
     rsi_oversold: int = 30
+    compat_int: int | None = None
+    params: dict[str, Any] | None = None
 
 
-__all__ = ["BaseStrategySettings"]
+__all__ = ["BaseStrategySettings", "H1EmaRsiAtrSettings"]

--- a/tests/test_config_live.py
+++ b/tests/test_config_live.py
@@ -74,3 +74,17 @@ def test_live_time_model_quantile_valid():
 def test_live_time_model_quantile_invalid(q_low: float, q_high: float):
     with pytest.raises(ValidationError, match="0.0 <= q_low < q_high <= 1.0"):
         LiveTimeModelSettings(q_low=q_low, q_high=q_high)
+
+
+def test_live_settings_h1_ema_rsi_atr(tmp_path: Path):
+    p = tmp_path / "cfg_live.yaml"
+    p.write_text(
+        "broker:\n  type: mt4\n" "strategy:\n  name: h1_ema_rsi_atr\n  compat_int: 42\n  params:\n    ema_fast: 21\n    ema_slow: 55\n",
+        encoding="utf-8",
+    )
+
+    s = load_live_settings(p)
+
+    assert s.strategy.name == "h1_ema_rsi_atr"  # nosec B101
+    assert s.strategy.compat_int == 42  # nosec B101
+    assert s.strategy.params["ema_fast"] == 21  # nosec B101

--- a/tests/test_config_live.py
+++ b/tests/test_config_live.py
@@ -79,7 +79,8 @@ def test_live_time_model_quantile_invalid(q_low: float, q_high: float):
 def test_live_settings_h1_ema_rsi_atr(tmp_path: Path):
     p = tmp_path / "cfg_live.yaml"
     p.write_text(
-        "broker:\n  type: mt4\n" "strategy:\n  name: h1_ema_rsi_atr\n  compat_int: 42\n  params:\n    ema_fast: 21\n    ema_slow: 55\n",
+        "broker:\n  type: mt4\n"
+        "strategy:\n  name: h1_ema_rsi_atr\n  compat_int: 42\n  params:\n    ema_fast: 21\n    ema_slow: 55\n",
         encoding="utf-8",
     )
 

--- a/tests/test_strategy_h1_ema_rsi_atr.py
+++ b/tests/test_strategy_h1_ema_rsi_atr.py
@@ -1,0 +1,8 @@
+from forest5.config.strategy import H1EmaRsiAtrSettings
+
+
+def test_h1_ema_rsi_atr_settings_defaults():
+    s = H1EmaRsiAtrSettings()
+    assert s.name == "h1_ema_rsi_atr"  # nosec B101
+    assert s.params.ema_fast == 21  # nosec B101
+    assert s.params.ema_slow == 55  # nosec B101


### PR DESCRIPTION
## Summary
- add dedicated `H1EmaRsiAtrSettings` model with nested params
- expand base strategy settings with optional `compat_int` and `params`
- test loading of `h1_ema_rsi_atr` strategy in live settings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa572ff22883268b3f8e4dc1fdedf5