### PR TITLE
Add telemetry context to signal generation

### DIFF
--- a/src/forest5/signals/factory.py
+++ b/src/forest5/signals/factory.py
@@ -10,6 +10,7 @@ from .ema import ema_cross_signal
 from .macd import macd_cross_signal
 from .h1_ema_rsi_atr import compute_primary_signal_h1
 from .contract import TechnicalSignal
+from ..utils.log import TelemetryContext
 
 
 def compute_signal(
@@ -17,6 +18,7 @@ def compute_signal(
     settings,
     price_col: str = "close",
     compat_int: bool = False,
+    ctx: TelemetryContext | None = None,
 ) -> pd.Series | TechnicalSignal:
     """Generate trading signal without mutating the input settings."""
 


### PR DESCRIPTION
## Summary
- pass TelemetryContext to compute_signal in backtest engine
- allow compute_signal to accept an optional TelemetryContext

## Testing
- `pre-commit run --files src/forest5/backtest/engine.py src/forest5/signals/factory.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac37dac14c8326a9f277a110f9105f