### PR TITLE
Add CLI aliases for H1 strategy overrides

### DIFF
--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -496,14 +496,20 @@ def build_parser() -> argparse.ArgumentParser:
     p_gr.add_argument("--rsi-oversold", type=int, default=30, choices=range(0, 101))
     p_gr.add_argument("--rsi-overbought", type=int, default=70, choices=range(0, 101))
 
-    p_gr.add_argument("--t-sep-atr", type=float, default=0.5)
-    p_gr.add_argument("--pullback-atr", type=float, default=0.5)
-    p_gr.add_argument("--entry-buffer-atr", type=float, default=0.1)
-    p_gr.add_argument("--sl-atr", type=float, default=1.0)
-    p_gr.add_argument("--sl-min-atr", type=float, default=0.0)
-    p_gr.add_argument("--rr", type=float, default=2.0)
-    p_gr.add_argument("--q-low", type=float, default=0.1)
-    p_gr.add_argument("--q-high", type=float, default=0.9)
+    p_gr.add_argument("--t-sep-atr", dest="t_sep_atr", type=float, default=0.5)
+    p_gr.add_argument(
+        "--pullback-atr",
+        "--pullback-to-ema-fast-atr",
+        dest="pullback_atr",
+        type=float,
+        default=0.5,
+    )
+    p_gr.add_argument("--entry-buffer-atr", dest="entry_buffer_atr", type=float, default=0.1)
+    p_gr.add_argument("--sl-atr", dest="sl_atr", type=float, default=1.0)
+    p_gr.add_argument("--sl-min-atr", dest="sl_min_atr", type=float, default=0.0)
+    p_gr.add_argument("--rr", dest="rr", type=float, default=2.0)
+    p_gr.add_argument("--q-low", dest="q_low", type=float, default=0.1)
+    p_gr.add_argument("--q-high", dest="q_high", type=float, default=0.9)
     p_gr.add_argument("--no-engulf", dest="pat_engulf", action="store_false", default=True)
     p_gr.add_argument("--no-pinbar", dest="pat_pinbar", action="store_false", default=True)
     p_gr.add_argument("--no-star", dest="pat_star", action="store_false", default=True)
@@ -536,14 +542,20 @@ def build_parser() -> argparse.ArgumentParser:
     p_wf.add_argument("--ema-slow", required=True)
     p_wf.add_argument("--rsi-len", default="14")
     p_wf.add_argument("--atr-len", default="14")
-    p_wf.add_argument("--t-sep-atr", type=float, default=0.5)
-    p_wf.add_argument("--pullback-atr", type=float, default=0.5)
-    p_wf.add_argument("--entry-buffer-atr", type=float, default=0.1)
-    p_wf.add_argument("--sl-atr", type=float, default=1.0)
-    p_wf.add_argument("--sl-min-atr", type=float, default=0.0)
-    p_wf.add_argument("--rr", type=float, default=2.0)
-    p_wf.add_argument("--q-low", type=float, default=0.1)
-    p_wf.add_argument("--q-high", type=float, default=0.9)
+    p_wf.add_argument("--t-sep-atr", dest="t_sep_atr", type=float, default=0.5)
+    p_wf.add_argument(
+        "--pullback-atr",
+        "--pullback-to-ema-fast-atr",
+        dest="pullback_atr",
+        type=float,
+        default=0.5,
+    )
+    p_wf.add_argument("--entry-buffer-atr", dest="entry_buffer_atr", type=float, default=0.1)
+    p_wf.add_argument("--sl-atr", dest="sl_atr", type=float, default=1.0)
+    p_wf.add_argument("--sl-min-atr", dest="sl_min_atr", type=float, default=0.0)
+    p_wf.add_argument("--rr", dest="rr", type=float, default=2.0)
+    p_wf.add_argument("--q-low", dest="q_low", type=float, default=0.1)
+    p_wf.add_argument("--q-high", dest="q_high", type=float, default=0.9)
     p_wf.add_argument("--no-engulf", dest="pat_engulf", action="store_false", default=True)
     p_wf.add_argument("--no-pinbar", dest="pat_pinbar", action="store_false", default=True)
     p_wf.add_argument("--no-star", dest="pat_star", action="store_false", default=True)

