### PR TITLE
Extend trade book entries with richer metadata

### DIFF
--- a/src/forest5/backtest/engine.py
+++ b/src/forest5/backtest/engine.py
@@ -78,7 +78,7 @@ def bootstrap_position(
             qty0 = rm.position_size(price=p0, atr=a0, atr_multiple=atr_multiple)
             if qty0 > 0.0:
                 rm.buy(p0, qty0)
-                tb.add(df.index[0], p0, qty0, "BUY")
+                tb.add(df.index[0], p0, qty0, "BUY", entry=p0)
                 position += qty0
     return position
 
@@ -417,8 +417,9 @@ def _trading_loop(
             debug.log("signal_rejected", time=str(t), reason="no_confluence")
 
         if this_sig < 0 and position > 0.0:
+            entry_price = getattr(rm, "_avg_price", 0.0)
             rm.sell(price, position)
-            tb.add(t, price, position, "SELL")
+            tb.add(t, entry_price, position, "SELL", price_close=float(price), entry=entry_price)
             if debug:
                 debug.log("position_close", time=str(t), price=float(price), qty=float(position))
             position = 0.0
@@ -428,7 +429,7 @@ def _trading_loop(
             qty *= float(weight)
             if qty > 0.0:
                 rm.buy(price, qty)
-                tb.add(t, price, qty, "BUY")
+                tb.add(t, price, qty, "BUY", entry=float(price))
                 if debug:
                     debug.log(
                         "position_open",

--- a/src/forest5/backtest/tradebook.py
+++ b/src/forest5/backtest/tradebook.py
@@ -1,23 +1,86 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, List
+from typing import Any, List, Optional
 
 
 @dataclass
 class Trade:
     time: Any
-    price: float
+    price_open: float
+    price_close: float
     qty: float
     side: str  # "BUY" | "SELL"
+    pnl: float
+    entry: Optional[float] = None
+    sl: Optional[float] = None
+    tp: Optional[float] = None
+    reason_close: Optional[str] = None
+    setup_id: Optional[str] = None
+    pattern: Optional[str] = None
 
 
 class TradeBook:
+    columns = [
+        "time",
+        "price_open",
+        "price_close",
+        "qty",
+        "side",
+        "pnl",
+        "entry",
+        "sl",
+        "tp",
+        "reason_close",
+        "setup_id",
+        "pattern",
+    ]
+
     def __init__(self) -> None:
         self.trades: List[Trade] = []
 
-    def add(self, time, price: float, qty: float, side: str):
-        self.trades.append(Trade(time=time, price=float(price), qty=float(qty), side=side))
+    def add(
+        self,
+        time,
+        price_open: float,
+        qty: float,
+        side: str,
+        price_close: float | None = None,
+        entry: float | None = None,
+        sl: float | None = None,
+        tp: float | None = None,
+        reason_close: str | None = None,
+        setup_id: str | None = None,
+        pattern: str | None = None,
+    ) -> None:
+        price_open = float(price_open)
+        price_close = float(price_close if price_close is not None else price_open)
+        qty = float(qty)
+        side_u = side.upper()
+        pnl = (price_close - price_open) * qty if side_u == "BUY" else (price_open - price_close) * qty
+        self.trades.append(
+            Trade(
+                time=time,
+                price_open=price_open,
+                price_close=price_close,
+                qty=qty,
+                side=side_u,
+                pnl=pnl,
+                entry=entry,
+                sl=sl,
+                tp=tp,
+                reason_close=reason_close,
+                setup_id=setup_id,
+                pattern=pattern,
+            )
+        )
 
     def __len__(self) -> int:
         return len(self.trades)
+
+    def to_frame(self):  # pragma: no cover - simple export helper
+        try:
+            import pandas as pd
+        except Exception:  # pragma: no cover - defensive
+            raise RuntimeError("pandas required for exporting trades")
+        return pd.DataFrame([t.__dict__ for t in self.trades], columns=self.columns)

--- a/tests/test_no_overbuy_fx.py
+++ b/tests/test_no_overbuy_fx.py
@@ -25,4 +25,4 @@ def test_no_overbuy_fx():
     for tr in res.trades.trades:
         d = _asdict_trade(tr)
         if d.get("side") == "BUY":
-            assert d["price"] * d["qty"] <= cap + 1e-6, "BUY przekracza dostępny kapitał!"
+            assert d["price_open"] * d["qty"] <= cap + 1e-6, "BUY przekracza dostępny kapitał!"

--- a/tests/test_trading_loop_benchmark.py
+++ b/tests/test_trading_loop_benchmark.py
@@ -21,15 +21,16 @@ def _old_trading_loop(df, sig, rm, tb, position, price_col, atr_multiple):
         this_sig = int(sig.loc[t]) if t in sig.index else 0
 
         if this_sig < 0 and position > 0.0:
+            entry_price = getattr(rm, "_avg_price", 0.0)
             rm.sell(price, position)
-            tb.add(t, price, position, "SELL")
+            tb.add(t, entry_price, position, "SELL", price_close=price, entry=entry_price)
             position = 0.0
 
         if this_sig > 0 and position <= 0.0:
             qty = rm.position_size(price=price, atr=float(row["atr"]), atr_multiple=atr_multiple)
             if qty > 0.0:
                 rm.buy(price, qty)
-                tb.add(t, price, qty, "BUY")
+                tb.add(t, price, qty, "BUY", entry=price)
                 position = qty
 
         equity_mtm = rm.equity + position * price


### PR DESCRIPTION
## Summary
- enrich Trade dataclass with entry price, SL/TP, close reason, setup and pattern info
- compute trade PnL from open/close fill prices and expose new columns for export
- adapt engine and tests to use expanded TradeBook API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aaca1be8008326a0c544456275555a