### PR TITLE
refactor: introduce decision dataclasses

### DIFF
--- a/src/forest5/decision.py
+++ b/src/forest5/decision.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, is_dataclass
-from typing import Mapping
+from dataclasses import asdict, dataclass, is_dataclass
+from typing import Any, Literal, Mapping
 
 import pandas as pd
 
@@ -11,34 +11,75 @@ from .time_only import TimeOnlyModel
 from .signals.fusion import _to_sign
 
 
+Dir = Literal[-1, 0, 1]
+
+
+@dataclass
+class DecisionVote:
+    source: str
+    direction: Dir
+    weight: float = 0.0
+    score: float = 0.0
+    meta: dict[str, Any] | None = None
+
+
+@dataclass(init=False)
+class DecisionResult:
+    action: Literal["BUY", "SELL", "WAIT"]
+    weight_sum: float
+    reason: str = ""
+    details: dict[str, Any] | None = None
+
+    def __init__(
+        self,
+        action: Literal["BUY", "SELL", "WAIT"],
+        weight_sum: float,
+        reason_or_details: str | dict[str, Any] = "",
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        if isinstance(reason_or_details, dict):
+            self.action = action
+            self.weight_sum = weight_sum
+            self.details = reason_or_details
+            self.reason = details or ""
+        else:
+            self.action = action
+            self.weight_sum = weight_sum
+            self.reason = reason_or_details
+            self.details = details or {}
+
+    # Backward compatibility helpers
+    @property
+    def decision(self) -> Literal["BUY", "SELL", "WAIT"]:
+        return self.action
+
+    @property
+    def weight(self) -> float:
+        return self.weight_sum
+
+    @property
+    def votes(self) -> dict[str, Dir]:
+        if not self.details:
+            return {}
+        out: dict[str, Dir] = {}
+        for k, v in self.details.items():
+            if isinstance(v, Mapping) and "direction" in v:
+                out[k] = v["direction"]  # type: ignore[assignment]
+            else:
+                out[k] = v  # type: ignore[assignment]
+        return out
+
+    def __iter__(self):  # pragma: no cover - tiny helper
+        yield self.action
+        yield self.votes
+        yield self.reason
+
+
 def _normalize_action(action: int | float | str) -> int | float:
     """Convert common string actions to numeric values."""
     if isinstance(action, str):
         return {"BUY": 1, "SELL": -1, "KEEP": 0, "WAIT": 0}.get(action.upper(), 0)
     return action
-
-
-@dataclass
-class DecisionResult:
-    """Result of a decision fusion.
-
-    ``decision`` is one of ``"BUY"``, ``"SELL"`` or ``"WAIT"``. ``weight``
-    denotes the confidence in the decision (0–1). ``votes`` keep the raw sign
-    of each component (technical/time/AI) for backwards compatibility.
-
-    The class implements ``__iter__`` so existing code expecting a 3-tuple
-    ``(decision, votes, reason)`` continues to work.
-    """
-
-    decision: str
-    weight: float
-    votes: dict[str, int]
-    reason: str
-
-    def __iter__(self):  # pragma: no cover - tiny helper
-        yield self.decision
-        yield self.votes
-        yield self.reason
 
 
 @dataclass
@@ -90,19 +131,26 @@ class DecisionAgent:
             action = _normalize_action(get("action", 0))
             tech_score = get("technical_score", action)
             confidence = get("confidence_tech", 1.0)
-            votes: dict[str, tuple[int, float]] = {
-                "tech": (
-                    _to_sign(action if action else tech_score),
-                    abs(float(tech_score)) * float(confidence),
+            votes: dict[str, DecisionVote] = {
+                "tech": DecisionVote(
+                    source="tech",
+                    direction=_to_sign(action if action else tech_score),
+                    weight=abs(float(tech_score)) * float(confidence),
+                    score=float(tech_score),
                 ),
-                "time": (0, 0.0),
-                "ai": (0, 0.0),
+                "time": DecisionVote(source="time", direction=0),
+                "ai": DecisionVote(source="ai", direction=0),
             }
         else:
-            votes: dict[str, tuple[int, float]] = {
-                "tech": (_to_sign(int(tech_signal)), 1.0),
-                "time": (0, 0.0),
-                "ai": (0, 0.0),
+            votes = {
+                "tech": DecisionVote(
+                    source="tech",
+                    direction=_to_sign(int(tech_signal)),
+                    weight=1.0,
+                    score=float(tech_signal),
+                ),
+                "time": DecisionVote(source="time", direction=0),
+                "ai": DecisionVote(source="ai", direction=0),
             }
 
         if self.config.time_model:
@@ -112,37 +160,57 @@ class DecisionAgent:
             else:  # backward compatibility
                 tm_decision, tm_weight = tm_res, 1.0
             if tm_decision == "WAIT":
-                return DecisionResult("WAIT", 0.0, {k: v[0] for k, v in votes.items()}, "time_wait")
-            votes["time"] = (_to_sign(1 if tm_decision == "BUY" else -1), float(tm_weight))
+                return DecisionResult(
+                    "WAIT",
+                    0.0,
+                    "time_wait",
+                    {k: asdict(v) for k, v in votes.items()},
+                )
+            votes["time"] = DecisionVote(
+                source="time",
+                direction=_to_sign(1 if tm_decision == "BUY" else -1),
+                weight=float(tm_weight),
+                score=float(tm_weight),
+            )
 
         if self.ai:
             s = self.ai.analyse(context_text, symbol).score
-            votes["ai"] = (_to_sign(s), abs(float(s)))
+            votes["ai"] = DecisionVote(
+                source="ai",
+                direction=_to_sign(s),
+                weight=abs(float(s)),
+                score=float(s),
+            )
 
-        pos_total = sum(w for s, w in votes.values() if s > 0)
-        neg_total = sum(w for s, w in votes.values() if s < 0)
+        pos_total = sum(v.weight for v in votes.values() if v.direction > 0)
+        neg_total = sum(v.weight for v in votes.values() if v.direction < 0)
         if max(pos_total, neg_total) < max(self.config.min_confluence, 1.0):
             return DecisionResult(
                 "WAIT",
                 0.0,
-                {k: v[0] for k, v in votes.items()},
                 "no_consensus",
+                {k: asdict(v) for k, v in votes.items()},
             )
 
         if pos_total > neg_total:
             dec = "BUY"
-            weights = [w for s, w in votes.values() if s > 0]
+            weights = [v.weight for v in votes.values() if v.direction > 0]
         elif neg_total > pos_total:
             dec = "SELL"
-            weights = [w for s, w in votes.values() if s < 0]
+            weights = [v.weight for v in votes.values() if v.direction < 0]
         else:
             return DecisionResult(
                 "WAIT",
                 0.0,
-                {k: v[0] for k, v in votes.items()},
                 "no_consensus",
+                {k: asdict(v) for k, v in votes.items()},
             )
 
         final_weight = min(weights) if weights else 0.0
         reason = "buy_majority" if dec == "BUY" else "sell_majority"
-        return DecisionResult(dec, final_weight, {k: v[0] for k, v in votes.items()}, reason)
+        return DecisionResult(
+            dec,
+            final_weight,
+            reason,
+            {k: asdict(v) for k, v in votes.items()},
+        )


### PR DESCRIPTION
## Summary
- define internal Dir, DecisionVote and DecisionResult dataclasses with backward-compatible helpers
- refactor DecisionAgent to use DecisionVote objects and return enriched DecisionResult

## Testing
- `pre-commit run --files src/forest5/decision.py tests/test_live_timeonly_paper_smoke.py tests/test_decision_agent.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab60621e388326a0c71c1ae3036487