### PR TITLE
Add tests for grid export, CLI dry run, and walkforward

### DIFF
--- a/tests/test_cli_grid_dry_run.py
+++ b/tests/test_cli_grid_dry_run.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+import ast
+import pandas as pd
+import pytest
+
+from forest5.cli import build_parser, cmd_grid
+
+
+def _write_csv(path: Path, periods: int = 3) -> Path:
+    idx = pd.date_range("2020-01-01", periods=periods, freq="h")
+    df = pd.DataFrame(
+        {
+            "time": idx,
+            "open": [1.0 + i * 0.1 for i in range(periods)],
+            "high": [1.1 + i * 0.1 for i in range(periods)],
+            "low": [0.9 + i * 0.1 for i in range(periods)],
+            "close": [1.0 + i * 0.1 for i in range(periods)],
+        }
+    )
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_cli_grid_dry_run(tmp_path, monkeypatch, capsys):
+    csv_path = _write_csv(tmp_path / "data.csv")
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "grid",
+            "--csv",
+            str(csv_path),
+            "--symbol",
+            "EURUSD",
+            "--fast-values",
+            "1,2",
+            "--slow-values",
+            "3,4",
+            "--dry-run",
+        ]
+    )
+
+    called = False
+
+    def fake_run_grid(*a, **k):
+        nonlocal called
+        called = True
+        return pd.DataFrame()
+
+    monkeypatch.setattr("forest5.cli.run_grid", fake_run_grid)
+
+    rc = cmd_grid(args)
+    assert rc == 0
+    assert called is False
+
+    out = capsys.readouterr().out.strip()
+    assert out.startswith("dry-run")
+    kw = ast.literal_eval(out.split("dry-run ", 1)[1])
+    combos = len(kw["fast_values"]) * len(kw["slow_values"])
+    assert combos == 4

--- a/tests/test_cli_grid_dry_run.py
+++ b/tests/test_cli_grid_dry_run.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import ast
 import pandas as pd
-import pytest
 
 from forest5.cli import build_parser, cmd_grid
 

--- a/tests/test_grid_export_columns.py
+++ b/tests/test_grid_export_columns.py
@@ -1,0 +1,46 @@
+import pandas as pd
+
+from forest5.backtest.grid import run_param_grid
+from forest5.config import BacktestSettings
+from forest5.examples.synthetic import generate_ohlc
+
+
+def _base_settings() -> BacktestSettings:
+    return BacktestSettings(symbol="SYMB", timeframe="1h", strategy={"name": "ema_cross"})
+
+
+def test_grid_export_columns(tmp_path):
+    df = generate_ohlc(periods=10, start_price=100.0, freq="D")
+    settings = _base_settings()
+    params = {"fast": [5], "slow": [10]}
+    results_path = tmp_path / "results.csv"
+    meta_path = tmp_path / "meta.json"
+    run_param_grid(
+        df,
+        settings,
+        params,
+        results_path=results_path,
+        meta_path=meta_path,
+    )
+    assert results_path.exists()
+    csv = pd.read_csv(results_path)
+    expected_cols = [
+        "fast",
+        "slow",
+        "equity_end",
+        "dd",
+        "cagr",
+        "rar",
+        "trades",
+        "winrate",
+        "pnl",
+        "pnl_net",
+        "sharpe",
+        "expectancy",
+        "expectancy_by_pattern",
+        "timeonly_wait_pct",
+        "setups_expired_pct",
+        "rr_avg",
+        "rr_median",
+    ]
+    assert list(csv.columns) == expected_cols

--- a/tests/test_walkforward_smoke.py
+++ b/tests/test_walkforward_smoke.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from forest5.cli import build_parser, cmd_walkforward
+
+
+def _write_csv(path: Path, periods: int = 5) -> Path:
+    idx = pd.date_range("2020-01-01", periods=periods, freq="h")
+    df = pd.DataFrame(
+        {
+            "time": idx,
+            "open": [1.0 + i * 0.1 for i in range(periods)],
+            "high": [1.1 + i * 0.1 for i in range(periods)],
+            "low": [0.9 + i * 0.1 for i in range(periods)],
+            "close": [1.0 + i * 0.1 for i in range(periods)],
+        }
+    )
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_walkforward_smoke(tmp_path, monkeypatch):
+    csv_path = _write_csv(tmp_path / "data.csv", periods=5)
+    out_csv = tmp_path / "wf.csv"
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "walkforward",
+            "--csv",
+            str(csv_path),
+            "--symbol",
+            "EURUSD",
+            "--train",
+            "2",
+            "--test",
+            "1",
+            "--ema-fast",
+            "5",
+            "--ema-slow",
+            "10",
+            "--rsi-len",
+            "14",
+            "--atr-len",
+            "14",
+            "--out",
+            str(out_csv),
+        ]
+    )
+
+    counter = {"i": 0}
+
+    def fake_run_backtest(df_local, settings):
+        counter["i"] += 1
+        eq_end = float(counter["i"])
+        return SimpleNamespace(
+            equity_curve=pd.Series([eq_end], index=df_local.index[:1]),
+            max_dd=0.0,
+            trades=SimpleNamespace(trades=[]),
+        )
+
+    monkeypatch.setattr("forest5.cli.run_backtest", fake_run_backtest)
+
+    rc = cmd_walkforward(args)
+    assert rc == 0
+
+    out_df = pd.read_csv(out_csv)
+    assert len(out_df) >= 2
+    agg = out_df["equity_end"].mean()
+    expected = (len(out_df) + 1) / 2.0
+    assert agg == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- ensure grid results CSV has expected columns
- verify CLI grid dry-run reports parameter combination count without executing backtests
- add walkforward smoke test spanning multiple folds with aggregated WF-score

## Testing
- `pytest tests/test_grid_export_columns.py tests/test_cli_grid_dry_run.py tests/test_walkforward_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab48279e748326ac553d4d22d2770b