### PR TITLE
Add candlestick pattern detectors with registry and tests

### DIFF
--- a/src/forest5/signals/patterns/__init__.py
+++ b/src/forest5/signals/patterns/__init__.py
@@ -1,0 +1,6 @@
+"""Candlestick pattern detectors."""
+
+from . import engulfing, pinbar, stars
+from .registry import best_pattern
+
+__all__ = ["engulfing", "pinbar", "stars", "best_pattern"]

--- a/src/forest5/signals/patterns/engulfing.py
+++ b/src/forest5/signals/patterns/engulfing.py
@@ -1,0 +1,60 @@
+"""Engulfing pattern detector."""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def detect(df: pd.DataFrame, atr: float) -> dict | None:
+    """Detect bullish or bearish engulfing pattern.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame slice containing the last two candles with columns
+        ``open``, ``high``, ``low`` and ``close``.
+    atr : float
+        Average true range used for scoring.
+
+    Returns
+    -------
+    dict | None
+        A dictionary with ``type``, ``hi``, ``lo`` and ``score`` keys
+        when the pattern is found otherwise ``None``.
+    """
+    if len(df) < 2:
+        return None
+
+    a = df.iloc[-2]
+    b = df.iloc[-1]
+
+    # Bullish engulfing
+    if (
+        a.close < a.open
+        and b.close > b.open
+        and b.open < a.close
+        and b.close > a.open
+    ):
+        score = (abs(b.close - b.open) + abs(a.close - a.open)) / atr
+        return {
+            "type": "bullish_engulfing",
+            "hi": float(b.high),
+            "lo": float(b.low),
+            "score": float(score),
+        }
+
+    # Bearish engulfing
+    if (
+        a.close > a.open
+        and b.close < b.open
+        and b.open > a.close
+        and b.close < a.open
+    ):
+        score = (abs(b.close - b.open) + abs(a.close - a.open)) / atr
+        return {
+            "type": "bearish_engulfing",
+            "hi": float(b.high),
+            "lo": float(b.low),
+            "score": float(score),
+        }
+
+    return None

--- a/src/forest5/signals/patterns/pinbar.py
+++ b/src/forest5/signals/patterns/pinbar.py
@@ -1,0 +1,35 @@
+"""Pinbar pattern detector."""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def detect(df: pd.DataFrame, atr: float) -> dict | None:
+    """Detect bullish or bearish pinbar pattern."""
+    if len(df) < 1:
+        return None
+
+    c = df.iloc[-1]
+    body = abs(c.close - c.open)
+    upper = c.high - max(c.open, c.close)
+    lower = min(c.open, c.close) - c.low
+
+    if upper <= body and lower >= 2 * body:
+        score = lower / atr
+        return {
+            "type": "bullish_pinbar",
+            "hi": float(c.high),
+            "lo": float(c.low),
+            "score": float(score),
+        }
+
+    if lower <= body and upper >= 2 * body:
+        score = upper / atr
+        return {
+            "type": "bearish_pinbar",
+            "hi": float(c.high),
+            "lo": float(c.low),
+            "score": float(score),
+        }
+
+    return None

--- a/src/forest5/signals/patterns/registry.py
+++ b/src/forest5/signals/patterns/registry.py
@@ -1,0 +1,28 @@
+"""Registry and utilities for candlestick patterns."""
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+from . import engulfing, pinbar, stars
+
+Detector = Callable[["DataFrame", float], Optional[dict]]
+
+PATTERN_DETECTORS: Dict[str, Detector] = {
+    "engulfing": engulfing.detect,
+    "pinbar": pinbar.detect,
+    "stars": stars.detect,
+}
+
+
+def best_pattern(df, atr: float, config: Optional[Dict[str, bool]] = None) -> Optional[dict]:
+    """Return the highest score pattern based on configuration."""
+    best = None
+    for name, detector in PATTERN_DETECTORS.items():
+        if config is not None and not config.get(name, False):
+            continue
+        result = detector(df, atr)
+        if not result:
+            continue
+        if best is None or result["score"] > best["score"]:
+            best = result
+    return best

