### PR TITLE
Ensure DecisionResult iterability and use weight_sum

### DIFF
--- a/src/forest5/decision.py
+++ b/src/forest5/decision.py
@@ -84,10 +84,14 @@ class DecisionResult:
                 out[k] = v  # type: ignore[assignment]
         return out
 
-    def __iter__(self):  # pragma: no cover - tiny helper
-        yield self.action
-        yield self.votes
-        yield self.reason
+    def __iter__(self):  # pragma: no cover - legacy helper
+        """Allow unpacking ``decision, votes, reason = result``.
+
+        The second element is a mapping of ``{source: direction}`` extracted from
+        the ``details`` field to retain backward compatibility with older
+        return formats.
+        """
+        return iter((self.action, self.votes, self.reason))
 
 
 def _normalize_action(action: int | float | str) -> int | float:

--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -288,7 +288,7 @@ def run_live(
                             context_text,
                         )
                         decision = dec.decision
-                        weight = dec.weight
+                        weight = dec.weight_sum
                         votes = dec.votes
                         reason = dec.reason
                         log.info(
@@ -358,7 +358,7 @@ def run_live(
                             context_text,
                         )
                         decision = dec.decision
-                        weight = dec.weight
+                        weight = dec.weight_sum
                         votes = dec.votes
                         reason = dec.reason
                         log.info(


### PR DESCRIPTION
## Summary
- allow DecisionResult to be unpacked into `(action, votes, reason)`
- read `DecisionResult.weight_sum` in live runner instead of deprecated alias

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab79824a748326962b17d62b84f28d