### PR TITLE
Add walk-forward grid search with per-fold outputs

### DIFF
--- a/scripts/walkforward.py
+++ b/scripts/walkforward.py
@@ -3,16 +3,14 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from typing import Dict, Iterable, List, Tuple
+from typing import Dict
 
 import pandas as pd
-from pandas.tseries.offsets import DateOffset
 
 # forest5
 from forest5.cli import SafeHelpFormatter, _parse_range
-from forest5.config import BacktestSettings, StrategySettings, RiskSettings
-from forest5.backtest.engine import run_backtest
 from forest5.utils.argparse_ext import PercentAction
+from forest5.backtest.walkforward import run_walkforward
 
 
 # ----------------------------- CSV LOADING ---------------------------------
@@ -86,35 +84,6 @@ def load_prices(path: str | Path) -> pd.DataFrame:
     return df
 
 
-# ----------------------------- RANGES & GRID --------------------------------
-
-
-def build_param_grid(
-    fast: Iterable[int],
-    slow: Iterable[int],
-    use_rsi: bool,
-    rsi_period: int,
-    rsi_oversold: int,
-    rsi_overbought: int,
-    skip_fast_ge_slow: bool,
-) -> List[Dict[str, int | bool]]:
-    out: List[Dict[str, int | bool]] = []
-    for f in fast:
-        for s in slow:
-            if skip_fast_ge_slow and f >= s:
-                continue
-            rec: Dict[str, int | bool] = {
-                "fast": int(f),
-                "slow": int(s),
-                "use_rsi": bool(use_rsi),
-                "rsi_period": int(rsi_period),
-                "rsi_oversold": int(rsi_oversold),
-                "rsi_overbought": int(rsi_overbought),
-            }
-            out.append(rec)
-    return out
-
-
 # ----------------------------- TIME UTILS -----------------------------------
 
 
@@ -132,144 +101,6 @@ def cut_df(df: pd.DataFrame, start: str | None, end: str | None) -> pd.DataFrame
         e = ts_naive_utc(end)
         out = out.loc[out.index <= e]
     return out
-
-
-def iter_walkforward_windows(
-    start: pd.Timestamp,
-    end: pd.Timestamp,
-    train_months: int,
-    test_months: int,
-    step_months: int,
-) -> Iterable[Tuple[pd.Timestamp, pd.Timestamp, pd.Timestamp, pd.Timestamp]]:
-    """
-    Generuj kolejne okna WF: [train] -> [test], przesuwając co step_months.
-    Każde okno obcinamy do maksymalnego `end`.
-    """
-    cur_train_start = start
-    while True:
-        train_end = cur_train_start + DateOffset(months=train_months) - pd.Timedelta(seconds=1)
-        test_start = train_end + pd.Timedelta(seconds=1)
-        test_end = test_start + DateOffset(months=test_months) - pd.Timedelta(seconds=1)
-
-        if train_end > end:
-            break
-        if test_start > end:
-            break
-
-        yield (cur_train_start, train_end, test_start, min(test_end, end))
-
-        cur_train_start = cur_train_start + DateOffset(months=step_months)
-        if cur_train_start > end:
-            break
-
-
-# ----------------------------- EVAL & SELECTION -----------------------------
-
-
-def _mk_settings(
-    symbol: str,
-    fast: int,
-    slow: int,
-    use_rsi: bool,
-    rsi_period: int,
-    rsi_oversold: int,
-    rsi_overbought: int,
-    capital: float,
-    risk: float,
-    fee_perc: float,
-    slippage_perc: float,
-    atr_period: int,
-    atr_multiple: float,
-) -> BacktestSettings:
-    strat = StrategySettings(
-        name="ema_cross",
-        fast=int(fast),
-        slow=int(slow),
-        use_rsi=bool(use_rsi),
-        rsi_period=int(rsi_period),
-        rsi_oversold=int(rsi_oversold),
-        rsi_overbought=int(rsi_overbought),
-    )
-    riskset = RiskSettings(
-        initial_capital=float(capital),
-        risk_per_trade=float(risk),
-        fee_perc=float(fee_perc),
-        slippage_perc=float(slippage_perc),
-    )
-    return BacktestSettings(
-        symbol=symbol,
-        strategy=strat,
-        risk=riskset,
-        atr_period=int(atr_period),
-        atr_multiple=float(atr_multiple),
-    )
-
-
-def evaluate_df(
-    df: pd.DataFrame,
-    settings: BacktestSettings,
-) -> Tuple[float, float, int, float, float, float]:
-    res = run_backtest(df, settings)
-
-    equity = res.equity_curve
-    eq_end = float(equity.iloc[-1]) if not equity.empty else 0.0
-    init_cap = float(settings.risk.initial_capital)
-    ret = (eq_end / init_cap) - 1.0 if init_cap > 0 else 0.0
-    pnl_net = eq_end - init_cap
-    returns = equity.pct_change().dropna()
-    sharpe = (
-        float(returns.mean() / returns.std() * (252**0.5))
-        if not returns.empty and returns.std() != 0
-        else 0.0
-    )
-    max_dd = float(res.max_dd)
-    trades = len(res.trades.trades)
-    return ret, max_dd, trades, eq_end, pnl_net, sharpe
-
-
-def pick_best_on_train(
-    train_df: pd.DataFrame,
-    grid: List[Dict[str, int | bool]],
-    symbol: str,
-    capital: float,
-    risk: float,
-    fee_perc: float,
-    slippage_perc: float,
-    atr_period: int,
-    atr_multiple: float,
-    dd_penalty: float,
-) -> Tuple[Dict[str, int | bool], float, float]:
-    best: Dict[str, int | bool] | None = None
-    best_score = -1e9
-    best_ret = 0.0
-    best_dd = 1.0
-
-    for p in grid:
-        st = _mk_settings(
-            symbol=symbol,
-            fast=int(p["fast"]),
-            slow=int(p["slow"]),
-            use_rsi=bool(p["use_rsi"]),
-            rsi_period=int(p["rsi_period"]),
-            rsi_oversold=int(p["rsi_oversold"]),
-            rsi_overbought=int(p["rsi_overbought"]),
-            capital=capital,
-            risk=risk,
-            fee_perc=fee_perc,
-            slippage_perc=slippage_perc,
-            atr_period=atr_period,
-            atr_multiple=atr_multiple,
-        )
-        tr_ret, tr_dd, _, _, _, _ = evaluate_df(train_df, st)
-        score = tr_ret - dd_penalty * tr_dd
-        if (score > best_score) or (score == best_score and (tr_ret > best_ret or tr_dd < best_dd)):
-            best = p
-            best_score = score
-            best_ret = tr_ret
-            best_dd = tr_dd
-
-    assert best is not None  # grid nie może być puste
-    return best, best_ret, best_dd
 
 
 # ----------------------------- CLI / MAIN -----------------------------------
