### PR TITLE
feat: boost technical score based on candlestick patterns

### DIFF
--- a/config/live.example.yaml
+++ b/config/live.example.yaml
@@ -47,13 +47,11 @@ time:
         entry_buffer_atr: 0.1
         sl_atr: 1.0
         rr: 2.0
-    patterns:  # candlestick pattern filters; disable any to skip its detector
-      engulf:
-        enabled: true  # disable to ignore engulfing candles
-      pinbar:
-        enabled: true  # disable to ignore pinbar patterns
-      star:
-        enabled: true  # disable to ignore morning/evening star patterns
+    patterns:
+      enabled: true  # enable candlestick pattern boosts
+      min_strength: 0.0
+      boost_conf: 0.1
+      boost_score: 0.2
 
 backtest:
   tp_sl_priority: SL_FIRST   # or TP_FIRST

--- a/src/forest5/config/strategy.py
+++ b/src/forest5/config/strategy.py
@@ -29,14 +29,11 @@ class H1EmaRsiAtrParams(BaseModel):
         return getattr(self, item)
 
 
-class PatternToggle(BaseModel):
-    enabled: bool = True
-
-
-class PatternMetrics(BaseModel):
-    engulf: PatternToggle = Field(default_factory=PatternToggle)
-    pinbar: PatternToggle = Field(default_factory=PatternToggle)
-    star: PatternToggle = Field(default_factory=PatternToggle)
+class PatternSettings(BaseModel):
+    enabled: bool = False
+    min_strength: float = 0.0
+    boost_conf: float = 0.0
+    boost_score: float = 0.0
 
 
 class ProfileSettings(BaseModel):
@@ -54,7 +51,7 @@ class H1EmaRsiAtrSettings(BaseModel):
     name: Literal["h1_ema_rsi_atr"] = "h1_ema_rsi_atr"
     compat_int: int | None = None
     params: H1EmaRsiAtrParams = Field(default_factory=H1EmaRsiAtrParams)
-    patterns: PatternMetrics = Field(default_factory=PatternMetrics)
+    patterns: PatternSettings = Field(default_factory=PatternSettings)
     profile: ProfileSettings = Field(default_factory=ProfileSettings)
     time: TimeModelQuantiles = Field(default_factory=TimeModelQuantiles)
     tp_sl_priority: Literal["SL_FIRST", "TP_FIRST"] = "SL_FIRST"
@@ -126,4 +123,4 @@ class BaseStrategySettings(BaseModel):
         return self
 
 
-__all__ = ["BaseStrategySettings", "H1EmaRsiAtrSettings"]
+__all__ = ["BaseStrategySettings", "H1EmaRsiAtrSettings", "PatternSettings"]

--- a/src/forest5/config_live.py
+++ b/src/forest5/config_live.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from .config import RiskSettings, AISettings
-from .config.strategy import BaseStrategySettings
+from .config.strategy import BaseStrategySettings, PatternSettings
 from .utils.timeframes import normalize_timeframe
 
 
@@ -71,19 +71,9 @@ class LiveTimeModelSettings(BaseModel):
         return self
 
 
-class PatternToggle(BaseModel):
-    enabled: bool = True
-
-
-class PrimaryPatternsSettings(BaseModel):
-    engulf: PatternToggle = Field(default_factory=PatternToggle)
-    pinbar: PatternToggle = Field(default_factory=PatternToggle)
-    star: PatternToggle = Field(default_factory=PatternToggle)
-
-
 class PrimarySignalSettings(BaseModel):
     strategy: BaseStrategySettings = Field(default_factory=BaseStrategySettings)
-    patterns: PrimaryPatternsSettings = Field(default_factory=PrimaryPatternsSettings)
+    patterns: PatternSettings = Field(default_factory=PatternSettings)
 
 
 class LiveTimeSettings(BaseModel):
