### PR TITLE
Propagate telemetry context to H1 signal computation

### DIFF
--- a/src/forest5/signals/factory.py
+++ b/src/forest5/signals/factory.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import pandas as pd
 
 from ..core.indicators import rsi
 from .candles import candles_signal
@@ -9,17 +8,16 @@ from .combine import apply_rsi_filter, confirm_with_candles
 from .ema import ema_cross_signal
 from .macd import macd_cross_signal
 from .h1_ema_rsi_atr import compute_primary_signal_h1
-from .contract import TechnicalSignal
 from ..utils.log import TelemetryContext
 
 
 def compute_signal(
-    df: pd.DataFrame,
+    df,
     settings,
-    price_col: str = "close",
-    compat_int: bool = False,
+    price_col="close",
+    compat_int=False,
     ctx: TelemetryContext | None = None,
-) -> pd.Series | TechnicalSignal:
+):
     """Generate trading signal without mutating the input settings."""
 
     strategy = copy.deepcopy(settings.strategy)
@@ -59,7 +57,7 @@ def compute_signal(
         return confirm_with_candles(base, candles)
     if name == "h1_ema_rsi_atr":
         params = getattr(strategy, "params", None)
-        res = compute_primary_signal_h1(df, params)
+        res = compute_primary_signal_h1(df, params, ctx=ctx)
         if compat_int:
             from .compat import contract_to_int
 

--- a/src/forest5/signals/h1_ema_rsi_atr.py
+++ b/src/forest5/signals/h1_ema_rsi_atr.py
@@ -25,6 +25,7 @@ import pandas as pd
 from forest5.core.indicators import atr, ema, rsi
 from .contract import TechnicalSignal
 from .setups import SetupRegistry
+from ..utils.log import TelemetryContext
 
 
 _REGISTRY = SetupRegistry()
@@ -65,6 +66,7 @@ def compute_primary_signal_h1(
     df: pd.DataFrame,
     params: Any | None = None,
     registry: SetupRegistry | None = None,
+    ctx: TelemetryContext | None = None,
 ) -> TechnicalSignal:
     """Compute H1 EMA/RSI/ATR signal.
 

--- a/tests/test_signals_factory.py
+++ b/tests/test_signals_factory.py
@@ -144,7 +144,7 @@ def test_compute_signal_passes_contract(monkeypatch):
     s.strategy.name = "h1_ema_rsi_atr"
     fake = TechnicalSignal(action="BUY", entry=1.0, sl=0.5, tp=1.5)
 
-    def _fake(df, params):
+    def _fake(df, params, ctx=None):
         return fake
 
     monkeypatch.setattr("forest5.signals.factory.compute_primary_signal_h1", _fake)


### PR DESCRIPTION
## Summary
- allow passing a telemetry context into `compute_signal`
- forward telemetry context to `compute_primary_signal_h1`
- support the new context parameter in `compute_primary_signal_h1`

## Testing
- `python -m ruff check src/forest5/signals/factory.py src/forest5/signals/h1_ema_rsi_atr.py`
- `python -m ruff check tests/test_signals_factory.py`
- `python -m black --check src/forest5/signals/factory.py src/forest5/signals/h1_ema_rsi_atr.py`
- `python -m black --check tests/test_signals_factory.py`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68ac39bab5f8832687d8bfe0c0d00d2a