### PR TITLE
feat: add pattern gate defaults

### DIFF
--- a/src/forest5/config/loader.py
+++ b/src/forest5/config/loader.py
@@ -7,6 +7,8 @@ import yaml
 
 from typing import Any, TYPE_CHECKING, Type
 
+from .strategy import PatternSettings
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from ..config_live import LiveSettings
 
@@ -48,6 +50,9 @@ def _pydantic_validate(model_cls: Type, data: dict) -> Any:
     return model_cls(**data)
 
 
+DEFAULT_PATTERNS = PatternSettings().model_dump()
+
+
 def load_live_settings(path: str | Path) -> "LiveSettings":
     from ..config_live import LiveSettings
 
@@ -58,7 +63,7 @@ def load_live_settings(path: str | Path) -> "LiveSettings":
 
     strategy = data.get("strategy")
     if isinstance(strategy, dict):
-        strategy.setdefault("patterns", {})
+        strategy.setdefault("patterns", dict(DEFAULT_PATTERNS))
         data["strategy"] = strategy
 
     broker = data.get("broker")
@@ -99,7 +104,7 @@ def load_live_settings(path: str | Path) -> "LiveSettings":
 
         primary_signal = time.get("primary_signal")
         if isinstance(primary_signal, dict):
-            primary_signal.setdefault("patterns", {})
+            primary_signal.setdefault("patterns", dict(DEFAULT_PATTERNS))
             time["primary_signal"] = primary_signal
         data["time"] = time
     return _pydantic_validate(LiveSettings, data)

--- a/src/forest5/config/strategy.py
+++ b/src/forest5/config/strategy.py
@@ -30,10 +30,11 @@ class H1EmaRsiAtrParams(BaseModel):
 
 
 class PatternSettings(BaseModel):
-    enabled: bool = False
-    min_strength: float = 0.0
-    boost_conf: float = 0.0
-    boost_score: float = 0.0
+    enabled: bool = True
+    min_strength: float = 0.6
+    boost_conf: float = 0.20
+    boost_score: float = 0.20
+    gate: bool = False
 
 
 class ProfileSettings(BaseModel):

