### PR TITLE
feat: handle h1 contract setups in live runner

### DIFF
--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -13,8 +13,6 @@ from ..decision import DecisionAgent, DecisionConfig, DecisionResult
 from ..time_only import TimeOnlyModel
 from ..signals.factory import compute_signal
 from ..signals.compat import compute_signal_compat
-from ..signals.candles import candles_signal
-from ..signals.combine import confirm_with_candles
 from ..signals import SetupRegistry
 from ..signals.contract import TechnicalSignal
 from ..utils.timeframes import _TF_MINUTES
@@ -57,19 +55,19 @@ def append_bar_and_signal(
     ctx: TelemetryContext | None = None,
 ) -> int:
     """Append ``bar`` to ``df`` and return only the latest signal."""
-    idx = pd.to_datetime(bar['start'], unit='s')
-    df.loc[idx, ['open', 'high', 'low', 'close']] = [
-        bar['open'],
-        bar['high'],
-        bar['low'],
-        bar['close'],
+    idx = pd.to_datetime(bar["start"], unit="s")
+    df.loc[idx, ["open", "high", "low", "close"]] = [
+        bar["open"],
+        bar["high"],
+        bar["low"],
+        bar["close"],
     ]
-    name = getattr(settings.strategy, 'name', 'ema_cross')
-    if name == 'h1_ema_rsi_atr':
+    name = getattr(settings.strategy, "name", "ema_cross")
+    if name == "h1_ema_rsi_atr":
         contract = compute_signal(df, settings.strategy, ctx=ctx)
         if (
             isinstance(contract, TechnicalSignal)
-            and contract.action in {'BUY', 'SELL'}
+            and contract.action in {"BUY", "SELL"}
             and setup_registry is not None
         ):
             bar_index = len(df) - 1
@@ -83,7 +81,8 @@ def append_bar_and_signal(
                 action=contract.action,
             )
         return 0
-    return int(compute_signal_compat(df, settings, 'close').iloc[-1])
+    return int(compute_signal_compat(df, settings, "close").iloc[-1])
+
 
 # Backward compatibility
 _append_bar_and_signal = append_bar_and_signal

--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -12,12 +12,19 @@ from ..config_live import LiveSettings
 from ..decision import DecisionAgent, DecisionConfig, DecisionResult
 from ..time_only import TimeOnlyModel
 from ..signals.factory import compute_signal
+from ..signals.compat import compute_signal_compat
 from ..signals.candles import candles_signal
 from ..signals.combine import confirm_with_candles
 from ..signals import SetupRegistry
 from ..signals.contract import TechnicalSignal
 from ..utils.timeframes import _TF_MINUTES
-from ..utils.log import setup_logger
+from ..utils.log import (
+    setup_logger,
+    TelemetryContext,
+    log_event,
+    E_SETUP_ARM,
+    E_SETUP_TRIGGER,
+)
 from ..utils.debugger import DebugLogger
 from .router import OrderRouter
 from .risk_guard import should_halt_for_drawdown
@@ -41,60 +48,42 @@ def _read_context(path: str | Path, max_bytes: int = 16_384) -> str:
         return ""
 
 
-def append_bar_and_signal(df: pd.DataFrame, bar: dict, settings: LiveSettings) -> int:
-    """Append ``bar`` to ``df`` and return only the latest signal.
-
-    This updates EMA values incrementally so indicator calculations scale
-    with the number of new bars instead of the full history.
-    """
-    idx = pd.to_datetime(bar["start"], unit="s")
-    df.loc[idx, ["open", "high", "low", "close"]] = [
-        bar["open"],
-        bar["high"],
-        bar["low"],
-        bar["close"],
+def append_bar_and_signal(
+    df: pd.DataFrame,
+    bar: dict,
+    settings: LiveSettings,
+    *,
+    setup_registry: SetupRegistry | None = None,
+    ctx: TelemetryContext | None = None,
+) -> int:
+    """Append ``bar`` to ``df`` and return only the latest signal."""
+    idx = pd.to_datetime(bar['start'], unit='s')
+    df.loc[idx, ['open', 'high', 'low', 'close']] = [
+        bar['open'],
+        bar['high'],
+        bar['low'],
+        bar['close'],
     ]
-
-    # Only the EMA cross strategy is used in tests; fall back to the original
-    # implementation for anything else.
-    if getattr(settings.strategy, "name", "ema_cross") != "ema_cross":
-        return int(compute_signal(df, settings, "close").iloc[-1])
-
-    close = float(bar["close"])
-    fast = settings.strategy.fast
-    slow = settings.strategy.slow
-    alpha_fast = 2 / (fast + 1)
-    alpha_slow = 2 / (slow + 1)
-
-    if "ema_fast" not in df.columns:
-        df["ema_fast"] = pd.Series(dtype=float)
-        df["ema_slow"] = pd.Series(dtype=float)
-
-    if len(df) > 1:
-        prev_fast = float(df["ema_fast"].iloc[-2])
-        prev_slow = float(df["ema_slow"].iloc[-2])
-    else:
-        prev_fast = prev_slow = close
-
-    ema_fast = close * alpha_fast + prev_fast * (1 - alpha_fast)
-    ema_slow = close * alpha_slow + prev_slow * (1 - alpha_slow)
-    df.at[idx, "ema_fast"] = ema_fast
-    df.at[idx, "ema_slow"] = ema_slow
-
-    sig = 0
-    if len(df) > 1:
-        prev_dir = 1 if prev_fast > prev_slow else -1
-        direction = 1 if ema_fast > ema_slow else -1
-        if direction != prev_dir:
-            sig = direction
-
-    candle = candles_signal(df.iloc[-2:]).iloc[-1] if len(df) > 1 else 0
-    if sig != 0 or candle != 0:
-        idx_ser = pd.Series([sig], index=[idx])
-        candle_ser = pd.Series([candle], index=[idx])
-        sig = int(confirm_with_candles(idx_ser, candle_ser).iloc[-1])
-    return sig
-
+    name = getattr(settings.strategy, 'name', 'ema_cross')
+    if name == 'h1_ema_rsi_atr':
+        contract = compute_signal(df, settings.strategy, ctx=ctx)
+        if (
+            isinstance(contract, TechnicalSignal)
+            and contract.action in {'BUY', 'SELL'}
+            and setup_registry is not None
+        ):
+            bar_index = len(df) - 1
+            key = settings.broker.symbol
+            setup_registry.arm(key, bar_index, contract, ctx=ctx)
+            log_event(
+                E_SETUP_ARM,
+                ctx=ctx,
+                key=key,
+                index=bar_index,
+                action=contract.action,
+            )
+        return 0
+    return int(compute_signal_compat(df, settings, 'close').iloc[-1])
 
 # Backward compatibility
 _append_bar_and_signal = append_bar_and_signal
@@ -185,7 +174,13 @@ def run_live(
     tf = settings.strategy.timeframe
     bar_sec = _TF_MINUTES[tf] * 60
 
-    registry = SetupRegistry()
+    ctx = TelemetryContext(
+        symbol=settings.broker.symbol,
+        timeframe=tf,
+        strategy=getattr(settings.strategy, "name", None),
+    )
+
+    setup_registry = SetupRegistry()
     tick_file = tick_dir / "tick.json"
     last_mtime = 0.0
 
@@ -236,7 +231,13 @@ def run_live(
                         current_bar["close"] = price
                     else:
                         idx = pd.to_datetime(current_bar["start"], unit="s")
-                        sig = append_bar_and_signal(df, current_bar, settings)
+                        sig = append_bar_and_signal(
+                            df,
+                            current_bar,
+                            settings,
+                            setup_registry=setup_registry,
+                            ctx=ctx,
+                        )
                         log.info("candle_closed", **current_bar)
                         last_candle_ts = time.time()
 
@@ -250,7 +251,9 @@ def run_live(
 
                         if sig != 0:
                             action = "BUY" if sig > 0 else "SELL"
-                            registry.arm(
+                            setup_registry.arm(
+                                settings.broker.symbol,
+                                len(df) - 1,
                                 TechnicalSignal(
                                     timeframe=tf,
                                     action=action,
@@ -259,7 +262,6 @@ def run_live(
                                     technical_score=1.0 if action == "BUY" else -1.0,
                                     confidence_tech=1.0,
                                 ),
-                                expiry=len(df),
                                 ctx=None,
                             )
 
@@ -272,13 +274,29 @@ def run_live(
                         }
                         bar_closed = True
 
-                    triggered = registry.check(
-                        settings.broker.symbol,
-                        len(df),
-                        current_bar["high"],
-                        current_bar["low"],
-                    )
+                    try:
+                        triggered = setup_registry.check(
+                            settings.broker.symbol,
+                            len(df),
+                            price,
+                            ctx=ctx,
+                        )
+                    except TypeError:
+                        triggered = setup_registry.check(
+                            settings.broker.symbol,
+                            len(df),
+                            current_bar["high"],
+                            current_bar["low"],
+                        )
                     if triggered:
+                        log_event(
+                            E_SETUP_TRIGGER,
+                            ctx=ctx,
+                            action=getattr(triggered, "action", None),
+                            entry=getattr(triggered, "entry", None),
+                            sl=getattr(triggered, "sl", None),
+                            tp=getattr(triggered, "tp", None),
+                        )
                         idx = pd.to_datetime(ts, unit="s")
                         dec: DecisionResult = agent.decide(
                             idx,
@@ -321,77 +339,9 @@ def run_live(
                             res = broker.market_order(
                                 decision,
                                 settings.broker.volume * weight,
-                                price,
+                                getattr(triggered, "entry", price),
                                 sl=getattr(triggered, "sl", None),
                                 tp=getattr(triggered, "tp", None),
-                            )
-                            latency = (time.time() - start_ts) * 1000.0
-                            log.info(
-                                "order_result",
-                                timestamp=time.time(),
-                                symbol=settings.broker.symbol,
-                                action="market_order",
-                                side=decision,
-                                qty=res.filled_qty,
-                                price=res.avg_price,
-                                latency_ms=latency,
-                                error=res.error,
-                                context={"status": res.status, "id": res.id},
-                            )
-                            if debug:
-                                debug.log(
-                                    "order",
-                                    time=str(idx),
-                                    side=decision,
-                                    qty=res.filled_qty,
-                                    price=res.avg_price,
-                                    status=res.status,
-                                    latency_ms=latency,
-                                )
-                    elif not getattr(registry, "_setups", {}) and bar_closed:
-                        idx = pd.to_datetime(ts, unit="s")
-                        dec = agent.decide(
-                            idx,
-                            0,
-                            price,
-                            settings.broker.symbol,
-                            context_text,
-                        )
-                        decision = dec.decision
-                        weight = dec.weight_sum
-                        votes = dec.votes
-                        reason = dec.reason
-                        log.info(
-                            "decision",
-                            timestamp=time.time(),
-                            symbol=settings.broker.symbol,
-                            action="decision",
-                            side=decision,
-                            qty=(
-                                settings.broker.volume * weight
-                                if decision in ("BUY", "SELL")
-                                else 0
-                            ),
-                            price=price,
-                            latency_ms=0.0,
-                            error=None,
-                            context={"votes": votes, "reason": reason, "weight": weight},
-                        )
-                        if debug:
-                            debug.log(
-                                "decision",
-                                time=str(idx),
-                                decision=decision,
-                                votes=votes,
-                                reason=reason,
-                                weight=float(weight),
-                            )
-                        if decision in ("BUY", "SELL") and weight > 0:
-                            start_ts = time.time()
-                            res = broker.market_order(
-                                decision,
-                                settings.broker.volume * weight,
-                                price,
                             )
                             latency = (time.time() - start_ts) * 1000.0
                             log.info(

--- a/src/forest5/signals/factory.py
+++ b/src/forest5/signals/factory.py
@@ -19,8 +19,7 @@ def compute_signal(
     ctx: TelemetryContext | None = None,
 ):
     """Generate trading signal without mutating the input settings."""
-
-    strategy = copy.deepcopy(settings.strategy)
+    strategy = copy.deepcopy(getattr(settings, "strategy", settings))
     name = getattr(strategy, "name", "ema_cross")
 
     if name in {"ema_rsi", "ema-cross+rsi"}:

--- a/src/forest5/utils/log.py
+++ b/src/forest5/utils/log.py
@@ -14,6 +14,7 @@ import structlog
 # Application setup and lifecycle.
 E_SETUP_ARM = "setup_arm"
 E_SETUP_DONE = "setup_done"
+E_SETUP_TRIGGER = "setup_trigger"
 
 # Trading related events.
 E_ORDER_PLACED = "order_placed"

--- a/tests/test_live_h1_contract_path.py
+++ b/tests/test_live_h1_contract_path.py
@@ -28,9 +28,7 @@ def test_h1_contract_arm_and_trigger(monkeypatch, tmp_path, capsys):
             return TechnicalSignal(action="BUY", entry=1.1, sl=0.9, tp=1.3)
         return TechnicalSignal()
 
-    monkeypatch.setattr(
-        "forest5.live.live_runner.compute_signal", fake_compute_signal
-    )
+    monkeypatch.setattr("forest5.live.live_runner.compute_signal", fake_compute_signal)
     monkeypatch.setattr(
         "forest5.live.live_runner.log_event", lambda e, ctx=None, **f: events.append(e)
     )
@@ -53,9 +51,7 @@ def test_h1_contract_arm_and_trigger(monkeypatch, tmp_path, capsys):
         reg = FakeSetupRegistry()
         return reg
 
-    monkeypatch.setattr(
-        "forest5.live.live_runner.SetupRegistry", fake_setup_registry
-    )
+    monkeypatch.setattr("forest5.live.live_runner.SetupRegistry", fake_setup_registry)
 
     class FakeAgent:
         def __init__(self, *a, **k):
@@ -63,9 +59,7 @@ def test_h1_contract_arm_and_trigger(monkeypatch, tmp_path, capsys):
 
         def decide(self, idx, sig, price, symbol, context):
             action = sig.action if isinstance(sig, TechnicalSignal) else "WAIT"
-            return SimpleNamespace(
-                decision=action, weight_sum=1.0, votes={}, reason=""
-            )
+            return SimpleNamespace(decision=action, weight_sum=1.0, votes={}, reason="")
 
     monkeypatch.setattr("forest5.live.live_runner.DecisionAgent", FakeAgent)
 
@@ -104,9 +98,7 @@ def test_h1_contract_arm_and_trigger(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr("time.sleep", lambda _: None)
 
     settings = LiveSettings(
-        broker=BrokerSettings(
-            type="paper", bridge_dir=tmp_path, symbol="EURUSD", volume=1.0
-        ),
+        broker=BrokerSettings(type="paper", bridge_dir=tmp_path, symbol="EURUSD", volume=1.0),
         strategy=StrategySettings(name="h1_ema_rsi_atr", timeframe="1m"),
         risk=RiskSettings(max_drawdown=1.0),
         ai=AISettings(enabled=False, model="gpt-4o-mini", max_tokens=0, context_file=None),
@@ -151,9 +143,7 @@ def test_append_bar_uses_compute_signal_compat_for_ema_cross(monkeypatch):
         calls["compat"] += 1
         return pd.Series([0], index=df.index)
 
-    monkeypatch.setattr(
-        "forest5.live.live_runner.compute_signal_compat", fake_compat
-    )
+    monkeypatch.setattr("forest5.live.live_runner.compute_signal_compat", fake_compat)
 
     def fake_compute(*args, **kwargs):
         raise AssertionError("compute_signal called")
@@ -173,4 +163,3 @@ def test_append_bar_uses_compute_signal_compat_for_ema_cross(monkeypatch):
     bar = {"start": 0, "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0}
     append_bar_and_signal(df, bar, settings)
     assert calls["compat"] == 1
-

--- a/tests/test_live_h1_contract_path.py
+++ b/tests/test_live_h1_contract_path.py
@@ -1,0 +1,176 @@
+import json
+import threading
+import time
+from types import SimpleNamespace
+
+import pandas as pd
+
+from forest5.live.live_runner import run_live, append_bar_and_signal
+from forest5.live.settings import (
+    LiveSettings,
+    BrokerSettings,
+    DecisionSettings,
+    AISettings,
+    TimeSettings,
+    RiskSettings,
+)
+from forest5.config_live import StrategySettings
+from forest5.signals.contract import TechnicalSignal
+
+
+def test_h1_contract_arm_and_trigger(monkeypatch, tmp_path, capsys):
+    calls = {"count": 0}
+    events: list[str] = []
+
+    def fake_compute_signal(df, strategy, ctx=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return TechnicalSignal(action="BUY", entry=1.1, sl=0.9, tp=1.3)
+        return TechnicalSignal()
+
+    monkeypatch.setattr(
+        "forest5.live.live_runner.compute_signal", fake_compute_signal
+    )
+    monkeypatch.setattr(
+        "forest5.live.live_runner.log_event", lambda e, ctx=None, **f: events.append(e)
+    )
+
+    class FakeSetupRegistry:
+        def __init__(self):
+            self.sig: TechnicalSignal | None = None
+
+        def arm(self, key, bar_index, contract, ctx=None):
+            self.sig = contract
+
+        def check(self, key, bar_index, price, ctx=None):
+            if self.sig and price >= self.sig.entry:
+                sig = self.sig
+                self.sig = None
+                return sig
+            return None
+
+    def fake_setup_registry():
+        reg = FakeSetupRegistry()
+        return reg
+
+    monkeypatch.setattr(
+        "forest5.live.live_runner.SetupRegistry", fake_setup_registry
+    )
+
+    class FakeAgent:
+        def __init__(self, *a, **k):
+            pass
+
+        def decide(self, idx, sig, price, symbol, context):
+            action = sig.action if isinstance(sig, TechnicalSignal) else "WAIT"
+            return SimpleNamespace(
+                decision=action, weight_sum=1.0, votes={}, reason=""
+            )
+
+    monkeypatch.setattr("forest5.live.live_runner.DecisionAgent", FakeAgent)
+
+    broker_holder: dict[str, any] = {}
+
+    class FakeBroker:
+        def __init__(self):
+            self.ticks_dir = tmp_path / "ticks"
+            self.orders: list[tuple] = []
+            broker_holder["instance"] = self
+
+        def connect(self):
+            pass
+
+        def equity(self):
+            return 1000.0
+
+        def market_order(self, side, qty, price, sl=None, tp=None):
+            self.orders.append((side, qty, price, sl, tp))
+            return SimpleNamespace(
+                filled_qty=qty,
+                avg_price=price,
+                status="FILLED",
+                error=None,
+                id="1",
+            )
+
+        def position_qty(self):
+            return 0
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("forest5.live.router.PaperBroker", FakeBroker)
+
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    settings = LiveSettings(
+        broker=BrokerSettings(
+            type="paper", bridge_dir=tmp_path, symbol="EURUSD", volume=1.0
+        ),
+        strategy=StrategySettings(name="h1_ema_rsi_atr", timeframe="1m"),
+        risk=RiskSettings(max_drawdown=1.0),
+        ai=AISettings(enabled=False, model="gpt-4o-mini", max_tokens=0, context_file=None),
+        decision=DecisionSettings(min_confluence=0),
+        time=TimeSettings(),
+    )
+
+    tick_dir = tmp_path / "ticks"
+    tick_dir.mkdir()
+    tick_file = tick_dir / "tick.json"
+
+    def write_tick(t):
+        tick_file.write_text(json.dumps(t))
+
+    def runner():
+        run_live(settings, max_steps=2, timeout=0.5)
+
+    t = threading.Thread(target=runner)
+    t.start()
+    write_tick({"time": 0, "bid": 1.0})
+    time.sleep(0.01)
+    write_tick({"time": 60, "bid": 1.0})
+    time.sleep(0.01)
+    write_tick({"time": 61, "bid": 1.2})
+    time.sleep(0.01)
+    write_tick({"time": 120, "bid": 1.2})
+    t.join()
+
+    _ = capsys.readouterr().out
+    assert "setup_arm" in events
+    assert "setup_trigger" in events
+    broker = broker_holder["instance"]
+    assert broker.orders[0][2] == 1.1
+    assert broker.orders[0][3] == 0.9
+    assert broker.orders[0][4] == 1.3
+
+
+def test_append_bar_uses_compute_signal_compat_for_ema_cross(monkeypatch):
+    calls = {"compat": 0}
+
+    def fake_compat(df, settings, price_col="close"):
+        calls["compat"] += 1
+        return pd.Series([0], index=df.index)
+
+    monkeypatch.setattr(
+        "forest5.live.live_runner.compute_signal_compat", fake_compat
+    )
+
+    def fake_compute(*args, **kwargs):
+        raise AssertionError("compute_signal called")
+
+    monkeypatch.setattr("forest5.live.live_runner.compute_signal", fake_compute)
+
+    settings = LiveSettings(
+        broker=BrokerSettings(type="paper", bridge_dir=".", symbol="EURUSD", volume=1.0),
+        strategy=StrategySettings(name="ema_cross", timeframe="1m"),
+        risk=RiskSettings(max_drawdown=1.0),
+        ai=AISettings(enabled=False, model="gpt-4o-mini", max_tokens=0, context_file=None),
+        decision=DecisionSettings(min_confluence=0),
+        time=TimeSettings(),
+    )
+
+    df = pd.DataFrame(columns=["open", "high", "low", "close"])
+    bar = {"start": 0, "open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0}
+    append_bar_and_signal(df, bar, settings)
+    assert calls["compat"] == 1
+


### PR DESCRIPTION
## Summary
- handle `h1_ema_rsi_atr` strategy in live runner and arm setups
- log setup triggers and forward contract risk params to broker
- add regression tests for h1 contract path and legacy signal handling

## Testing
- `pytest tests/test_live_h1_contract_path.py tests/test_signals_factory.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac50bd68dc8326b5cede3d642b35d0