@@ -107,8 +97,6 @@ __all__ = [
     "DecisionWeights",
     "DecisionSettings",
     "LiveTimeModelSettings",
-    "PatternToggle",
-    "PrimaryPatternsSettings",
     "PrimarySignalSettings",
     "LiveTimeSettings",
     "LiveSettings",

--- a/src/forest5/signals/patterns/registry.py
+++ b/src/forest5/signals/patterns/registry.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Mapping, Optional
 
 from pandas import DataFrame
 
@@ -18,16 +18,29 @@ PATTERN_DETECTORS: Dict[str, Detector] = {
 
 
 def best_pattern(
-    df: DataFrame, atr: float, config: Optional[Dict[str, bool]] = None
+    df: DataFrame, atr: float, config: Optional[Mapping[str, bool]] = None
 ) -> Optional[dict]:
     """Return the highest score pattern based on configuration."""
+
+    if config is not None:
+        # Accept pydantic models or other containers with ``model_dump``/``dict``
+        if hasattr(config, "model_dump"):
+            config = config.model_dump()
+        elif hasattr(config, "dict"):
+            config = config.dict()
+
     best = None
     for name, detector in PATTERN_DETECTORS.items():
-        if config is not None and not config.get(name, False):
+        if config is not None and config.get(name) is False:
             continue
         result = detector(df, atr)
         if not result:
             continue
         if best is None or result["score"] > best["score"]:
             best = result
+    if best is None:
+        return None
+    # Provide generic aliases for callers expecting ``name``/``strength``
+    best.setdefault("name", best.get("type"))
+    best.setdefault("strength", best.get("score"))
     return best

--- a/tests/test_h1_ema_rsi_atr_signal.py
+++ b/tests/test_h1_ema_rsi_atr_signal.py
@@ -105,3 +105,55 @@ def test_h1_signal_requires_rsi_cross(monkeypatch, base_params):
     )
     res = compute_primary_signal_h1(df2, base_params, registry=reg)
     assert res.action == "KEEP"
+
+
+def test_h1_signal_patterns_boost(monkeypatch, base_params):
+    params = {
+        **base_params,
+        "patterns": {
+            "enabled": True,
+            "min_strength": 0.1,
+            "boost_conf": 0.2,
+            "boost_score": 0.5,
+        },
+    }
+
+    df = _make_df()
+
+    def fake_ema(close, period):
+        n = len(close)
+        if period == base_params["ema_fast"]:
+            vals = [1] * (n - 1) + [2]
+        else:
+            vals = [0] * n
+        return pd.Series(vals, index=close.index)
+
+    def fake_atr(high, low, close, period):
+        return pd.Series([1.0] * len(close), index=close.index)
+
+    def fake_rsi(close, period):
+        n = len(close)
+        vals = [40] * (n - 2) + [40, 60]
+        return pd.Series(vals, index=close.index)
+
+    def fake_best_pattern(df, atr, cfg):
+        return {"name": "pinbar", "strength": 0.3}
+
+    monkeypatch.setattr("forest5.signals.h1_ema_rsi_atr.ema", fake_ema)
+    monkeypatch.setattr("forest5.signals.h1_ema_rsi_atr.atr", fake_atr)
+    monkeypatch.setattr("forest5.signals.h1_ema_rsi_atr.rsi", fake_rsi)
+    monkeypatch.setattr(
+        "forest5.signals.h1_ema_rsi_atr.patterns.registry.best_pattern", fake_best_pattern
+    )
+
+    reg = SetupRegistry()
+    compute_primary_signal_h1(df, params, registry=reg)
+
+    df2 = pd.concat(
+        [df, pd.DataFrame([{"open": 2, "high": 3.2, "low": 2.0, "close": 2.5}])],
+        ignore_index=True,
+    )
+    res = compute_primary_signal_h1(df2, params, registry=reg)
+    assert res.technical_score > 1.0
+    assert any(isinstance(d, dict) and d.get("pattern") == "pinbar" for d in res.drivers)
+    assert res.meta.get("pattern") == "pinbar"

--- a/tests/test_live_example_yaml_shape.py
+++ b/tests/test_live_example_yaml_shape.py
@@ -22,9 +22,10 @@ def test_live_example_yaml_parses_and_has_fields():
     assert hasattr(ps, "strategy")  # nosec B101
     assert getattr(ps.strategy, "compat_int", None) is not None  # nosec B101
     pats = ps.patterns
-    assert hasattr(pats, "engulf") and pats.engulf.enabled is True  # nosec B101
-    assert hasattr(pats, "pinbar") and pats.pinbar.enabled is True  # nosec B101
-    assert hasattr(pats, "star") and pats.star.enabled is True  # nosec B101
+    assert hasattr(pats, "enabled") and pats.enabled is True  # nosec B101
+    assert hasattr(pats, "min_strength")  # nosec B101
+    assert hasattr(pats, "boost_conf")  # nosec B101
+    assert hasattr(pats, "boost_score")  # nosec B101
     assert hasattr(s, "risk")  # nosec B101
     assert getattr(s.risk, "on_drawdown", None) is not None  # nosec B101
     assert s.risk.on_drawdown.action == "halt"  # nosec B101


### PR DESCRIPTION
## Summary
- enhance H1 EMA/RSI/ATR signal with optional candlestick pattern boost
- add pattern settings to strategy and live configs with example YAML
- test pattern boosting and update live config shape tests

## Testing
- `pre-commit run --files src/forest5/signals/patterns/registry.py src/forest5/signals/h1_ema_rsi_atr.py src/forest5/config/strategy.py src/forest5/config_live.py config/live.example.yaml tests/test_h1_ema_rsi_atr_signal.py`
- `pre-commit run --files tests/test_live_example_yaml_shape.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac760b57e483268436d9720c6d77e1