### PR TITLE
Refactor SetupRegistry arm usage in live runner

### DIFF
--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -251,8 +251,6 @@ def run_live(
                         if sig != 0:
                             action = "BUY" if sig > 0 else "SELL"
                             registry.arm(
-                                settings.broker.symbol,
-                                len(df) - 1,
                                 TechnicalSignal(
                                     timeframe=tf,
                                     action=action,
@@ -261,6 +259,8 @@ def run_live(
                                     technical_score=1.0 if action == "BUY" else -1.0,
                                     confidence_tech=1.0,
                                 ),
+                                expiry=len(df),
+                                ctx=None,
                             )
 
                         current_bar = {

--- a/tests/test_live_runner_paper_smoke.py
+++ b/tests/test_live_runner_paper_smoke.py
@@ -69,7 +69,7 @@ def test_triggered_setup_executes(tmp_path: Path, capfd, monkeypatch):
         def __init__(self, *args, **kwargs):
             self.armed = False
 
-        def arm(self, key, index, signal):
+        def arm(self, signal, *, expiry=None, ctx=None):
             self.armed = True
 
         def check(self, key, index, high, low):
@@ -126,7 +126,7 @@ def test_setup_expires_without_trigger(tmp_path: Path, capfd, monkeypatch):
         def __init__(self, *args, **kwargs):
             pass
 
-        def arm(self, key, index, signal):
+        def arm(self, signal, *, expiry=None, ctx=None):
             pass
 
         def check(self, key, index, high, low):


### PR DESCRIPTION
## Summary
- update live runner to call `SetupRegistry.arm` with explicit expiry and context per new API
- adjust paper smoke tests to use the revised `SetupRegistry.arm` signature

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac4293dbd4832680acb1ef62e0069d