### PR TITLE
feat: normalize technical inputs

### DIFF
--- a/src/forest5/decision.py
+++ b/src/forest5/decision.py
@@ -116,7 +116,11 @@ def _normalize_tech_input(tech_signal, cfg) -> DecisionVote:
         raw_meta = get("meta")
         if isinstance(raw_meta, Mapping):
             meta.update(raw_meta)
-        meta["mode"] = "dataclass" if is_dataclass(tech_signal) and not isinstance(tech_signal, Mapping) else "mapping"
+        meta["mode"] = (
+            "dataclass"
+            if is_dataclass(tech_signal) and not isinstance(tech_signal, Mapping)
+            else "mapping"
+        )
         return DecisionVote(
             source="tech",
             direction=_to_sign(action if action else tech_score),

--- a/src/forest5/decision.py
+++ b/src/forest5/decision.py
@@ -82,6 +82,72 @@ def _normalize_action(action: int | float | str) -> int | float:
     return action
 
 
+def _normalize_tech_input(tech_signal, cfg) -> DecisionVote:
+    """Normalize various technical signal formats into a ``DecisionVote``.
+
+    ``tech_signal`` may be an int/float, mapping, or dataclass. For mappings and
+    dataclasses we expect ``action``/``technical_score``/``confidence_tech``
+    fields. Confidence is clamped to ``cfg.decision.tech.conf_floor`` and
+    ``cfg.decision.tech.conf_cap``. String actions like ``BUY``/``SELL``/``KEEP``
+    are mapped to numeric directions. The returned ``DecisionVote`` always
+    includes ``meta={'mode': <mode>}`` describing the normalization path.
+    Unknown formats yield a neutral vote.
+    """
+
+    tech_cfg = getattr(getattr(cfg, "decision", object()), "tech", object())
+    default_conf_int = getattr(tech_cfg, "default_conf_int", 1.0)
+    conf_floor = getattr(tech_cfg, "conf_floor", 0.0)
+    conf_cap = getattr(tech_cfg, "conf_cap", 1.0)
+    w_tech = getattr(getattr(getattr(cfg, "decision", object()), "weights", object()), "tech", 1.0)
+
+    def _clamp(v: float) -> float:
+        return max(conf_floor, min(conf_cap, v))
+
+    if isinstance(tech_signal, Mapping) or is_dataclass(tech_signal):
+        get = (
+            tech_signal.get
+            if isinstance(tech_signal, Mapping)
+            else lambda k, d=None: getattr(tech_signal, k, d)
+        )
+        action = _normalize_action(get("action", 0))
+        tech_score = float(get("technical_score", action))
+        conf = _clamp(float(get("confidence_tech", default_conf_int)))
+        meta = {}
+        raw_meta = get("meta")
+        if isinstance(raw_meta, Mapping):
+            meta.update(raw_meta)
+        meta["mode"] = "dataclass" if is_dataclass(tech_signal) and not isinstance(tech_signal, Mapping) else "mapping"
+        return DecisionVote(
+            source="tech",
+            direction=_to_sign(action if action else tech_score),
+            weight=conf * w_tech,
+            score=tech_score,
+            meta=meta,
+        )
+
+    if isinstance(tech_signal, str):
+        dir_val = _normalize_action(tech_signal)
+        if isinstance(dir_val, (int, float)):
+            return DecisionVote(
+                source="tech",
+                direction=_to_sign(dir_val),
+                weight=default_conf_int * w_tech,
+                score=float(dir_val),
+                meta={"mode": "str"},
+            )
+
+    if isinstance(tech_signal, (int, float)):
+        return DecisionVote(
+            source="tech",
+            direction=_to_sign(int(tech_signal)),
+            weight=default_conf_int * w_tech,
+            score=float(tech_signal),
+            meta={"mode": "int"},
+        )
+
+    return DecisionVote(source="tech", direction=0, weight=0.0, score=0.0, meta={"mode": "unknown"})
+
+
 @dataclass
 class DecisionConfig:
     use_ai: bool = False

--- a/tests/test_normalize_tech_input.py
+++ b/tests/test_normalize_tech_input.py
@@ -1,6 +1,6 @@
 from types import SimpleNamespace
 
-from forest5.decision import _normalize_tech_input, DecisionVote
+from forest5.decision import _normalize_tech_input
 from forest5.signals.contract import TechnicalSignal
 
 

--- a/tests/test_normalize_tech_input.py
+++ b/tests/test_normalize_tech_input.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+
+from forest5.decision import _normalize_tech_input, DecisionVote
+from forest5.signals.contract import TechnicalSignal
+
+
+class Cfg:
+    decision = SimpleNamespace(
+        tech=SimpleNamespace(default_conf_int=0.2, conf_floor=0.1, conf_cap=0.9),
+        weights=SimpleNamespace(tech=1.5),
+    )
+
+
+def test_normalize_int() -> None:
+    cfg = Cfg()
+    vote = _normalize_tech_input(1, cfg)
+    assert vote.direction == 1
+    assert vote.weight == 0.2 * 1.5
+    assert vote.meta == {"mode": "int"}
+
+
+def test_normalize_mapping_clamp_floor() -> None:
+    cfg = Cfg()
+    signal = {"action": "SELL", "technical_score": -2.5, "confidence_tech": 0.05}
+    vote = _normalize_tech_input(signal, cfg)
+    assert vote.direction == -1
+    assert vote.weight == 0.1 * 1.5
+    assert vote.score == -2.5
+    assert vote.meta["mode"] == "mapping"
+
+
+def test_normalize_dataclass_clamp_cap() -> None:
+    cfg = Cfg()
+    sig = TechnicalSignal(action="BUY", technical_score=3.0, confidence_tech=0.95)
+    vote = _normalize_tech_input(sig, cfg)
+    assert vote.direction == 1
+    assert vote.weight == 0.9 * 1.5
+    assert vote.score == 3.0
+    assert vote.meta["mode"] == "dataclass"
+
+
+def test_normalize_unknown() -> None:
+    cfg = Cfg()
+    vote = _normalize_tech_input(object(), cfg)
+    assert vote.direction == 0
+    assert vote.weight == 0.0
+    assert vote.meta["mode"] == "unknown"


### PR DESCRIPTION
## Summary
- add `_normalize_tech_input` helper to convert various technical signal formats into `DecisionVote`
- cover normalization with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab646d5c1c832682963bc940a7710a