### PR TITLE
Arm H1 setups in live runner

### DIFF
--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -13,7 +13,7 @@ from ..decision import DecisionAgent, DecisionConfig, DecisionResult
 from ..time_only import TimeOnlyModel
 from ..signals.candles import candles_signal
 from ..signals.combine import confirm_with_candles
-from ..signals.compat import compute_signal_compat, contract_to_int
+from ..signals.compat import compute_signal_compat
 from ..signals import SetupRegistry, compute_signal
 from ..signals.contract import TechnicalSignal
 from ..utils.timeframes import _TF_MINUTES


### PR DESCRIPTION
## Summary
- handle `h1_ema_rsi_atr` strategy in live runner
- arm setups and log `setup_arm` events based on computed signal
- defer breakout trigger to `SetupRegistry.check`

## Testing
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68ac8dc78f448326801aa177f7281d7c