### PR TITLE
feat: extend telemetry context with optional fields

### DIFF
--- a/src/forest5/utils/log.py
+++ b/src/forest5/utils/log.py
@@ -44,6 +44,9 @@ class TelemetryContext:
     run_id: str | None = None
     strategy_id: str | None = None
     order_id: str | None = None
+    symbol: str | None = None
+    timeframe: str | None = None
+    strategy: str | None = None
 
 
 def new_id(prefix: str) -> str:

--- a/tests/test_utils_log.py
+++ b/tests/test_utils_log.py
@@ -1,0 +1,58 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+import structlog
+
+spec = spec_from_file_location(
+    "log", Path(__file__).resolve().parents[1] / "src/forest5/utils/log.py"
+)
+log = module_from_spec(spec)
+sys.modules[spec.name] = log
+spec.loader.exec_module(log)  # type: ignore[misc]
+
+E_ORDER_PLACED = log.E_ORDER_PLACED
+TelemetryContext = log.TelemetryContext
+log_event = log.log_event
+
+
+class DummyLogger:
+    def __init__(self):
+        self.bound = {}
+        self.records = []
+
+    def bind(self, **kwargs):
+        self.bound.update(kwargs)
+        return self
+
+    def info(self, *args, **fields):
+        event = args[0] if args else fields.pop("event")
+        fields.pop("event", None)
+        record = {"event": event, **self.bound, **fields}
+        self.records.append(record)
+
+
+def test_log_event_binds_only_non_none_fields():
+    logger = DummyLogger()
+    orig_get_logger = structlog.get_logger
+    structlog.get_logger = lambda: logger
+    try:
+        ctx = TelemetryContext(
+            run_id="run123",
+            strategy_id=None,
+            order_id="order456",
+            symbol="EURUSD",
+            timeframe=None,
+            strategy="rsi",
+        )
+        log_event(E_ORDER_PLACED, ctx, extra="foo")
+    finally:
+        structlog.get_logger = orig_get_logger
+    event = logger.records[0]
+    assert event["run_id"] == "run123"
+    assert "strategy_id" not in event
+    assert event["order_id"] == "order456"
+    assert event["symbol"] == "EURUSD"
+    assert "timeframe" not in event
+    assert event["strategy"] == "rsi"
+    assert event["extra"] == "foo"
+    assert event["event"] == E_ORDER_PLACED


### PR DESCRIPTION
## Summary
- extend TelemetryContext with optional symbol, timeframe, and strategy fields
- test that log_event binds only non-null context fields

## Testing
- `.venv/bin/pre-commit run --files src/forest5/utils/log.py tests/test_utils_log.py`
- `.venv/bin/pytest tests/test_utils_log.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac2a23c82083268bf3386a62d9755b