--- a/src/forest5/signals/patterns/stars.py
+++ b/src/forest5/signals/patterns/stars.py
@@ -1,0 +1,50 @@
+"""Morning/Evening star detector."""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def detect(df: pd.DataFrame, atr: float) -> dict | None:
+    """Detect morning star (bullish) or evening star (bearish) pattern."""
+    if len(df) < 3:
+        return None
+
+    a = df.iloc[-3]
+    b = df.iloc[-2]
+    c = df.iloc[-1]
+
+    body_a = abs(a.close - a.open)
+    body_b = abs(b.close - b.open)
+    body_c = abs(c.close - c.open)
+
+    # Morning star
+    if (
+        a.close < a.open
+        and body_a > body_b
+        and c.close > c.open
+        and c.close >= (a.open + a.close) / 2
+    ):
+        score = (body_a + body_c) / atr
+        return {
+            "type": "morning_star",
+            "hi": float(max(a.high, b.high, c.high)),
+            "lo": float(min(a.low, b.low, c.low)),
+            "score": float(score),
+        }
+
+    # Evening star
+    if (
+        a.close > a.open
+        and body_a > body_b
+        and c.close < c.open
+        and c.close <= (a.open + a.close) / 2
+    ):
+        score = (body_a + body_c) / atr
+        return {
+            "type": "evening_star",
+            "hi": float(max(a.high, b.high, c.high)),
+            "lo": float(min(a.low, b.low, c.low)),
+            "score": float(score),
+        }
+
+    return None

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,0 +1,79 @@
+import pandas as pd
+
+from forest5.signals.patterns import engulfing, pinbar, stars, registry
+
+
+def test_engulfing_detects_positive():
+    df = pd.DataFrame(
+        [
+            {"open": 10, "high": 10.5, "low": 9.5, "close": 9.6},
+            {"open": 9.4, "high": 10.7, "low": 9.3, "close": 10.8},
+        ]
+    )
+    res = engulfing.detect(df, atr=1.0)
+    assert res and res["type"] == "bullish_engulfing"
+
+
+def test_engulfing_negative():
+    df = pd.DataFrame(
+        [
+            {"open": 10, "high": 10.5, "low": 9.5, "close": 9.6},
+            {"open": 9.8, "high": 10.1, "low": 9.3, "close": 9.9},
+        ]
+    )
+    assert engulfing.detect(df, atr=1.0) is None
+
+
+def test_pinbar_detects_positive():
+    df = pd.DataFrame(
+        [{"open": 11, "high": 11.2, "low": 9, "close": 11.1}]
+    )
+    res = pinbar.detect(df, atr=1.0)
+    assert res and res["type"] == "bullish_pinbar"
+
+
+def test_pinbar_negative():
+    df = pd.DataFrame(
+        [{"open": 10, "high": 10.5, "low": 9.8, "close": 10.2}]
+    )
+    assert pinbar.detect(df, atr=1.0) is None
+
+
+def test_stars_detects_positive():
+    df = pd.DataFrame(
+        [
+            {"open": 10, "high": 10.2, "low": 9, "close": 9.2},
+            {"open": 9.1, "high": 9.3, "low": 9.0, "close": 9.15},
+            {"open": 9.2, "high": 10.5, "low": 9.1, "close": 10.4},
+        ]
+    )
+    res = stars.detect(df, atr=1.0)
+    assert res and res["type"] == "morning_star"
+
+
+def test_stars_negative():
+    df = pd.DataFrame(
+        [
+            {"open": 9, "high": 9.5, "low": 8.5, "close": 9.4},
+            {"open": 9.6, "high": 10, "low": 9.4, "close": 9.9},
+            {"open": 10, "high": 10.5, "low": 9.8, "close": 10.2},
+        ]
+    )
+    assert stars.detect(df, atr=1.0) is None
+
+
+def test_registry_best_pattern(monkeypatch):
+    def fake_a(df, atr):
+        return {"type": "a", "hi": 1, "lo": 0, "score": 1}
+
+    def fake_b(df, atr):
+        return {"type": "b", "hi": 1, "lo": 0, "score": 2}
+
+    monkeypatch.setitem(registry.PATTERN_DETECTORS, "engulfing", fake_a)
+    monkeypatch.setitem(registry.PATTERN_DETECTORS, "pinbar", fake_b)
+
+    res = registry.best_pattern(pd.DataFrame(), 1.0, {"engulfing": True, "pinbar": True})
+    assert res["type"] == "b"
+
+    res = registry.best_pattern(pd.DataFrame(), 1.0, {"engulfing": True, "pinbar": False})
+    assert res["type"] == "a"


### PR DESCRIPTION
## Summary
- add candlestick pattern detectors for engulfing, pinbar, and star formations
- register pattern detectors and expose best score selection
- test positive and negative detections plus registry selection

## Testing
- `pytest tests/test_patterns.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa5b5399dc8326bd18ca79f7fd3e68