### PR TITLE
Refine decision voting with AI and time signals

### DIFF
--- a/tests/test_decision_agent.py
+++ b/tests/test_decision_agent.py
@@ -13,8 +13,8 @@ def test_decision_agent_waits_when_time_model_waits() -> None:
     ts = datetime(2024, 1, 1)  # 00:00
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=0.0, symbol="EURUSD")
     assert decision == "WAIT"
-    assert votes == {"tech": 1, "time": 0, "ai": 0}
-    assert reason == "time_wait"
+    assert votes == {"tech": 1}
+    assert reason == "timeonly_wait"
 
 
 def test_decision_agent_majority_and_tie() -> None:
@@ -25,19 +25,19 @@ def test_decision_agent_majority_and_tie() -> None:
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=2.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "BUY",
-        {"tech": 1, "time": 1, "ai": 0},
+        {"tech": 1, "time": 1},
         "buy_majority",
     )
     decision, votes, reason = agent.decide(ts, tech_signal=-1, value=-2.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "SELL",
-        {"tech": -1, "time": -1, "ai": 0},
+        {"tech": -1, "time": -1},
         "sell_majority",
     )
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=-2.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "WAIT",
-        {"tech": 1, "time": -1, "ai": 0},
+        {"tech": 1, "time": -1},
         "no_consensus",
     )
 
@@ -49,7 +49,7 @@ def test_decision_agent_respects_confluence_threshold() -> None:
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=0.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "WAIT",
-        {"tech": 1, "time": 0, "ai": 0},
+        {"tech": 1},
         "no_consensus",
     )
 
@@ -58,7 +58,7 @@ def test_decision_agent_respects_confluence_threshold() -> None:
     decision, votes, reason = agent2.decide(ts, tech_signal=1, value=2.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "BUY",
-        {"tech": 1, "time": 1, "ai": 0},
+        {"tech": 1, "time": 1},
         "buy_majority",
     )
 
@@ -71,7 +71,7 @@ def test_decision_agent_accepts_mapping_and_dataclass() -> None:
     res = agent.decide(ts, tech_signal=mapping_signal, value=0.0, symbol="EURUSD")
     assert (res.decision, res.votes, res.reason, res.weight) == (
         "BUY",
-        {"tech": 1, "time": 0, "ai": 0},
+        {"tech": 1},
         "buy_majority",
         1.0,
     )
@@ -80,9 +80,9 @@ def test_decision_agent_accepts_mapping_and_dataclass() -> None:
     res2 = agent.decide(ts, tech_signal=sig, value=0.0, symbol="EURUSD")
     assert (res2.decision, res2.votes, res2.reason, res2.weight) == (
         "SELL",
-        {"tech": -1, "time": 0, "ai": 0},
+        {"tech": -1},
         "sell_majority",
-        1.5,
+        1.0,
     )
 
 
@@ -90,22 +90,22 @@ def test_decision_agent_accepts_string_actions() -> None:
     ts = datetime(2024, 1, 1)
     agent = DecisionAgent()
 
-    mapping_signal = {"action": "BUY", "technical_score": 2.0, "confidence_tech": 0.5}
+    mapping_signal = {"action": "BUY", "technical_score": 2.0, "confidence_tech": 1.0}
     res = agent.decide(ts, tech_signal=mapping_signal, value=0.0, symbol="EURUSD")
     assert (res.decision, res.votes, res.reason, res.weight) == (
         "BUY",
-        {"tech": 1, "time": 0, "ai": 0},
+        {"tech": 1},
         "buy_majority",
         1.0,
     )
 
-    sig = TechnicalSignal(action="SELL", technical_score=-3.0, confidence_tech=0.5)
+    sig = TechnicalSignal(action="SELL", technical_score=-3.0, confidence_tech=1.0)
     res2 = agent.decide(ts, tech_signal=sig, value=0.0, symbol="EURUSD")
     assert (res2.decision, res2.votes, res2.reason, res2.weight) == (
         "SELL",
-        {"tech": -1, "time": 0, "ai": 0},
+        {"tech": -1},
         "sell_majority",
-        1.5,
+        1.0,
     )
 
 
@@ -123,7 +123,7 @@ def test_decision_agent_handles_custom_dataclass_with_string_action() -> None:
     res = agent.decide(ts, tech_signal=sig, value=0.0, symbol="EURUSD")
     assert (res.decision, res.votes, res.reason, res.weight) == (
         "BUY",
-        {"tech": 1, "time": 0, "ai": 0},
+        {"tech": 1},
         "buy_majority",
         1.0,
     )