@@ -302,10 +133,10 @@ def main() -> None:
     ap.add_argument("--train-months", type=int, default=12)
     ap.add_argument("--test-months", type=int, default=3)
     ap.add_argument("--step-months", type=int, default=3)
+    ap.add_argument("--mode", choices=("rolling", "anchored"), default="rolling")
 
-    ap.add_argument("--dd-penalty", type=float, default=0.5)
     ap.add_argument("--skip-fast-ge-slow", action="store_true")
-    ap.add_argument("--export", default="out/walkforward.csv")
+    ap.add_argument("--out", default="out/walkforward")
     ap.add_argument("--top", type=int, default=10, help="Ile rekordów wyświetlić")
 
     args = ap.parse_args()
@@ -317,116 +148,40 @@ def main() -> None:
     if df.empty:
         raise SystemExit("Pusty zakres danych po cięciu start/end.")
 
-    # 2) grid parametrów
+    # 2) param ranges
     fast_vals = _parse_range(args.fast)
     slow_vals = _parse_range(args.slow)
-    grid = build_param_grid(
-        fast_vals,
-        slow_vals,
-        args.use_rsi,
-        args.rsi_period,
-        args.rsi_oversold,
-        args.rsi_overbought,
-        args.skip_fast_ge_slow,
+
+    res_df = run_walkforward(
+        df,
+        symbol=args.symbol,
+        fast_values=fast_vals,
+        slow_values=slow_vals,
+        use_rsi=args.use_rsi,
+        rsi_period=args.rsi_period,
+        rsi_oversold=args.rsi_oversold,
+        rsi_overbought=args.rsi_overbought,
+        capital=args.capital,
+        risk=args.risk,
+        fee_perc=args.fee_perc,
+        slippage_perc=args.slippage_perc,
+        atr_period=args.atr_period,
+        atr_multiple=args.atr_multiple,
+        train_months=args.train_months,
+        test_months=args.test_months,
+        step_months=args.step_months,
+        mode=args.mode,
+        skip_fast_ge_slow=args.skip_fast_ge_slow,
+        out_dir=args.out,
     )
-    if not grid:
-        raise SystemExit("Siatka parametrów jest pusta (sprawdź --fast/--slow).")
 
-    # 3) walk-forward
-    start_ts = df.index[0]
-    end_ts = df.index[-1]
-    if args.start:
-        start_ts = max(start_ts, ts_naive_utc(args.start))
-    if args.end:
-        end_ts = min(end_ts, ts_naive_utc(args.end))
-
-    rows: List[Dict[str, object]] = []
-
-    for tr_start, tr_end, te_start, te_end in iter_walkforward_windows(
-        start_ts, end_ts, args.train_months, args.test_months, args.step_months
-    ):
-        train = df.loc[(df.index >= tr_start) & (df.index <= tr_end)]
-        test = df.loc[(df.index >= te_start) & (df.index <= te_end)]
-        if train.empty or test.empty:
-            continue
-
-        best, tr_ret, tr_dd = pick_best_on_train(
-            train_df=train,
-            grid=grid,
-            symbol=args.symbol,
-            capital=args.capital,
-            risk=args.risk,
-            fee_perc=args.fee_perc,
-            slippage_perc=args.slippage_perc,
-            atr_period=args.atr_period,
-            atr_multiple=args.atr_multiple,
-            dd_penalty=args.dd_penalty,
-        )
-
-        # ewaluacja na teście
-        st_best = _mk_settings(
-            symbol=args.symbol,
-            fast=int(best["fast"]),
-            slow=int(best["slow"]),
-            use_rsi=bool(best["use_rsi"]),
-            rsi_period=int(best["rsi_period"]),
-            rsi_oversold=int(best["rsi_oversold"]),
-            rsi_overbought=int(best["rsi_overbought"]),
-            capital=args.capital,
-            risk=args.risk,
-            fee_perc=args.fee_perc,
-            slippage_perc=args.slippage_perc,
-            atr_period=args.atr_period,
-            atr_multiple=args.atr_multiple,
-        )
-        te_ret, te_dd, te_trades, te_eq_end, te_pnl_net, te_sharpe = evaluate_df(test, st_best)
-
-        row = {
-            "train_start": tr_start,
-            "train_end": tr_end,
-            "test_start": te_start,
-            "test_end": te_end,
-            "fast": int(best["fast"]),
-            "slow": int(best["slow"]),
-            "use_rsi": bool(best["use_rsi"]),
-            "rsi_period": int(best["rsi_period"]),
-            "rsi_oversold": int(best["rsi_oversold"]),
-            "rsi_overbought": int(best["rsi_overbought"]),
-            "train_ret": tr_ret,
-            "train_max_dd": tr_dd,
-            "test_ret": te_ret,
-            "test_max_dd": te_dd,
-            "test_trades": te_trades,
-            "test_equity_end": te_eq_end,
-            "test_pnl_net": te_pnl_net,
-            "test_sharpe": te_sharpe,
-        }
-        rows.append(row)
-        print(
-            {
-                "event": "wf_window",
-                "train": [str(tr_start), str(tr_end)],
-                "test": [str(te_start), str(te_end)],
-                "best": {"fast": row["fast"], "slow": row["slow"], "use_rsi": row["use_rsi"]},
-                "train_ret": tr_ret,
-                "train_dd": tr_dd,
-                "test_ret": te_ret,
-                "test_dd": te_dd,
-            }
-        )
-
-    # 4) sort & export
-    res_df = pd.DataFrame(rows)
     sort_cols = [c for c in ("test_pnl_net", "test_sharpe") if c in res_df.columns]
     if sort_cols:
         res_df = res_df.sort_values(by=sort_cols, ascending=False)
     with pd.option_context("display.max_columns", None, "display.width", 120):
         print(res_df.head(args.top).to_string(index=False, justify="right"))
 
-    out_path = Path(args.export)
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    res_df.to_csv(out_path, index=False)
-    print({"event": "walkforward_export_done", "out": str(out_path), "rows": len(res_df)})
+    print({"event": "walkforward_export_done", "out": str(Path(args.out) / "summary.csv"), "rows": len(res_df)})
 
 
 if __name__ == "__main__":

--- a/src/forest5/backtest/walkforward.py
+++ b/src/forest5/backtest/walkforward.py
@@ -1,0 +1,253 @@
+"""Walk-forward evaluation utilities."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Tuple
+import json
+
+import pandas as pd
+from pandas.tseries.offsets import DateOffset
+
+from ..config import BacktestSettings, StrategySettings, RiskSettings
+from .engine import run_backtest as _run_backtest
+
+
+def _mk_settings(
+    *,
+    symbol: str,
+    fast: int,
+    slow: int,
+    use_rsi: bool,
+    rsi_period: int,
+    rsi_oversold: int,
+    rsi_overbought: int,
+    capital: float,
+    risk: float,
+    fee_perc: float,
+    slippage_perc: float,
+    atr_period: int,
+    atr_multiple: float,
+) -> BacktestSettings:
+    strat = StrategySettings(
+        name="ema_cross",
+        fast=int(fast),
+        slow=int(slow),
+        use_rsi=bool(use_rsi),
+        rsi_period=int(rsi_period),
+        rsi_oversold=int(rsi_oversold),
+        rsi_overbought=int(rsi_overbought),
+    )
+    riskset = RiskSettings(
+        initial_capital=float(capital),
+        risk_per_trade=float(risk),
+        fee_perc=float(fee_perc),
+        slippage_perc=float(slippage_perc),
+    )
+    return BacktestSettings(
+        symbol=symbol,
+        strategy=strat,
+        risk=riskset,
+        atr_period=int(atr_period),
+        atr_multiple=float(atr_multiple),
+    )
+
+
+def _evaluate_df(
+    df: pd.DataFrame,
+    settings: BacktestSettings,
+    run_backtest_func: Callable[[pd.DataFrame, BacktestSettings], object],
+) -> Tuple[float, float, int, float, float, float]:
+    res = run_backtest_func(df, settings)
+    equity = res.equity_curve
+    eq_end = float(equity.iloc[-1]) if not equity.empty else 0.0
+    init_cap = float(settings.risk.initial_capital)
+    ret = (eq_end / init_cap) - 1.0 if init_cap > 0 else 0.0
+    pnl_net = eq_end - init_cap
+    returns = equity.pct_change().dropna()
+    sharpe = (
+        float(returns.mean() / returns.std() * (252 ** 0.5))
+        if not returns.empty and returns.std() != 0
+        else 0.0
+    )
+    max_dd = float(res.max_dd)
+    trades = len(res.trades.trades)
+    return ret, max_dd, trades, eq_end, pnl_net, sharpe
+
+
+def _iter_windows(
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+    train_months: int,
+    test_months: int,
+    step_months: int,
+    mode: str,
+) -> Iterable[Tuple[pd.Timestamp, pd.Timestamp, pd.Timestamp, pd.Timestamp]]:
+    cur = start
+    if mode == "anchored":
+        train_start = start
+        train_end = train_start + DateOffset(months=train_months) - pd.Timedelta(seconds=1)
+        while True:
+            test_start = train_end + pd.Timedelta(seconds=1)
+            test_end = test_start + DateOffset(months=test_months) - pd.Timedelta(seconds=1)
+            if train_end > end or test_start > end:
+                break
+            yield (train_start, train_end, test_start, min(test_end, end))
+            train_end = train_end + DateOffset(months=step_months)
+            cur = cur + DateOffset(months=step_months)
+            if cur > end:
+                break
+    else:  # rolling
+        while True:
+            train_start = cur
+            train_end = train_start + DateOffset(months=train_months) - pd.Timedelta(seconds=1)
+            test_start = train_end + pd.Timedelta(seconds=1)
+            test_end = test_start + DateOffset(months=test_months) - pd.Timedelta(seconds=1)
+            if train_end > end or test_start > end:
+                break
+            yield (train_start, train_end, test_start, min(test_end, end))
+            cur = cur + DateOffset(months=step_months)
+            if cur > end:
+                break
+
+
+def run_walkforward(
+    df: pd.DataFrame,
+    *,
+    symbol: str,
+    fast_values: Iterable[int],
+    slow_values: Iterable[int],
+    use_rsi: bool = False,
+    rsi_period: int = 14,
+    rsi_oversold: int = 30,
+    rsi_overbought: int = 70,
+    capital: float = 100_000.0,
+    risk: float = 0.01,
+    fee_perc: float = 0.0005,
+    slippage_perc: float = 0.0,
+    atr_period: int = 14,
+    atr_multiple: float = 2.0,
+    train_months: int = 12,
+    test_months: int = 3,
+    step_months: int = 3,
+    mode: str = "rolling",
+    skip_fast_ge_slow: bool = False,
+    out_dir: str | Path | None = None,
+    run_backtest_func: Callable[[pd.DataFrame, BacktestSettings], object] = _run_backtest,
+) -> pd.DataFrame:
+    """Run walk-forward analysis on ``df``.
+
+    Parameters are intentionally similar to :mod:`scripts.walkforward`.
+    """
+
+    start_ts = df.index[0]
+    end_ts = df.index[-1]
+
+    grid: List[Dict[str, int | bool]] = []
+    for f in fast_values:
+        for s in slow_values:
+            if skip_fast_ge_slow and f >= s:
+                continue
+            grid.append(
+                {
+                    "fast": int(f),
+                    "slow": int(s),
+                    "use_rsi": bool(use_rsi),
+                    "rsi_period": int(rsi_period),
+                    "rsi_oversold": int(rsi_oversold),
+                    "rsi_overbought": int(rsi_overbought),
+                }
+            )
+
+    out_path: Path | None = Path(out_dir) if out_dir else None
+    if out_path:
+        out_path.mkdir(parents=True, exist_ok=True)
+
+    rows: List[Dict[str, object]] = []
+    for i, (tr_start, tr_end, te_start, te_end) in enumerate(
+        _iter_windows(start_ts, end_ts, train_months, test_months, step_months, mode)
+    ):
+        train_df = df.loc[(df.index >= tr_start) & (df.index <= tr_end)]
+        test_df = df.loc[(df.index >= te_start) & (df.index <= te_end)]
+        if train_df.empty or test_df.empty:
+            continue
+
+        best: Dict[str, int | bool] | None = None
+        best_pnl = -1e18
+        best_sharpe = -1e18
+        for p in grid:
+            st = _mk_settings(
+                symbol=symbol,
+                fast=int(p["fast"]),
+                slow=int(p["slow"]),
+                use_rsi=bool(p["use_rsi"]),
+                rsi_period=int(p["rsi_period"]),
+                rsi_oversold=int(p["rsi_oversold"]),
+                rsi_overbought=int(p["rsi_overbought"]),
+                capital=capital,
+                risk=risk,
+                fee_perc=fee_perc,
+                slippage_perc=slippage_perc,
+                atr_period=atr_period,
+                atr_multiple=atr_multiple,
+            )
+            _, _, _, _, pnl_net, sharpe = _evaluate_df(train_df, st, run_backtest_func)
+            if (pnl_net > best_pnl) or (pnl_net == best_pnl and sharpe > best_sharpe):
+                best = p
+                best_pnl = pnl_net
+                best_sharpe = sharpe
+        if best is None:
+            continue
+
+        best_settings = _mk_settings(
+            symbol=symbol,
+            fast=int(best["fast"]),
+            slow=int(best["slow"]),
+            use_rsi=bool(best["use_rsi"]),
+            rsi_period=int(best["rsi_period"]),
+            rsi_oversold=int(best["rsi_oversold"]),
+            rsi_overbought=int(best["rsi_overbought"]),
+            capital=capital,
+            risk=risk,
+            fee_perc=fee_perc,
+            slippage_perc=slippage_perc,
+            atr_period=atr_period,
+            atr_multiple=atr_multiple,
+        )
+        te_ret, te_dd, te_trades, te_eq_end, te_pnl_net, te_sharpe = _evaluate_df(
+            test_df, best_settings, run_backtest_func
+        )
+
+        wf_score = te_pnl_net / best_pnl if best_pnl else 0.0
+
+        row = {
+            "fold": i,
+            "train_start": tr_start,
+            "train_end": tr_end,
+            "test_start": te_start,
+            "test_end": te_end,
+            "fast": int(best["fast"]),
+            "slow": int(best["slow"]),
+            "use_rsi": bool(best["use_rsi"]),
+            "rsi_period": int(best["rsi_period"]),
+            "rsi_oversold": int(best["rsi_oversold"]),
+            "rsi_overbought": int(best["rsi_overbought"]),
+            "train_pnl_net": best_pnl,
+            "train_sharpe": best_sharpe,
+            "test_ret": te_ret,
+            "test_max_dd": te_dd,
+            "test_trades": te_trades,
+            "test_equity_end": te_eq_end,
+            "test_pnl_net": te_pnl_net,
+            "test_sharpe": te_sharpe,
+            "wf_score": wf_score,
+        }
+        rows.append(row)
+
+        if out_path:
+            with (out_path / f"fold_{i}.json").open("w", encoding="utf-8") as fh:
+                json.dump(row, fh, default=str, ensure_ascii=False, indent=2)
+
+    result_df = pd.DataFrame(rows)
+    if out_path:
+        result_df.to_csv(out_path / "summary.csv", index=False)
+    return result_df


### PR DESCRIPTION
## Summary
- add `run_walkforward` API to perform walk-forward analysis with per-fold JSON results, WF-score, and anchored/rolling modes
- simplify `scripts/walkforward.py` to use new API and support `--mode` and `--out` directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab569fc20c8326a23f63c2ca30b8c2