### PR TITLE
feat: add span or list parser

### DIFF
--- a/src/forest5/utils/argparse_ext.py
+++ b/src/forest5/utils/argparse_ext.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 
 
 class PercentAction(argparse.Action):
@@ -26,3 +27,94 @@ class PercentAction(argparse.Action):
         if not (self.min_value <= val <= self.max_value):
             parser.error(f"{option_string} must be between {self.min_value} and {self.max_value}")
         setattr(namespace, self.dest, val)
+
+
+def span_or_list(spec: str, type_fn=float) -> list:
+    """Parse a numeric span or comma separated list.
+
+    Parameters
+    ----------
+    spec:
+        String specification in one of the forms ``lo-hi[:step]`` or
+        ``lo:hi:step`` or a comma separated list.
+    type_fn:
+        Callable used to convert parsed numbers. Typically :class:`int` or
+        :class:`float`.
+
+    Returns
+    -------
+    list
+        List of numbers converted by ``type_fn``.
+
+    Raises
+    ------
+    argparse.ArgumentTypeError
+        If the specification is malformed or violates bounds/step rules.
+    """
+
+    spec = str(spec).strip()
+
+    def _cast(value: str):
+        return int(float(value)) if type_fn is int else float(value)
+
+    def _range(lo: float, hi: float, step: float) -> list:
+        if type_fn is int:
+            lo_i, hi_i, step_i = int(lo), int(hi), int(step)
+            vals = list(range(lo_i, hi_i + 1, step_i))
+            if vals[-1] != hi_i:
+                vals.append(hi_i)
+            return vals
+
+        vals: list[float] = []
+        cur = lo
+        eps = step / 10_000_000.0
+        while cur <= hi + eps:
+            vals.append(cur)
+            cur += step
+        if abs(vals[-1] - hi) > eps:
+            vals.append(hi)
+        return [float(v) for v in vals]
+
+    # Comma separated list
+    if "," in spec:
+        try:
+            return [type_fn(_cast(x.strip())) for x in spec.split(",") if x.strip()]
+        except ValueError as ex:
+            raise argparse.ArgumentTypeError(f"Invalid list: {spec}") from ex
+
+    # ``lo:hi:step`` form
+    m = re.fullmatch(
+        r"\s*([+-]?\d+(?:\.\d+)?)\s*:\s*([+-]?\d+(?:\.\d+)?)\s*:\s*([+-]?\d+(?:\.\d+)?)\s*",
+        spec,
+    )
+    if m:
+        lo, hi, step = map(_cast, m.groups())
+        if step <= 0:
+            raise argparse.ArgumentTypeError(f"Step must be > 0 (given: {step})")
+        if hi < lo:
+            raise argparse.ArgumentTypeError(f"Upper bound < lower: {spec}")
+        return [type_fn(v) for v in _range(lo, hi, step)]
+
+    # ``lo-hi[:step]`` form
+    core, step_str = (spec.split(":", 1) + ["1"])[:2]
+    try:
+        step = _cast(step_str)
+    except ValueError as ex:
+        raise argparse.ArgumentTypeError(f"Invalid step: {step_str}") from ex
+    if step <= 0:
+        raise argparse.ArgumentTypeError(f"Step must be > 0 (given: {step})")
+
+    m = re.fullmatch(r"\s*([+-]?\d+(?:\.\d+)?)\s*-\s*([+-]?\d+(?:\.\d+)?)\s*", core)
+    if m:
+        lo, hi = map(_cast, m.groups())
+        if hi < lo:
+            raise argparse.ArgumentTypeError(f"Upper bound < lower: {spec}")
+        return [type_fn(v) for v in _range(lo, hi, step)]
+
+    # Single value
+    try:
+        return [type_fn(_cast(spec))]
+    except ValueError as ex:
+        raise argparse.ArgumentTypeError(
+            f"Invalid range: {spec}. Expected formats: lo-hi[:step] or lo:hi:step"
+        ) from ex

--- a/tests/test_parse_span_or_list.py
+++ b/tests/test_parse_span_or_list.py
@@ -1,30 +1,42 @@
 import argparse
 import pytest
 
-from forest5.cli import _parse_span_or_list
+from forest5.utils.argparse_ext import span_or_list
 
 
-def test_parse_span_positive_range():
-    assert _parse_span_or_list("1-3") == [1, 2, 3]
+def test_int_positive_range():
+    assert span_or_list("1-3", int) == [1, 2, 3]
 
 
-def test_parse_span_negative_range():
-    assert _parse_span_or_list("-3--1") == [-3, -2, -1]
+def test_int_negative_range():
+    assert span_or_list("-3--1", int) == [-3, -2, -1]
 
 
-def test_parse_span_list():
-    assert _parse_span_or_list("1,4,7") == [1, 4, 7]
+def test_int_list():
+    assert span_or_list("1,4,7", int) == [1, 4, 7]
 
 
-def test_parse_span_colon_syntax():
-    assert _parse_span_or_list("8:16:1") == [8, 9, 10, 11, 12, 13, 14, 15, 16]
+def test_int_colon_syntax():
+    assert span_or_list("8:16:1", int) == [8, 9, 10, 11, 12, 13, 14, 15, 16]
 
 
-def test_parse_span_step_error():
-    with pytest.raises(argparse.ArgumentTypeError, match="Step"):
-        _parse_span_or_list("1-5:0")
+def test_float_range_colon():
+    assert span_or_list("1:2:0.5", float) == [1.0, 1.5, 2.0]
 
 
-def test_parse_span_hi_less_than_lo():
-    with pytest.raises(argparse.ArgumentTypeError, match="Upper bound < lower"):
-        _parse_span_or_list("5-3")
+def test_float_range_dash():
+    assert span_or_list("1.0-2.0:0.5", float) == [1.0, 1.5, 2.0]
+
+
+def test_float_range_non_divisible():
+    assert span_or_list("0:1:0.3", float) == pytest.approx([0.0, 0.3, 0.6, 0.9, 1.0])
+
+
+def test_step_error():
+    with pytest.raises(argparse.ArgumentTypeError):
+        span_or_list("1-5:0", int)
+
+
+def test_hi_less_than_lo():
+    with pytest.raises(argparse.ArgumentTypeError):
+        span_or_list("5-3", int)


### PR DESCRIPTION
## Summary
- add generic span_or_list helper for comma lists and inclusive ranges
- use span_or_list for grid, walkforward, and float list CLI options
- test span_or_list for integer and float parsing and validation

## Testing
- `pre-commit run --files src/forest5/utils/argparse_ext.py src/forest5/cli.py tests/test_parse_span_or_list.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab380075f483269b512a8049feaa63