### PR TITLE
feat: propagate optional sl and tp

### DIFF
--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -319,6 +319,8 @@ def run_live(
                                 decision,
                                 settings.broker.volume * weight,
                                 price,
+                                sl=getattr(triggered, "sl", None),
+                                tp=getattr(triggered, "tp", None),
                             )
                             latency = (time.time() - start_ts) * 1000.0
                             log.info(

--- a/src/forest5/live/mt4_broker.py
+++ b/src/forest5/live/mt4_broker.py
@@ -129,7 +129,15 @@ class MT4Broker(OrderRouter):
         return OrderResult(0, "rejected", 0.0, 0.0, "timeout")
 
     # ------------------------------------------------------------------
-    def market_order(self, side: str, qty: float, price: Optional[float] = None) -> OrderResult:
+    def market_order(
+        self,
+        side: str,
+        qty: float,
+        price: Optional[float] = None,
+        *,
+        sl: Optional[float] = None,
+        tp: Optional[float] = None,
+    ) -> OrderResult:
         if not self._connected:
             res = OrderResult(0, "rejected", 0.0, 0.0, "not connected")
             log.info(
@@ -153,11 +161,10 @@ class MT4Broker(OrderRouter):
             "action": side.upper(),
             "symbol": self.symbol,
             "volume": qty,
-            "sl": None,
-            "tp": None,
+            "price": price,
+            "sl": sl,
+            "tp": tp,
         }
-        if price is not None:
-            cmd["price"] = price
 
         cmd_path = self._command_path(uid)
         tmp_path = self.commands_dir / f"cmd_{uid}.json.tmp"

--- a/src/forest5/live/router.py
+++ b/src/forest5/live/router.py
@@ -8,7 +8,15 @@ class OrderRouter(Protocol):
     def connect(self) -> None: ...
     def close(self) -> None: ...
     def set_price(self, price: float) -> None: ...
-    def market_order(self, side: str, qty: float, price: Optional[float] = None) -> OrderResult: ...
+    def market_order(
+        self,
+        side: str,
+        qty: float,
+        price: Optional[float] = None,
+        *,
+        sl: Optional[float] = None,
+        tp: Optional[float] = None,
+    ) -> OrderResult: ...
     def position_qty(self) -> float: ...
     def equity(self) -> float: ...
 
@@ -63,7 +71,15 @@ class PaperBroker:
     def _fee(self, notional: float) -> float:
         return abs(notional) * self._fee_perc
 
-    def market_order(self, side: str, qty: float, price: Optional[float] = None) -> OrderResult:
+    def market_order(
+        self,
+        side: str,
+        qty: float,
+        price: Optional[float] = None,
+        *,
+        sl: Optional[float] = None,
+        tp: Optional[float] = None,
+    ) -> OrderResult:
         self._id += 1
 
         if not self._connected:

--- a/tests/test_mt4_broker_sl_tp.py
+++ b/tests/test_mt4_broker_sl_tp.py
@@ -3,6 +3,7 @@ import json
 
 from forest5.live.mt4_broker import MT4Broker
 
+
 def test_command_contains_sl_tp(tmp_path: Path):
     bridge = tmp_path / "bridge"
     br = MT4Broker(bridge_dir=bridge, symbol="EURUSD", timeout_sec=0.2)
@@ -13,4 +14,3 @@ def test_command_contains_sl_tp(tmp_path: Path):
     data = json.loads(cmds[0].read_text(encoding="utf-8"))
     assert data["sl"] == 1.2300
     assert data["tp"] == 1.2400
-

--- a/tests/test_mt4_broker_sl_tp.py
+++ b/tests/test_mt4_broker_sl_tp.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import json
+
+from forest5.live.mt4_broker import MT4Broker
+
+def test_command_contains_sl_tp(tmp_path: Path):
+    bridge = tmp_path / "bridge"
+    br = MT4Broker(bridge_dir=bridge, symbol="EURUSD", timeout_sec=0.2)
+    br.connect()
+    br.market_order("BUY", 0.1, price=1.2345, sl=1.2300, tp=1.2400)
+    cmds = list((bridge / "commands").glob("cmd_*.json"))
+    assert cmds, "no command file written"
+    data = json.loads(cmds[0].read_text(encoding="utf-8"))
+    assert data["sl"] == 1.2300
+    assert data["tp"] == 1.2400
+


### PR DESCRIPTION
## Summary
- extend broker API with optional stop loss and take profit parameters
- forward sl/tp to MT4 command JSON and from live runner
- add test verifying command includes sl/tp

## Testing
- `pytest -q tests/test_router.py tests/test_mt4_broker.py tests/test_mt4_broker_file_bridge.py tests/test_live_runner_paper_smoke.py tests/test_mt4_broker_sl_tp.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68aaf3a885788326b04b68d5b3792261