### PR TITLE
feat: add triggered setup tracking

### DIFF
--- a/src/forest5/live/setups.py
+++ b/src/forest5/live/setups.py
@@ -1,0 +1,3 @@
+from ..signals.setups import SetupRegistry
+
+__all__ = ["SetupRegistry"]

--- a/src/forest5/signals/h1_ema_rsi_atr.py
+++ b/src/forest5/signals/h1_ema_rsi_atr.py
@@ -87,7 +87,9 @@ def compute_primary_signal_h1(
     high = df["high"]
     low = df["low"]
 
-    triggered = reg.check(p["timeframe"], idx, high.iloc[-1], low.iloc[-1])
+    triggered = reg.check(idx, high.iloc[-1], ctx=ctx)
+    if not triggered:
+        triggered = reg.check(idx, low.iloc[-1], ctx=ctx)
     if triggered:
         return triggered
 

--- a/src/forest5/utils/log.py
+++ b/src/forest5/utils/log.py
@@ -14,6 +14,8 @@ import structlog
 # Application setup and lifecycle.
 E_SETUP_ARM = "setup_arm"
 E_SETUP_DONE = "setup_done"
+E_SETUP_TRIGGER = "setup_trigger"
+E_SETUP_EXPIRE = "setup_expire"
 
 # Trading related events.
 E_ORDER_PLACED = "order_placed"
@@ -79,7 +81,7 @@ def log_event(event: str, ctx: TelemetryContext | None = None, **fields) -> None
     if ctx is not None:
         # Only bind values that are not ``None`` to keep the log output compact.
         logger = logger.bind(**{k: v for k, v in asdict(ctx).items() if v is not None})
-    logger.info(event, event=event, **fields)
+    logger.info(event, **fields)
 
 
 def setup_logger(level: str = "INFO"):

--- a/tests/test_live_h1_contract_path.py
+++ b/tests/test_live_h1_contract_path.py
@@ -51,10 +51,11 @@ def test_h1_contract_arm_and_trigger(tmp_path: Path, monkeypatch):
         def __init__(self, *args, **kwargs):
             self.armed = False
 
-        def arm(self, signal, *, expiry=None, ctx=None):
+        def arm(self, key, index, signal, *, ctx=None):
             self.armed = True
+            return "id"
 
-        def check(self, key, index, high, low):
+        def check(self, index, price, ctx=None):
             if self.armed:
                 self.armed = False
                 return TechnicalSignal(

--- a/tests/test_live_runner_paper_smoke.py
+++ b/tests/test_live_runner_paper_smoke.py
@@ -69,10 +69,11 @@ def test_triggered_setup_executes(tmp_path: Path, capfd, monkeypatch):
         def __init__(self, *args, **kwargs):
             self.armed = False
 
-        def arm(self, signal, *, expiry=None, ctx=None):
+        def arm(self, key, index, signal, *, ctx=None):
             self.armed = True
+            return "id"
 
-        def check(self, key, index, high, low):
+        def check(self, index, price, ctx=None):
             if self.armed:
                 self.armed = False
                 return TechnicalSignal(
@@ -126,10 +127,10 @@ def test_setup_expires_without_trigger(tmp_path: Path, capfd, monkeypatch):
         def __init__(self, *args, **kwargs):
             pass
 
-        def arm(self, signal, *, expiry=None, ctx=None):
-            pass
+        def arm(self, key, index, signal, *, ctx=None):
+            return "id"
 
-        def check(self, key, index, high, low):
+        def check(self, index, price, ctx=None):
             return None
 
     monkeypatch.setattr(live_runner, "SetupRegistry", NoTriggerRegistry)

--- a/tests/test_setup_registry.py
+++ b/tests/test_setup_registry.py
@@ -1,39 +1,40 @@
-from forest5.signals.setups import SetupRegistry
+from forest5.signals.setups import SetupRegistry, TriggeredSignal
 from forest5.signals.contract import TechnicalSignal
 
 
 def test_setup_registry_triggers_and_clears():
     reg = SetupRegistry(ttl_bars=1)
     sig = TechnicalSignal(action="BUY", entry=10.0)
-    reg.arm("tf", 0, sig)
+    setup_id = reg.arm("tf", 0, sig)
     # Trigger on next bar
-    res = reg.check("tf", 1, high=11.0, low=9.0)
-    assert res is sig
+    res = reg.check(1, 11.0)
+    assert isinstance(res, TriggeredSignal)
+    assert res.setup_id == setup_id
     # After triggering it should be removed
-    assert reg.check("tf", 1, high=11.0, low=9.0) is None
+    assert reg.check(1, 11.0) is None
 
 
 def test_setup_registry_expires_without_trigger():
     reg = SetupRegistry(ttl_bars=1)
     sig = TechnicalSignal(action="SELL", entry=5.0)
     reg.arm("tf", 0, sig)
-    # Next bar without breakout expires the setup
-    assert reg.check("tf", 1, high=5.5, low=5.1) is None
-    # Subsequent checks remain empty
-    assert reg.check("tf", 2, high=4.0, low=3.0) is None
+    # Next bar without breakout, no trigger yet
+    assert reg.check(1, 5.5) is None
+    # Subsequent bar expires the setup
+    assert reg.check(2, 4.0) is None
 
 
 def test_setup_registry_gap_fill_triggers():
     reg = SetupRegistry(ttl_bars=1)
     sig = TechnicalSignal(action="BUY", entry=10.0)
     reg.arm("tf", 0, sig)
-    res = reg.check("tf", 1, high=11.0, low=11.0)
-    assert res is sig
+    res = reg.check(1, 11.0)
+    assert isinstance(res, TriggeredSignal)
 
 
 def test_setup_registry_blocked_by_time_removes():
     reg = SetupRegistry(ttl_bars=1)
     sig = TechnicalSignal(action="BUY", entry=10.0)
     reg.arm("tf", 0, sig)
-    _ = reg.check("tf", 1, high=11.0, low=9.0)
-    assert reg.check("tf", 1, high=11.0, low=9.0) is None
+    _ = reg.check(1, 11.0)
+    assert reg.check(1, 11.0) is None


### PR DESCRIPTION
## Summary
- add `TriggeredSignal` to carry setup IDs
- track setup triggering and expiration with logging
- update backtest and live runners to new setup registry API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac604326e083268936b4c41cadfa92