### PR TITLE
Add telemetry events for setup lifecycle

### DIFF
--- a/src/forest5/utils/log.py
+++ b/src/forest5/utils/log.py
@@ -14,6 +14,8 @@ import structlog
 # Application setup and lifecycle.
 E_SETUP_ARM = "setup_arm"
 E_SETUP_DONE = "setup_done"
+E_SETUP_TRIGGER = "setup_trigger"
+E_SETUP_EXPIRE = "setup_expire"
 
 # Trading related events.
 E_ORDER_PLACED = "order_placed"
@@ -31,6 +33,7 @@ R_TIMEONLY_WAIT = "timeonly_wait"
 R_TIMEOUT = "timeout"
 R_CANCELLED = "cancelled"
 R_ERROR = "error"
+R_TTL = "ttl"
 
 
 @dataclass(slots=True)
@@ -42,6 +45,9 @@ class TelemetryContext:
     """
 
     run_id: str | None = None
+    symbol: str | None = None
+    timeframe: str | None = None
+    setup_id: str | None = None
     strategy_id: str | None = None
     order_id: str | None = None
 
@@ -76,7 +82,7 @@ def log_event(event: str, ctx: TelemetryContext | None = None, **fields) -> None
     if ctx is not None:
         # Only bind values that are not ``None`` to keep the log output compact.
         logger = logger.bind(**{k: v for k, v in asdict(ctx).items() if v is not None})
-    logger.info(event, event=event, **fields)
+    logger.info(event, **fields)
 
 
 def setup_logger(level: str = "INFO"):


### PR DESCRIPTION
## Summary
- log setup arm/trigger/expire events with structured context
- carry TelemetryContext through setup management
- expand telemetry context and constants for setup lifecycle

## Testing
- `pytest -q`
- `pytest tests/test_setup_registry.py tests/test_engine.py tests/test_h1_ema_rsi_atr_signal.py tests/test_live_runner_paper_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab86fa26b88326987f5d1d1925a0db