--- a/tests/test_cli_aliases.py
+++ b/tests/test_cli_aliases.py
@@ -1,0 +1,90 @@
+import pandas as pd
+from pathlib import Path
+import pytest
+
+from forest5.cli import build_parser, cmd_grid, cmd_walkforward
+
+
+def _write_csv(path: Path) -> Path:
+    idx = pd.date_range("2020-01-01", periods=4, freq="h")
+    df = pd.DataFrame(
+        {
+            "time": idx,
+            "open": [1, 1.1, 1.2, 1.3],
+            "high": [1.1, 1.2, 1.3, 1.4],
+            "low": [0.9, 1.0, 1.1, 1.2],
+            "close": [1.0, 1.1, 1.2, 1.3],
+        }
+    )
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_cli_grid_pullback_alias(tmp_path, monkeypatch):
+    csv_path = _write_csv(tmp_path / "data.csv")
+
+    captured = {}
+
+    def fake_run_grid(df, symbol, fast_values, slow_values, **kwargs):
+        captured.update(kwargs)
+        return pd.DataFrame([{"fast": 1, "slow": 2, "equity_end": 1.0, "max_dd": 0.0, "cagr": 0.0, "rar": 0.0}])
+
+    monkeypatch.setattr("forest5.cli.run_grid", fake_run_grid)
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "grid",
+            "--csv",
+            str(csv_path),
+            "--symbol",
+            "EURUSD",
+            "--fast-values",
+            "2",
+            "--slow-values",
+            "5",
+            "--pullback-to-ema-fast-atr",
+            "0.7",
+        ]
+    )
+
+    cmd_grid(args)
+    assert captured["pullback_atr"] == pytest.approx(0.7)
+
+
+def test_cli_walkforward_pullback_alias(tmp_path, monkeypatch):
+    csv_path = _write_csv(tmp_path / "data.csv")
+
+    captured = {}
+
+    def fake_run_backtest(df, settings, **kwargs):
+        captured["pullback_atr"] = settings.strategy.params.pullback_atr
+        class Res:
+            equity_curve = pd.Series([1.0, 1.0])
+        return Res()
+
+    monkeypatch.setattr("forest5.cli.run_backtest", fake_run_backtest)
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "walkforward",
+            "--csv",
+            str(csv_path),
+            "--symbol",
+            "EURUSD",
+            "--train",
+            "1",
+            "--test",
+            "1",
+            "--ema-fast",
+            "21",
+            "--ema-slow",
+            "55",
+            "--pullback-to-ema-fast-atr",
+            "0.7",
+        ]
+    )
+
+    cmd_walkforward(args)
+    assert captured["pullback_atr"] == pytest.approx(0.7)

--- a/tests/test_strategy_overrides.py
+++ b/tests/test_strategy_overrides.py
@@ -1,0 +1,20 @@
+from forest5.config.strategy import BaseStrategySettings, H1EmaRsiAtrParams
+
+
+def test_overrides_propagate_to_params():
+    s = BaseStrategySettings(
+        name="h1_ema_rsi_atr",
+        ema_fast=10,
+        pullback_atr=0.7,
+        entry_buffer_atr=0.2,
+    )
+    assert isinstance(s.params, H1EmaRsiAtrParams)
+    assert s.params.ema_fast == 10
+    assert s.params.pullback_atr == 0.7
+    assert s.params.entry_buffer_atr == 0.2
+
+
+def test_alias_input_propagates():
+    s = BaseStrategySettings(name="h1_ema_rsi_atr", **{"pullback_to_ema_fast_atr": 0.8})
+    assert s.pullback_atr == 0.8
+    assert s.params.pullback_atr == 0.8


### PR DESCRIPTION
## Summary
- add explicit `dest` and aliases for H1 EMA RSI ATR CLI options
- verify CLI aliases and BaseStrategySettings overrides propagate to params

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab510492a08326975dd8f4858c5274