--- a/src/forest5/signals/h1_ema_rsi_atr.py
+++ b/src/forest5/signals/h1_ema_rsi_atr.py
@@ -168,7 +168,9 @@ def compute_primary_signal_h1(
         confidence_tech = abs(technical_score)
 
         patterns_cfg = p.get("patterns", {}) or {}
+        pattern_ok = True
         if patterns_cfg.get("enabled"):
+            pattern_ok = False
             pattern = patterns.registry.best_pattern(df, atr_last, patterns_cfg)
             if pattern:
                 name = pattern.get("name") or pattern.get("type")
@@ -181,6 +183,16 @@ def compute_primary_signal_h1(
                     technical_score += boost_score if technical_score > 0 else -boost_score
                     drivers.append({"pattern": name, "strength": strength})
                     meta["pattern"] = name
+                    pattern_ok = True
+            if patterns_cfg.get("gate") and not pattern_ok:
+                return TechnicalSignal(
+                    timeframe=p["timeframe"],
+                    horizon_minutes=p["horizon_minutes"],
+                    technical_score=0.0,
+                    confidence_tech=0.0,
+                    drivers=[],
+                    meta=meta,
+                )
         signal = TechnicalSignal(
             timeframe=p["timeframe"],
             action=action,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,5 +29,8 @@ def test_config_from_yaml(tmp_path: Path):
     assert s.tp_sl_priority == "TP_FIRST"
     assert s.setup_ttl_bars == 2
     pats = s.strategy.patterns
-    assert pats.enabled is False  # nosec B101
-    assert pats.min_strength == 0.0  # nosec B101
+    assert pats.enabled is True  # nosec B101
+    assert pats.min_strength == 0.6  # nosec B101
+    assert pats.boost_conf == 0.2  # nosec B101
+    assert pats.boost_score == 0.2  # nosec B101
+    assert pats.gate is False  # nosec B101

--- a/tests/test_config_live.py
+++ b/tests/test_config_live.py
@@ -6,7 +6,7 @@ from pydantic import ValidationError
 
 from forest5.config.loader import load_live_settings
 from forest5.config_live import LiveTimeModelSettings
-from forest5.config.strategy import BaseStrategySettings
+from forest5.config.strategy import BaseStrategySettings, PatternSettings
 
 
 def test_live_settings_from_yaml(tmp_path: Path):
@@ -44,8 +44,11 @@ def test_live_settings_from_yaml(tmp_path: Path):
     assert s.decision.tech.default_conf_int == 1.0  # nosec B101
     assert s.decision.tech.conf_floor == 0.0  # nosec B101
     assert s.decision.tech.conf_cap == 1.0  # nosec B101
-    assert s.strategy.patterns.enabled is False  # nosec B101
-    assert s.time.primary_signal.patterns.enabled is False  # nosec B101
+    default_patterns = PatternSettings().model_dump()
+    assert s.strategy.patterns.model_dump() == default_patterns  # nosec B101
+    assert (
+        s.time.primary_signal.patterns.model_dump() == default_patterns
+    )  # nosec B101
 
 
 def test_live_settings_ai_context_file_resolved(tmp_path: Path):

--- a/tests/test_config_live.py
+++ b/tests/test_config_live.py
@@ -46,9 +46,7 @@ def test_live_settings_from_yaml(tmp_path: Path):
     assert s.decision.tech.conf_cap == 1.0  # nosec B101
     default_patterns = PatternSettings().model_dump()
     assert s.strategy.patterns.model_dump() == default_patterns  # nosec B101
-    assert (
-        s.time.primary_signal.patterns.model_dump() == default_patterns
-    )  # nosec B101
+    assert s.time.primary_signal.patterns.model_dump() == default_patterns  # nosec B101
 
 
 def test_live_settings_ai_context_file_resolved(tmp_path: Path):

--- a/tests/test_h1_ema_rsi_atr_signal.py
+++ b/tests/test_h1_ema_rsi_atr_signal.py
@@ -186,9 +186,7 @@ def test_h1_signal_patterns_gate(monkeypatch, base_params):
     monkeypatch.setattr("forest5.signals.h1_ema_rsi_atr.ema", fake_ema)
     monkeypatch.setattr("forest5.signals.h1_ema_rsi_atr.atr", fake_atr)
     monkeypatch.setattr("forest5.signals.h1_ema_rsi_atr.rsi", fake_rsi)
-    monkeypatch.setattr(
-        "forest5.signals.h1_ema_rsi_atr.patterns.registry.best_pattern", no_pattern
-    )
+    monkeypatch.setattr("forest5.signals.h1_ema_rsi_atr.patterns.registry.best_pattern", no_pattern)
 
     reg = SetupRegistry()
     compute_primary_signal_h1(df, params, registry=reg)

--- a/tests/test_h1_ema_rsi_atr_signal.py
+++ b/tests/test_h1_ema_rsi_atr_signal.py
@@ -157,3 +157,46 @@ def test_h1_signal_patterns_boost(monkeypatch, base_params):
     assert res.technical_score > 1.0
     assert any(isinstance(d, dict) and d.get("pattern") == "pinbar" for d in res.drivers)
     assert res.meta.get("pattern") == "pinbar"
+
+
+def test_h1_signal_patterns_gate(monkeypatch, base_params):
+    params = {**base_params, "patterns": {"enabled": True, "gate": True}}
+
+    df = _make_df()
+
+    def fake_ema(close, period):
+        n = len(close)
+        if period == base_params["ema_fast"]:
+            vals = [1] * (n - 1) + [2]
+        else:
+            vals = [0] * n
+        return pd.Series(vals, index=close.index)
+
+    def fake_atr(high, low, close, period):
+        return pd.Series([1.0] * len(close), index=close.index)
+
+    def fake_rsi(close, period):
+        n = len(close)
+        vals = [40] * (n - 2) + [40, 60]
+        return pd.Series(vals, index=close.index)
+
+    def no_pattern(df, atr, cfg):
+        return None
+
+    monkeypatch.setattr("forest5.signals.h1_ema_rsi_atr.ema", fake_ema)
+    monkeypatch.setattr("forest5.signals.h1_ema_rsi_atr.atr", fake_atr)
+    monkeypatch.setattr("forest5.signals.h1_ema_rsi_atr.rsi", fake_rsi)
+    monkeypatch.setattr(
+        "forest5.signals.h1_ema_rsi_atr.patterns.registry.best_pattern", no_pattern
+    )
+
+    reg = SetupRegistry()
+    compute_primary_signal_h1(df, params, registry=reg)
+
+    df2 = pd.concat(
+        [df, pd.DataFrame([{"open": 2, "high": 3.2, "low": 2.0, "close": 2.5}])],
+        ignore_index=True,
+    )
+    res = compute_primary_signal_h1(df2, params, registry=reg)
+    assert res.action == "KEEP"
+    assert not reg._setups

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,6 +1,8 @@
 import pandas as pd
+import pytest
 
 from forest5.signals.patterns import engulfing, pinbar, stars, registry
+from forest5.config.strategy import PatternSettings
 
 
 def test_engulfing_detects_positive():
@@ -79,3 +81,12 @@ def test_registry_best_pattern(monkeypatch):
 
     res = registry.best_pattern(pd.DataFrame(), 1.0, {"engulfing": True, "pinbar": False})
     assert res["type"] == "a"
+
+
+def test_pattern_settings_defaults():
+    cfg = PatternSettings()
+    assert cfg.enabled is True
+    assert cfg.min_strength == pytest.approx(0.6)
+    assert cfg.boost_conf == pytest.approx(0.20)
+    assert cfg.boost_score == pytest.approx(0.20)
+    assert cfg.gate is False


### PR DESCRIPTION
## Summary
- add gate option and defaults to PatternSettings
- inject default pattern settings when missing from live config
- short-circuit primary signal when gating enabled without pattern

## Testing
- `pytest tests/test_patterns.py tests/test_h1_ema_rsi_atr_signal.py tests/test_config_live.py`

------
https://chatgpt.com/codex/tasks/task_e_68acaab87464832684030a2354d068bf