### PR TITLE
Use contract signals directly for H1 strategy

### DIFF
--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -73,7 +73,9 @@ def append_bar_and_signal(
 
     name = getattr(settings.strategy, "name", "ema_cross")
     if name == "h1_ema_rsi_atr":
-        contract = compute_signal(df, settings.strategy, ctx=ctx)
+        # For the H1 strategy we work with rich contract objects.  Compute the
+        # signal directly without going through the compatibility shim.
+        contract = compute_signal(df, settings, ctx=ctx)
         if (
             isinstance(contract, TechnicalSignal)
             and contract.action in ("BUY", "SELL")

--- a/src/forest5/signals/compat.py
+++ b/src/forest5/signals/compat.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 import pandas as pd
+import numpy as np
 
 from .factory import compute_signal
 from .contract import TechnicalSignal
@@ -57,12 +58,9 @@ def compute_signal_compat(
     if isinstance(res, pd.Series):
         return res.astype("int8")
 
-    import numpy as np
-
-    if isinstance(res, (TechnicalSignal, Mapping)):
-        arr = np.zeros(len(df), dtype=np.int8)
-        if len(df):
-            arr[-1] = contract_to_int(res)
-        return pd.Series(arr, index=df.index, dtype="int8")
-
-    return pd.Series([contract_to_int(res)], index=df.index[-1:], dtype="int8")
+    # Legacy paths may return a single contract or mapping-like object.  Convert
+    # only the latest value to an integer signal for backward compatibility.
+    arr = np.zeros(len(df), dtype=np.int8)
+    if len(df):
+        arr[-1] = contract_to_int(res)
+    return pd.Series(arr, index=df.index, dtype="int8")

--- a/src/forest5/signals/factory.py
+++ b/src/forest5/signals/factory.py
@@ -15,12 +15,18 @@ def compute_signal(
     df,
     settings,
     price_col="close",
-    compat_int=False,
+    compat_int: bool = False,
     ctx: TelemetryContext | None = None,
 ):
-    """Generate trading signal without mutating the input settings."""
+    """Generate trading signal without mutating the input settings.
 
-    strategy = copy.deepcopy(settings.strategy)
+    ``settings`` may either be a complete settings object exposing a ``strategy``
+    attribute or the strategy instance itself.  Only when ``compat_int`` is set
+    to ``True`` will contract style signals be coerced to ``-1/0/1`` integers.
+    """
+
+    strategy_obj = getattr(settings, "strategy", settings)
+    strategy = copy.deepcopy(strategy_obj)
     name = getattr(strategy, "name", "ema_cross")
 
     if name in {"ema_rsi", "ema-cross+rsi"}:


### PR DESCRIPTION
## Summary
- allow `compute_signal` to accept either full settings or strategy objects and document compat-int usage
- simplify `compute_signal_compat` to convert contract outputs only in legacy paths
- call `compute_signal` directly for `h1_ema_rsi_atr` in `append_bar_and_signal`

## Testing
- `pre-commit run --files src/forest5/signals/factory.py src/forest5/signals/compat.py src/forest5/live/live_runner.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac9f7a26c883269b15fd752f4a9b7f