--- a/tests/test_decision_fusion_min_confluence.py
+++ b/tests/test_decision_fusion_min_confluence.py
@@ -21,8 +21,8 @@ def test_wait_short_circuit() -> None:
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "WAIT",
-        {"tech": 1, "time": 0, "ai": 0},
-        "time_wait",
+        {"tech": 1},
+        "timeonly_wait",
     )
 
 
@@ -33,13 +33,13 @@ def test_min_confluence_requires_both_votes() -> None:
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "BUY",
-        {"tech": 1, "time": 1, "ai": 0},
+        {"tech": 1, "time": 1},
         "buy_majority",
     )
     decision, votes, reason = agent.decide(ts, tech_signal=0, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "WAIT",
-        {"tech": 0, "time": 1, "ai": 0},
+        {"tech": 0, "time": 1},
         "no_consensus",
     )
 
@@ -51,7 +51,7 @@ def test_min_confluence_sell_and_conflict_without_ai() -> None:
     decision, votes, reason = agent_sell.decide(ts, tech_signal=-1, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "SELL",
-        {"tech": -1, "time": -1, "ai": 0},
+        {"tech": -1, "time": -1},
         "sell_majority",
     )
     tm_buy = DummyTimeModel("BUY")
@@ -59,14 +59,17 @@ def test_min_confluence_sell_and_conflict_without_ai() -> None:
     decision, votes, reason = agent_conflict.decide(ts, tech_signal=-1, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "WAIT",
-        {"tech": -1, "time": 1, "ai": 0},
+        {"tech": -1, "time": 1},
         "no_consensus",
     )
 
 
+from dataclasses import dataclass
+
+
+@dataclass
 class DummySentiment:
-    def __init__(self, score: float) -> None:
-        self.score = score
+    score: float
 
 
 class DummyAI:
@@ -85,7 +88,7 @@ def test_min_confluence_with_ai() -> None:
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "BUY",
-        {"tech": 1, "time": 0, "ai": 1},
+        {"tech": 1, "ai": 1},
         "buy_majority",
     )
 
@@ -93,7 +96,7 @@ def test_min_confluence_with_ai() -> None:
     decision, votes, reason = agent.decide(ts, tech_signal=-1, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "SELL",
-        {"tech": -1, "time": 0, "ai": -1},
+        {"tech": -1, "ai": -1},
         "sell_majority",
     )
 
@@ -101,6 +104,6 @@ def test_min_confluence_with_ai() -> None:
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "WAIT",
-        {"tech": 1, "time": 0, "ai": -1},
+        {"tech": 1, "ai": -1},
         "no_consensus",
     )

--- a/tests/test_decision_fusion_min_confluence.py
+++ b/tests/test_decision_fusion_min_confluence.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal
 
@@ -62,9 +63,6 @@ def test_min_confluence_sell_and_conflict_without_ai() -> None:
         {"tech": -1, "time": 1},
         "no_consensus",
     )
-
-
-from dataclasses import dataclass
 
 
 @dataclass

--- a/tests/test_decision_fusion_tie.py
+++ b/tests/test_decision_fusion_tie.py
@@ -19,6 +19,6 @@ def test_min_confluence_conflicting_votes_wait() -> None:
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "WAIT",
-        {"tech": 1, "time": -1, "ai": 0},
+        {"tech": 1, "time": -1},
         "no_consensus",
     )

--- a/tests/test_timeonly_decision_agent.py
+++ b/tests/test_timeonly_decision_agent.py
@@ -21,7 +21,7 @@ class FakeTimeModel:
         ("WAIT", 1, "WAIT"),
         ("BUY", 1, "BUY"),
         ("SELL", -1, "SELL"),
-        ("BUY", -1, "SELL"),  # tech signal stronger
+        ("BUY", -1, "WAIT"),
     ],
 )
 def test_timeonly_decision_agent(time_sig: str, tech_sig: int, expected: str) -> None:
@@ -30,5 +30,5 @@ def test_timeonly_decision_agent(time_sig: str, tech_sig: int, expected: str) ->
     agent = DecisionAgent(config=DecisionConfig(min_confluence=1.0, time_model=fake))
     res = agent.decide(ts, tech_signal=tech_sig, value=100.0, symbol="EURUSD")
     assert res.decision == expected
-    exp_weight = 0.0 if expected == "WAIT" else (0.5 if time_sig == expected else 1.0)
+    exp_weight = 0.0 if expected == "WAIT" else 1.0
     assert res.weight == pytest.approx(exp_weight)


### PR DESCRIPTION
## Summary
- return early when time-only model yields WAIT and weight time votes via config
- add `_normalize_ai_input` and unify decision voting as a list
- update decision agent tests for new vote semantics

## Testing
- `python -m black --check src/forest5/decision.py`
- `python -m ruff check src/forest5/decision.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab68056bd88326a0a76fd91bf6a3f4