### PR TITLE
Store telemetry context with armed setups

### DIFF
--- a/src/forest5/signals/setups.py
+++ b/src/forest5/signals/setups.py
@@ -24,6 +24,7 @@ class SetupCandidate(TechnicalSignal):
 class _ArmedSetup:
     signal: TechnicalSignal
     expiry: int
+    ctx: TelemetryContext | None = None
 
 
 class SetupRegistry:
@@ -44,6 +45,7 @@ class SetupRegistry:
         key: str,
         index: int,
         signal: TechnicalSignal,
+        *,
         ctx: TelemetryContext | None = None,
     ) -> None:
         """Store ``signal`` and arm it for the next bar.
@@ -60,7 +62,9 @@ class SetupRegistry:
             execute upon breakout.
         """
 
-        self._setups[key] = _ArmedSetup(signal=signal, expiry=index + self.ttl_bars)
+        self._setups[key] = _ArmedSetup(
+            signal=signal, expiry=index + self.ttl_bars, ctx=ctx
+        )
         if ctx is not None:
             log_event(E_SETUP_ARM, ctx=ctx, key=key, index=index, action=signal.action)
 

--- a/src/forest5/signals/setups.py
+++ b/src/forest5/signals/setups.py
@@ -62,9 +62,7 @@ class SetupRegistry:
             execute upon breakout.
         """
 
-        self._setups[key] = _ArmedSetup(
-            signal=signal, expiry=index + self.ttl_bars, ctx=ctx
-        )
+        self._setups[key] = _ArmedSetup(signal=signal, expiry=index + self.ttl_bars, ctx=ctx)
         if ctx is not None:
             log_event(E_SETUP_ARM, ctx=ctx, key=key, index=index, action=signal.action)
 


### PR DESCRIPTION
## Summary
- allow SetupRegistry to capture telemetry context when arming

## Testing
- `pytest tests/test_setup_registry.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac3f18a928832698c822fc3055bb90