### PR TITLE
test: extend engine and setup coverage

### DIFF
--- a/tests/test_bootstrap_position.py
+++ b/tests/test_bootstrap_position.py
@@ -43,3 +43,5 @@ def test_bootstrap_opens_initial_long():
 
     assert pos > 0.0
     assert len(tb.trades) == 1
+    d = tb.trades[0].__dict__
+    assert {"entry", "sl", "tp", "reason_close", "setup_id", "pattern"}.issubset(d)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,9 @@ def test_config_from_yaml(tmp_path: Path):
         "  slow: 30\n"
         "risk:\n"
         "  initial_capital: 50000.0\n"
-        "  risk_per_trade: 0.02\n",
+        "  risk_per_trade: 0.02\n"
+        "tp_sl_priority: TP_FIRST\n"
+        "setup_ttl_bars: 2\n",
         encoding="utf-8",
     )
     s = BacktestSettings.from_file(p)
@@ -24,3 +26,5 @@ def test_config_from_yaml(tmp_path: Path):
     assert isinstance(s.strategy, BaseStrategySettings)
     assert s.risk.initial_capital == 50_000.0
     assert s.risk.on_drawdown.action == "halt"  # nosec B101
+    assert s.tp_sl_priority == "TP_FIRST"
+    assert s.setup_ttl_bars == 2

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,8 +1,9 @@
 import pandas as pd
 from unittest.mock import patch
 
-from forest5.backtest.engine import run_backtest
+from forest5.backtest.engine import BacktestEngine, run_backtest
 from forest5.config import BacktestSettings
+from forest5.signals.setups import SetupCandidate
 
 
 def _capture_atr(storage):
@@ -40,3 +41,40 @@ def test_atr_period_override_changes_atr():
     override_atr = storage[1]
 
     assert not override_atr.equals(default_atr)
+
+
+def test_gap_fill_trailing_and_priority():
+    idx = pd.RangeIndex(3)
+    df = pd.DataFrame(
+        {
+            "open": [100, 104, 103],
+            "high": [100, 104, 103],
+            "low": [100, 103.6, 100],
+            "close": [100, 104, 102],
+            "atr": [1.0, 1.0, 1.0],
+        },
+        index=idx,
+    )
+    settings = BacktestSettings(tp_sl_priority="TP_FIRST")
+    eng = BacktestEngine(df, settings)
+    cand = SetupCandidate(
+        id="s1",
+        action="BUY",
+        entry=100.0,
+        sl=95.0,
+        tp=110.0,
+        meta={"trailing_atr": 0.5},
+    )
+    eng.setups.arm("s1", 0, cand)
+
+    eng.on_bar_open(1)
+    assert eng.positions and eng.positions[0]["entry"] == 104.0
+
+    eng.on_bar_close(1)
+    assert eng.positions[0]["sl"] > 95.0
+
+    eng.on_bar_open(2)
+    eng.on_bar_close(2)
+    assert not eng.positions
+    assert eng.equity < 0.0
+    assert eng.tp_sl_policy.priority == "TP_FIRST"

--- a/tests/test_engine_mtm_once_per_bar.py
+++ b/tests/test_engine_mtm_once_per_bar.py
@@ -23,4 +23,4 @@ def test_engine_marks_once_per_bar():
     )
     res = run_backtest(df, s)
     # 1 punkt startowy + 1 punkt na bar => len == len(df) + 1
-    assert len(res.equity_curve) in (len(df), len(df) + 1)
+    assert len(res.equity_curve) == len(df) + 1

--- a/tests/test_no_overbuy_fx.py
+++ b/tests/test_no_overbuy_fx.py
@@ -24,5 +24,6 @@ def test_no_overbuy_fx():
     cap = s.risk.initial_capital
     for tr in res.trades.trades:
         d = _asdict_trade(tr)
+        assert {"entry", "sl", "tp", "reason_close", "setup_id", "pattern"}.issubset(d)
         if d.get("side") == "BUY":
             assert d["price_open"] * d["qty"] <= cap + 1e-6, "BUY przekracza dostępny kapitał!"

--- a/tests/test_setup_registry.py
+++ b/tests/test_setup_registry.py
@@ -21,3 +21,19 @@ def test_setup_registry_expires_without_trigger():
     assert reg.check("tf", 1, high=5.5, low=5.1) is None
     # Subsequent checks remain empty
     assert reg.check("tf", 2, high=4.0, low=3.0) is None
+
+
+def test_setup_registry_gap_fill_triggers():
+    reg = SetupRegistry(ttl_bars=1)
+    sig = TechnicalSignal(action="BUY", entry=10.0)
+    reg.arm("tf", 0, sig)
+    res = reg.check("tf", 1, high=11.0, low=11.0)
+    assert res is sig
+
+
+def test_setup_registry_blocked_by_time_removes():
+    reg = SetupRegistry(ttl_bars=1)
+    sig = TechnicalSignal(action="BUY", entry=10.0)
+    reg.arm("tf", 0, sig)
+    _ = reg.check("tf", 1, high=11.0, low=9.0)
+    assert reg.check("tf", 1, high=11.0, low=9.0) is None

--- a/tests/test_signals_factory.py
+++ b/tests/test_signals_factory.py
@@ -136,3 +136,17 @@ def test_compute_signal_compat_accepts_mapping(monkeypatch):
     series = compute_signal_compat(df, s)
     assert list(series.index) == list(df.index)  # nosec B101
     assert series.iloc[-1] == 1  # nosec B101
+
+
+def test_compute_signal_passes_contract(monkeypatch):
+    df = generate_ohlc(periods=10, start_price=100.0)
+    s = BacktestSettings()
+    s.strategy.name = "h1_ema_rsi_atr"
+    fake = TechnicalSignal(action="BUY", entry=1.0, sl=0.5, tp=1.5)
+
+    def _fake(df, params):
+        return fake
+
+    monkeypatch.setattr("forest5.signals.factory.compute_primary_signal_h1", _fake)
+    res = compute_signal(df, s)
+    assert res is fake


### PR DESCRIPTION
## Summary
- cover gap-fill, trailing stop and TP/SL priority in BacktestEngine
- verify trade log fields and new config keys
- ensure signals.factory passes through TechnicalSignal contracts

## Testing
- `pytest tests/test_engine.py tests/test_engine_mtm_once_per_bar.py tests/test_setup_registry.py tests/test_bootstrap_position.py tests/test_no_overbuy_fx.py tests/test_config.py tests/test_signals_factory.py`

------
https://chatgpt.com/codex/tasks/task_e_68aad2976524832699f8e0c637b067cd