### PR TITLE
Run TimeOnly before tech normalization

### DIFF
--- a/src/forest5/decision.py
+++ b/src/forest5/decision.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, is_dataclass
+from dataclasses import dataclass, is_dataclass
 from types import SimpleNamespace
 from typing import Any, Literal, Mapping
 
@@ -252,8 +252,6 @@ class DecisionAgent:
     ) -> DecisionResult:
         votes: list[DecisionVote] = []
 
-        votes.append(_normalize_tech_input(tech_signal, self.config))
-
         if self.config.time_model:
             tm_res = self.config.time_model.decide(ts, value)
             if isinstance(tm_res, tuple):
@@ -261,12 +259,7 @@ class DecisionAgent:
             else:
                 tm_decision, tm_weight = tm_res, 1.0
             if tm_decision == "WAIT":
-                return DecisionResult(
-                    "WAIT",
-                    0.0,
-                    "timeonly_wait",
-                    {v.source: asdict(v) for v in votes},
-                )
+                return DecisionResult("WAIT", 0.0, "timeonly_wait")
             w_time = getattr(
                 getattr(getattr(self.config, "decision", object()), "weights", object()),
                 "time",
@@ -280,6 +273,8 @@ class DecisionAgent:
                     score=float(tm_weight),
                 )
             )
+
+        votes.append(_normalize_tech_input(tech_signal, self.config))
 
         if self.ai:
             ai_sent = self.ai.analyse(context_text, symbol)

--- a/tests/test_decision_agent.py
+++ b/tests/test_decision_agent.py
@@ -13,7 +13,7 @@ def test_decision_agent_waits_when_time_model_waits() -> None:
     ts = datetime(2024, 1, 1)  # 00:00
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=0.0, symbol="EURUSD")
     assert decision == "WAIT"
-    assert votes == {"tech": 1}
+    assert votes == {}
     assert reason == "timeonly_wait"
 
 

--- a/tests/test_decision_fusion_min_confluence.py
+++ b/tests/test_decision_fusion_min_confluence.py
@@ -22,7 +22,7 @@ def test_wait_short_circuit() -> None:
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "WAIT",
-        {"tech": 1},
+        {},
         "timeonly_wait",
     )
 


### PR DESCRIPTION
## Summary
- Trigger the TimeOnly model before processing other signals; return `WAIT` immediately when it signals `WAIT`.
- Normalize technical, optional AI, and time signals into vote list and fuse via `_fuse_votes`.
- Preserve tuple-style destructuring of `DecisionResult`.

## Testing
- `pre-commit run --files src/forest5/decision.py tests/test_decision_agent.py tests/test_decision_fusion_min_confluence.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab6d9100e883269ad76d0a7cb5a0f4