### PR TITLE
feat: extend decision settings

### DIFF
--- a/config/live.example.yaml
+++ b/config/live.example.yaml
@@ -16,10 +16,16 @@ ai:
   model: "gpt-4o-mini"
   max_tokens: 200
   context_file: "context.txt"  # use absolute path; on Windows/Wine use Z:\\path\\to\\context.txt
-
 decision:
-  min_confluence: 2  # number of indicators that must agree; lower values may create false signals
-
+  min_confluence: 0.0
+  tie_epsilon: 0.05
+  weights:
+    tech: 1.0
+    ai: 0.75
+  tech:
+    default_conf_int: 0.50
+    conf_floor: 0.10
+    conf_cap: 1.00
 time:
   model:
     enabled: false  # true when using a trained time filter model

--- a/src/forest5/config_live.py
+++ b/src/forest5/config_live.py
@@ -33,8 +33,22 @@ class BrokerSettings(BaseModel):
         return Path(v)
 
 
+class DecisionTechSettings(BaseModel):
+    default_conf_int: float = 1.0
+    conf_floor: float = 0.0
+    conf_cap: float = 1.0
+
+
+class DecisionWeights(BaseModel):
+    tech: float = 1.0
+    ai: float = 1.0
+
+
 class DecisionSettings(BaseModel):
-    min_confluence: float = 1.0
+    min_confluence: float = 0.0
+    tie_epsilon: float = 0.05
+    weights: DecisionWeights = Field(default_factory=DecisionWeights)
+    tech: DecisionTechSettings = Field(default_factory=DecisionTechSettings)
 
 
 class LiveTimeModelSettings(BaseModel):
@@ -89,6 +103,8 @@ class LiveSettings(BaseModel):
 __all__ = [
     "BrokerSettings",
     "StrategySettings",
+    "DecisionTechSettings",
+    "DecisionWeights",
     "DecisionSettings",
     "LiveTimeModelSettings",
     "PatternToggle",

--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -172,6 +172,9 @@ def run_live(
             ai_max_tokens=settings.ai.max_tokens,
             time_model=time_model,
             min_confluence=settings.decision.min_confluence,
+            tie_epsilon=settings.decision.tie_epsilon,
+            weights=settings.decision.weights,
+            tech=settings.decision.tech,
         ),
     )
 

--- a/tests/test_live_example_yaml_shape.py
+++ b/tests/test_live_example_yaml_shape.py
@@ -9,7 +9,7 @@ def test_live_example_yaml_parses_and_has_fields():
     assert hasattr(s, "time")  # nosec B101
     assert hasattr(s, "decision")  # nosec B101
     assert getattr(s.decision, "min_confluence", None) is not None  # nosec B101
-    assert int(s.decision.min_confluence) >= 1  # nosec B101
+    assert s.decision.min_confluence >= 0  # nosec B101
     assert hasattr(s.ai, "context_file")  # nosec B101
     tm = s.time.model if hasattr(s.time, "model") else None
     assert tm is not None  # nosec B101


### PR DESCRIPTION
## Summary
- add weighted decision configuration with tie epsilon and confidence controls
- expose new decision settings in Pydantic models and live runner
- adjust live example config and tests

## Testing
- `pre-commit run --files config/live.example.yaml src/forest5/config_live.py src/forest5/decision.py src/forest5/live/live_runner.py tests/test_live_example_yaml_shape.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab72b55b7083269c222f32a926580b