### PR TITLE
Add detailed order flow telemetry logging

### DIFF
--- a/src/forest5/utils/log.py
+++ b/src/forest5/utils/log.py
@@ -18,8 +18,14 @@ E_SETUP_EXPIRE = "setup_expire"
 E_SETUP_DONE = "setup_done"
 
 # Trading related events.
-E_ORDER_PLACED = "order_placed"
+E_ORDER_SUBMITTED = "order_submitted"
+E_ORDER_ACK = "order_ack"
 E_ORDER_FILLED = "order_filled"
+E_ORDER_REJECTED = "order_rejected"
+E_ORDER_TIMEOUT = "order_timeout"
+E_ORDER_RETRY = "order_retry"
+# Legacy event names kept for backward compatibility.
+E_ORDER_PLACED = "order_placed"
 E_ORDER_CANCELLED = "order_cancelled"
 
 # Generic error/diagnostics events.

--- a/tests/test_logging_order_flow.py
+++ b/tests/test_logging_order_flow.py
@@ -1,0 +1,43 @@
+import json
+import logging
+
+import structlog
+
+from forest5.live.router import PaperBroker, submit_order
+from forest5.utils.log import (
+    E_ORDER_ACK,
+    E_ORDER_FILLED,
+    E_ORDER_SUBMITTED,
+    TelemetryContext,
+    new_id,
+    setup_logger,
+)
+
+
+def test_order_flow_logging(caplog):
+    processors = [
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.add_log_level,
+        structlog.processors.dict_tracebacks,
+        structlog.processors.JSONRenderer(),
+    ]
+    setup_logger()
+    structlog.configure(processors=processors, logger_factory=structlog.stdlib.LoggerFactory())
+    broker = PaperBroker()
+    broker.connect()
+    ctx = TelemetryContext(run_id="test_run", symbol="EURUSD")
+    cid = new_id("cl")
+
+    with caplog.at_level(logging.INFO):
+        submit_order(broker, "BUY", 1.0, price=1.2345, ctx=ctx, client_order_id=cid)
+
+    records = [json.loads(r.message) for r in caplog.records]
+    assert [r["event"] for r in records] == [
+        E_ORDER_SUBMITTED,
+        E_ORDER_ACK,
+        E_ORDER_FILLED,
+    ]
+    for r in records:
+        assert r.get("client_order_id") == cid
+    # restore default print logger for other tests
+    structlog.configure(processors=processors)


### PR DESCRIPTION
## Summary
- expand logging constants for rich order lifecycle telemetry
- emit order submission and broker events across PaperBroker, MT4 broker, and backtest engine
- add regression test validating order flow event sequence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac791e0e1c832680aca5bcc3c6e1b4