### PR TITLE
docs: describe decision weights and logging fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,32 @@ poetry run forest5 live --config config/live.yaml --paper
 ```
 
 Opcje `--q-low` i `--q-high` pozwalają dostroić kwantyle decyzyjne modelu.
+
+## DecisionAgent i `confidence_tech`
+
+`DecisionAgent` scala głosy z trzech źródeł: sygnału technicznego, modelu
+czasu oraz opcjonalnego agenta AI.  Każdy głos posiada kierunek (`BUY/SELL` lub
+`-1/0/1`) oraz wagę, która decyduje o ostatecznej konfluencji.  Waga głosu
+technicznego może być modulowana przez pole `confidence_tech` zwracane przez
+strategię.  Wartość jest przycinana do zakresu zdefiniowanego w
+`decision.tech.conf_floor` i `decision.tech.conf_cap`.  Jeśli strategia nie
+zwróci `confidence_tech`, użyta zostanie wartość
+`decision.tech.default_conf_int`.
+
+Globalne wagi dla poszczególnych źródeł ustawia się w sekcji
+`decision.weights`:
+
+```yaml
+decision:
+  weights:
+    tech: 1.0   # sygnał techniczny
+    ai: 1.0     # agent AI
+    time: 1.0   # model czasu
+  tech:
+    default_conf_int: 1.0
+    conf_floor: 0.0
+    conf_cap: 1.0
+```
+
+Zmniejszenie wag lub zawężenie przedziału `confidence_tech` pozwala
+kontrolować wpływ poszczególnych źródeł na końcową decyzję.

--- a/docs/15_logging_schema.json
+++ b/docs/15_logging_schema.json
@@ -12,7 +12,27 @@
     "price": {"type": "number"},
     "latency_ms": {"type": "number"},
     "error": {"type": ["string", "null"]},
-    "context": {"type": ["object", "null"]}
+    "context": {"type": ["object", "null"]},
+    "decision": {
+      "type": ["object", "null"],
+      "properties": {
+        "votes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "source": {"type": "string"},
+              "direction": {"type": ["string", "number"]},
+              "weight": {"type": "number"},
+              "score": {"type": "number"}
+            },
+            "required": ["source", "direction", "weight", "score"]
+          }
+        },
+        "weight_sum": {"type": "number"}
+      },
+      "required": ["votes", "weight_sum"]
+    }
   },
   "required": [
     "timestamp",


### PR DESCRIPTION
## Summary
- document DecisionAgent, `confidence_tech`, and configuration for `decision.weights` and `decision.tech.*`
- extend logging schema with `decision.votes` and `weight_sum`

## Testing
- `pre-commit run --files README.md docs/15_logging_schema.json`

------
https://chatgpt.com/codex/tasks/task_e_68ab77d336708326b0df7f23426a7242