### PR TITLE
feat: add generic span or list parser

### DIFF
--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 import random
+from functools import partial
 from pathlib import Path
 from typing import Optional
 
@@ -22,7 +23,7 @@ from forest5.backtest.engine import run_backtest
 from forest5.backtest.grid import run_grid
 from forest5.live.live_runner import run_live
 from forest5.utils.io import read_ohlc_csv, load_symbol_csv
-from forest5.utils.argparse_ext import PercentAction
+from forest5.utils.argparse_ext import PercentAction, span_or_list
 from forest5.utils.log import setup_logger
 
 
@@ -83,95 +84,24 @@ def load_ohlc_csv(
     return df
 
 
-# ------------------------------- CLI commands --------------------------------
-
-
-def _parse_span_or_list(spec: str) -> list[int]:
-    """Parse a numeric span (``lo-hi[:step]`` or ``lo:hi:step``) or
-    comma-separated list.
-
-    Examples::
-        "5-7"        -> [5, 6, 7]
-        "1-5:2"      -> [1, 3, 5]
-        "8:16:1"     -> [8, 9, 10, 11, 12, 13, 14, 15, 16]
-        "1,2,10"     -> [1, 2, 10]
-
-    The range is inclusive and supports negative numbers, e.g. ``-3--1``.
-    Raises :class:`argparse.ArgumentTypeError` when the specification is
-    malformed, ``lo > hi`` or ``step <= 0``.
-    """
-
-    spec = str(spec).strip()
-
-    # Comma separated list of values
-    if "," in spec:
-        try:
-            return [int(float(x.strip())) for x in spec.split(",") if x.strip()]
-        except ValueError as ex:
-            raise argparse.ArgumentTypeError(f"Invalid list: {spec}") from ex
-    # ``lo:hi:step`` form
-    m = re.fullmatch(
-        r"\s*([+-]?\d+(?:\.\d+)?)\s*:\s*([+-]?\d+(?:\.\d+)?)\s*:\s*([+-]?\d+(?:\.\d+)?)\s*",
-        spec,
-    )
-    if m:
-        lo = int(float(m.group(1)))
-        hi = int(float(m.group(2)))
-        step = int(float(m.group(3)))
-        if step <= 0:
-            raise argparse.ArgumentTypeError(f"Step must be > 0 (given: {step})")
-        if hi < lo:
-            raise argparse.ArgumentTypeError(f"Upper bound < lower: {spec}")
-        vals: list[int] = list(range(lo, hi + 1, step))
-        if vals[-1] != hi:
-            vals.append(hi)
-        return vals
-
-    # Extract optional step for ``lo-hi[:step]``
-    core, step_str = (spec.split(":", 1) + ["1"])[:2]
-    try:
-        step = int(float(step_str))
-    except ValueError as ex:
-        raise argparse.ArgumentTypeError(f"Invalid step: {step_str}") from ex
-    if step <= 0:
-        raise argparse.ArgumentTypeError(f"Step must be > 0 (given: {step})")
-
-    m = re.fullmatch(r"\s*([+-]?\d+(?:\.\d+)?)\s*-\s*([+-]?\d+(?:\.\d+)?)\s*", core)
-    if m:
-        lo = int(float(m.group(1)))
-        hi = int(float(m.group(2)))
-        if hi < lo:
-            raise argparse.ArgumentTypeError(f"Upper bound < lower: {spec}")
-        vals = list(range(lo, hi + 1, step))
-        if vals[-1] != hi:
-            vals.append(hi)
-        return vals
-
-    # Single value without span
-    try:
-        return [int(float(spec))]
-    except ValueError as ex:
-        raise argparse.ArgumentTypeError(
-            f"Invalid range: {spec}. Expected formats: lo-hi[:step] or lo:hi:step"
-        ) from ex
-
+_parse_span_or_list = partial(span_or_list, type_fn=int)
 
 # Backwards compatibility – old name used in previous versions/tests
 _parse_range = _parse_span_or_list
 
 
 def _parse_int_list(spec: str | None) -> list[int]:
-    """Parse comma-separated integers into a list of ints."""
+    """Parse comma-separated integers or ranges into a list of ints."""
     if not spec:
         return []
-    return [int(x.strip()) for x in spec.split(",") if x.strip()]
+    return span_or_list(spec, type_fn=int)
 
 
 def _parse_float_list(spec: str | None) -> list[float]:
-    """Parse comma-separated floats into a list of floats."""
+    """Parse comma-separated floats or ranges into a list of floats."""
     if not spec:
         return []
-    return [float(x.strip()) for x in str(spec).split(",") if x.strip()]
+    return span_or_list(spec, type_fn=float)
 
 
 def cmd_backtest(args: argparse.Namespace) -> int:

--- a/src/forest5/utils/argparse_ext.py
+++ b/src/forest5/utils/argparse_ext.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 import argparse
+import re
+from typing import Callable, List, TypeVar
+
+
+T = TypeVar("T", int, float)
 
 
 class PercentAction(argparse.Action):
@@ -26,3 +31,96 @@ class PercentAction(argparse.Action):
         if not (self.min_value <= val <= self.max_value):
             parser.error(f"{option_string} must be between {self.min_value} and {self.max_value}")
         setattr(namespace, self.dest, val)
+
+
+def span_or_list(spec: str, type_fn: Callable[[float], T] = float) -> List[T]:
+    """Parse comma separated list or inclusive numeric range specification.
+
+    Parameters
+    ----------
+    spec:
+        String containing either comma separated values or a range in one of
+        the following forms::
+
+            a,b,c
+            a:b:step
+            a-b[:step]
+
+    type_fn:
+        Function used to cast parsed numeric values. Defaults to ``float`` but
+        can be set to ``int``.
+
+    Returns
+    -------
+    list[``T``]
+        Parsed numeric values converted with ``type_fn``.
+
+    Raises
+    ------
+    argparse.ArgumentTypeError
+        If the specification is malformed, the range is descending or step is
+        not positive.
+    """
+
+    spec = str(spec).strip()
+
+    # Comma separated list
+    if "," in spec:
+        try:
+            return [type_fn(x.strip()) for x in spec.split(",") if x.strip()]
+        except ValueError as ex:
+            raise argparse.ArgumentTypeError(f"Invalid list: {spec}") from ex
+
+    # a:b:step form
+    m = re.fullmatch(
+        r"\s*([+-]?\d+(?:\.\d+)?)\s*:\s*([+-]?\d+(?:\.\d+)?)\s*:\s*([+-]?\d+(?:\.\d+)?)\s*",
+        spec,
+    )
+    if m:
+        lo = float(m.group(1))
+        hi = float(m.group(2))
+        step = float(m.group(3))
+        if step <= 0:
+            raise argparse.ArgumentTypeError(f"Step must be > 0 (given: {step})")
+        if hi < lo:
+            raise argparse.ArgumentTypeError(f"Upper bound < lower: {spec}")
+        vals: List[T] = []
+        v = lo
+        while v <= hi:
+            vals.append(type_fn(v))
+            v += step
+        if vals and vals[-1] != type_fn(hi):
+            vals.append(type_fn(hi))
+        return vals
+
+    # Extract optional step for a-b[:step]
+    core, step_str = (spec.split(":", 1) + ["1"])[:2]
+    try:
+        step = float(step_str)
+    except ValueError as ex:
+        raise argparse.ArgumentTypeError(f"Invalid step: {step_str}") from ex
+    if step <= 0:
+        raise argparse.ArgumentTypeError(f"Step must be > 0 (given: {step})")
+
+    m = re.fullmatch(r"\s*([+-]?\d+(?:\.\d+)?)\s*-\s*([+-]?\d+(?:\.\d+)?)\s*", core)
+    if m:
+        lo = float(m.group(1))
+        hi = float(m.group(2))
+        if hi < lo:
+            raise argparse.ArgumentTypeError(f"Upper bound < lower: {spec}")
+        vals: List[T] = []
+        v = lo
+        while v <= hi:
+            vals.append(type_fn(v))
+            v += step
+        if vals and vals[-1] != type_fn(hi):
+            vals.append(type_fn(hi))
+        return vals
+
+    # Single value
+    try:
+        return [type_fn(spec)]
+    except ValueError as ex:
+        raise argparse.ArgumentTypeError(
+            f"Invalid range: {spec}. Expected formats: lo-hi[:step] or lo:hi:step"
+        ) from ex

--- a/tests/test_parse_span_or_list.py
+++ b/tests/test_parse_span_or_list.py
@@ -1,30 +1,35 @@
 import argparse
 import pytest
 
-from forest5.cli import _parse_span_or_list
+from forest5.utils.argparse_ext import span_or_list
 
 
-def test_parse_span_positive_range():
-    assert _parse_span_or_list("1-3") == [1, 2, 3]
+def test_parse_span_positive_range_int():
+    assert span_or_list("1-3", type_fn=int) == [1, 2, 3]
 
 
-def test_parse_span_negative_range():
-    assert _parse_span_or_list("-3--1") == [-3, -2, -1]
+def test_parse_span_negative_range_int():
+    assert span_or_list("-3--1", type_fn=int) == [-3, -2, -1]
 
 
-def test_parse_span_list():
-    assert _parse_span_or_list("1,4,7") == [1, 4, 7]
+def test_parse_span_list_int():
+    assert span_or_list("1,4,7", type_fn=int) == [1, 4, 7]
 
 
-def test_parse_span_colon_syntax():
-    assert _parse_span_or_list("8:16:1") == [8, 9, 10, 11, 12, 13, 14, 15, 16]
+def test_parse_span_colon_syntax_int():
+    assert span_or_list("8:16:1", type_fn=int) == [8, 9, 10, 11, 12, 13, 14, 15, 16]
+
+
+def test_parse_span_default_float():
+    assert span_or_list("1.0-1.5:0.25") == [1.0, 1.25, 1.5]
 
 
 def test_parse_span_step_error():
     with pytest.raises(argparse.ArgumentTypeError, match="Step"):
-        _parse_span_or_list("1-5:0")
+        span_or_list("1-5:0", type_fn=int)
 
 
 def test_parse_span_hi_less_than_lo():
     with pytest.raises(argparse.ArgumentTypeError, match="Upper bound < lower"):
-        _parse_span_or_list("5-3")
+        span_or_list("5-3", type_fn=int)
+


### PR DESCRIPTION
## Summary
- add `span_or_list` utility for parsing comma lists or numeric ranges
- reuse `span_or_list` in CLI for int and float parsing
- test coverage for `span_or_list`

## Testing
- `pytest tests/test_parse_span_or_list.py tests/test_cli.py tests/test_grid.py tests/test_cli_grid_options.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab1a0338b883269c778ab961d4c50c