### PR TITLE
Add compatibility wrapper for append_bar_and_signal

### DIFF
--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -236,7 +236,18 @@ def run_live(
                         current_bar["close"] = price
                     else:
                         idx = pd.to_datetime(current_bar["start"], unit="s")
-                        sig = append_bar_and_signal(df, current_bar, settings)
+                        setup_registry = registry
+                        ctx = None
+                        try:
+                            sig = append_bar_and_signal(
+                                df,
+                                current_bar,
+                                settings,
+                                setup_registry=setup_registry,
+                                ctx=ctx,
+                            )
+                        except TypeError:
+                            sig = append_bar_and_signal(df, current_bar, settings)
                         log.info("candle_closed", **current_bar)
                         last_candle_ts = time.time()
 


### PR DESCRIPTION
## Summary
- Retry `append_bar_and_signal` with optional `setup_registry` and `ctx`, falling back to legacy signature on `TypeError`

## Testing
- `pytest tests/test_live_runner_paper_smoke.py::test_triggered_setup_executes tests/test_live_runner_paper_smoke.py::test_setup_expires_without_trigger -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac57cf8c008326961714c006dd4db2