### PR TITLE
Add default decision and pattern settings

### DIFF
--- a/config/live.example.yaml
+++ b/config/live.example.yaml
@@ -16,6 +16,15 @@ ai:
   model: "gpt-4o-mini"
   max_tokens: 200
   context_file: "context.txt"  # use absolute path; on Windows/Wine use Z:\\path\\to\\context.txt
+strategy:
+  timeframe: "1m"
+  fast: 12
+  slow: 26
+  patterns:
+    enabled: true  # enable candlestick pattern boosts for strategy
+    min_strength: 0.0
+    boost_conf: 0.1
+    boost_score: 0.2
 decision:
   min_confluence: 0.0
   tie_epsilon: 0.05

--- a/src/forest5/config/loader.py
+++ b/src/forest5/config/loader.py
@@ -56,6 +56,11 @@ def load_live_settings(path: str | Path) -> "LiveSettings":
     text = p.read_text(encoding="utf-8")
     data = yaml.safe_load(text) or {}
 
+    strategy = data.get("strategy")
+    if isinstance(strategy, dict):
+        strategy.setdefault("patterns", {})
+        data["strategy"] = strategy
+
     broker = data.get("broker")
     if isinstance(broker, dict):
         b_raw = broker.get("bridge_dir")
@@ -75,6 +80,12 @@ def load_live_settings(path: str | Path) -> "LiveSettings":
             ai["context_file"] = ""
         data["ai"] = ai
 
+    decision = data.get("decision")
+    if isinstance(decision, dict):
+        decision.setdefault("weights", {})
+        decision.setdefault("tech", {})
+        data["decision"] = decision
+
     time = data.get("time")
     if isinstance(time, dict):
         model = time.get("model")
@@ -85,5 +96,10 @@ def load_live_settings(path: str | Path) -> "LiveSettings":
             else:
                 model["path"] = ""
             time["model"] = model
+
+        primary_signal = time.get("primary_signal")
+        if isinstance(primary_signal, dict):
+            primary_signal.setdefault("patterns", {})
+            time["primary_signal"] = primary_signal
         data["time"] = time
     return _pydantic_validate(LiveSettings, data)

--- a/src/forest5/config/strategy.py
+++ b/src/forest5/config/strategy.py
@@ -73,6 +73,7 @@ class BaseStrategySettings(BaseModel):
     rsi_oversold: int = 30
     compat_int: int | None = None
     params: H1EmaRsiAtrParams | dict[str, Any] | None = None
+    patterns: PatternSettings = Field(default_factory=PatternSettings)
     tp_sl_priority: Literal["SL_FIRST", "TP_FIRST"] = "SL_FIRST"
     setup_ttl_bars: int = 1
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,3 +28,6 @@ def test_config_from_yaml(tmp_path: Path):
     assert s.risk.on_drawdown.action == "halt"  # nosec B101
     assert s.tp_sl_priority == "TP_FIRST"
     assert s.setup_ttl_bars == 2
+    pats = s.strategy.patterns
+    assert pats.enabled is False  # nosec B101
+    assert pats.min_strength == 0.0  # nosec B101

--- a/tests/test_config_live.py
+++ b/tests/test_config_live.py
@@ -38,6 +38,14 @@ def test_live_settings_from_yaml(tmp_path: Path):
     assert s.time.model.enabled is True  # nosec B101
     assert s.time.model.path == p.parent / "model.onnx"  # nosec B101
     assert s.risk.on_drawdown.action == "halt"  # nosec B101
+    assert s.decision.tie_epsilon == 0.05  # nosec B101
+    assert s.decision.weights.tech == 1.0  # nosec B101
+    assert s.decision.weights.ai == 1.0  # nosec B101
+    assert s.decision.tech.default_conf_int == 1.0  # nosec B101
+    assert s.decision.tech.conf_floor == 0.0  # nosec B101
+    assert s.decision.tech.conf_cap == 1.0  # nosec B101
+    assert s.strategy.patterns.enabled is False  # nosec B101
+    assert s.time.primary_signal.patterns.enabled is False  # nosec B101
 
 
 def test_live_settings_ai_context_file_resolved(tmp_path: Path):


### PR DESCRIPTION
## Summary
- support pattern configuration on base strategy settings with defaults
- ensure loader provides default decision weights and pattern sections
- extend example live config with decision and pattern keys
- test defaults for new decision and pattern fields

## Testing
- `pytest tests/test_config.py tests/test_config_live.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac7e7cd3308326b0e04f9276501a4a