### PR TITLE
feat: adjust decision defaults

### DIFF
--- a/src/forest5/config/loader.py
+++ b/src/forest5/config/loader.py
@@ -86,10 +86,15 @@ def load_live_settings(path: str | Path) -> "LiveSettings":
         data["ai"] = ai
 
     decision = data.get("decision")
-    if isinstance(decision, dict):
-        decision.setdefault("weights", {})
-        decision.setdefault("tech", {})
-        data["decision"] = decision
+    if not isinstance(decision, dict):
+        decision = {}
+    decision.setdefault("tie_epsilon", 0.05)
+    decision.setdefault("weights", {"tech": 1.0, "ai": 0.5})
+    decision.setdefault(
+        "tech",
+        {"conf_floor": 0.20, "conf_cap": 0.90, "default_conf_int": 0.50},
+    )
+    data["decision"] = decision
 
     time = data.get("time")
     if isinstance(time, dict):

--- a/src/forest5/config_live.py
+++ b/src/forest5/config_live.py
@@ -34,14 +34,14 @@ class BrokerSettings(BaseModel):
 
 
 class DecisionTechSettings(BaseModel):
-    default_conf_int: float = 1.0
-    conf_floor: float = 0.0
-    conf_cap: float = 1.0
+    default_conf_int: float = 0.50
+    conf_floor: float = 0.20
+    conf_cap: float = 0.90
 
 
 class DecisionWeights(BaseModel):
     tech: float = 1.0
-    ai: float = 1.0
+    ai: float = 0.5
 
 
 class DecisionSettings(BaseModel):

--- a/src/forest5/decision.py
+++ b/src/forest5/decision.py
@@ -114,9 +114,9 @@ def _normalize_tech_input(tech_signal, cfg) -> DecisionVote:
     """
 
     tech_cfg = getattr(getattr(cfg, "decision", object()), "tech", object())
-    default_conf_int = getattr(tech_cfg, "default_conf_int", 1.0)
-    conf_floor = getattr(tech_cfg, "conf_floor", 0.0)
-    conf_cap = getattr(tech_cfg, "conf_cap", 1.0)
+    default_conf_int = getattr(tech_cfg, "default_conf_int", 0.5)
+    conf_floor = getattr(tech_cfg, "conf_floor", 0.2)
+    conf_cap = getattr(tech_cfg, "conf_cap", 0.9)
     w_tech = getattr(getattr(getattr(cfg, "decision", object()), "weights", object()), "tech", 1.0)
 
     def _clamp(v: float) -> float:
@@ -228,9 +228,13 @@ class DecisionConfig:
     # Technical signal always contributes at least 1.
     min_confluence: float = 0.0
     tie_epsilon: float = 0.05
-    weights: Any = field(default_factory=lambda: SimpleNamespace(tech=1.0, ai=1.0, time=1.0))
+    weights: Any = field(
+        default_factory=lambda: SimpleNamespace(tech=1.0, ai=0.5, time=1.0)
+    )
     tech: Any = field(
-        default_factory=lambda: SimpleNamespace(default_conf_int=1.0, conf_floor=0.0, conf_cap=1.0)
+        default_factory=lambda: SimpleNamespace(
+            default_conf_int=0.5, conf_floor=0.2, conf_cap=0.9
+        )
     )
 
 

--- a/tests/test_config_live.py
+++ b/tests/test_config_live.py
@@ -40,10 +40,10 @@ def test_live_settings_from_yaml(tmp_path: Path):
     assert s.risk.on_drawdown.action == "halt"  # nosec B101
     assert s.decision.tie_epsilon == 0.05  # nosec B101
     assert s.decision.weights.tech == 1.0  # nosec B101
-    assert s.decision.weights.ai == 1.0  # nosec B101
-    assert s.decision.tech.default_conf_int == 1.0  # nosec B101
-    assert s.decision.tech.conf_floor == 0.0  # nosec B101
-    assert s.decision.tech.conf_cap == 1.0  # nosec B101
+    assert s.decision.weights.ai == 0.5  # nosec B101
+    assert s.decision.tech.default_conf_int == 0.50  # nosec B101
+    assert s.decision.tech.conf_floor == 0.20  # nosec B101
+    assert s.decision.tech.conf_cap == 0.90  # nosec B101
     default_patterns = PatternSettings().model_dump()
     assert s.strategy.patterns.model_dump() == default_patterns  # nosec B101
     assert s.time.primary_signal.patterns.model_dump() == default_patterns  # nosec B101

--- a/tests/test_decision_agent.py
+++ b/tests/test_decision_agent.py
@@ -19,7 +19,9 @@ def test_decision_agent_waits_when_time_model_waits() -> None:
 
 def test_decision_agent_majority_and_tie() -> None:
     time_model = TimeOnlyModel({0: (-1.0, 1.0)}, q_low=-1.0, q_high=1.0)
-    agent = DecisionAgent(config=DecisionConfig(time_model=time_model))
+    cfg = DecisionConfig(time_model=time_model)
+    cfg.weights.time = 0.5
+    agent = DecisionAgent(config=cfg)
     ts = datetime(2024, 1, 1)
 
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=2.0, symbol="EURUSD")
@@ -44,7 +46,7 @@ def test_decision_agent_majority_and_tie() -> None:
 
 def test_decision_agent_respects_confluence_threshold() -> None:
     ts = datetime(2024, 1, 1)
-    agent = DecisionAgent(config=DecisionConfig(min_confluence=2))
+    agent = DecisionAgent(config=DecisionConfig(min_confluence=1.4))
 
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=0.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
@@ -54,7 +56,7 @@ def test_decision_agent_respects_confluence_threshold() -> None:
     )
 
     time_model = TimeOnlyModel({0: (-1.0, 1.0)}, q_low=-1.0, q_high=1.0)
-    agent2 = DecisionAgent(config=DecisionConfig(time_model=time_model, min_confluence=2))
+    agent2 = DecisionAgent(config=DecisionConfig(time_model=time_model, min_confluence=1.4))
     decision, votes, reason = agent2.decide(ts, tech_signal=1, value=2.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "BUY",
@@ -73,7 +75,7 @@ def test_decision_agent_accepts_mapping_and_dataclass() -> None:
         "BUY",
         {"tech": 1},
         "ok",
-        1.0,
+        0.9,
     )
 
     sig = TechnicalSignal(action=-1, technical_score=-1.5, confidence_tech=1.0)
@@ -82,7 +84,7 @@ def test_decision_agent_accepts_mapping_and_dataclass() -> None:
         "SELL",
         {"tech": -1},
         "ok",
-        -1.0,
+        -0.9,
     )
 
 
@@ -96,7 +98,7 @@ def test_decision_agent_accepts_string_actions() -> None:
         "BUY",
         {"tech": 1},
         "ok",
-        1.0,
+        0.9,
     )
 
     sig = TechnicalSignal(action="SELL", technical_score=-3.0, confidence_tech=1.0)
@@ -105,7 +107,7 @@ def test_decision_agent_accepts_string_actions() -> None:
         "SELL",
         {"tech": -1},
         "ok",
-        -1.0,
+        -0.9,
     )
 
 
@@ -125,5 +127,5 @@ def test_decision_agent_handles_custom_dataclass_with_string_action() -> None:
         "BUY",
         {"tech": 1},
         "ok",
-        1.0,
+        0.9,
     )

--- a/tests/test_decision_fusion_min_confluence.py
+++ b/tests/test_decision_fusion_min_confluence.py
@@ -17,7 +17,7 @@ class DummyTimeModel:
 
 def test_wait_short_circuit() -> None:
     tm = DummyTimeModel("WAIT")
-    agent = DecisionAgent(config=DecisionConfig(time_model=tm, min_confluence=2))
+    agent = DecisionAgent(config=DecisionConfig(time_model=tm, min_confluence=1.4))
     ts = datetime(2024, 1, 1)
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
@@ -29,7 +29,7 @@ def test_wait_short_circuit() -> None:
 
 def test_min_confluence_requires_both_votes() -> None:
     tm = DummyTimeModel("BUY")
-    agent = DecisionAgent(config=DecisionConfig(time_model=tm, min_confluence=2))
+    agent = DecisionAgent(config=DecisionConfig(time_model=tm, min_confluence=1.4))
     ts = datetime(2024, 1, 1)
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
@@ -48,7 +48,9 @@ def test_min_confluence_requires_both_votes() -> None:
 def test_min_confluence_sell_and_conflict_without_ai() -> None:
     ts = datetime(2024, 1, 1)
     tm_sell = DummyTimeModel("SELL")
-    agent_sell = DecisionAgent(config=DecisionConfig(time_model=tm_sell, min_confluence=2))
+    cfg_sell = DecisionConfig(time_model=tm_sell, min_confluence=1.0)
+    cfg_sell.weights.time = 0.5
+    agent_sell = DecisionAgent(config=cfg_sell)
     decision, votes, reason = agent_sell.decide(ts, tech_signal=-1, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "SELL",
@@ -56,7 +58,9 @@ def test_min_confluence_sell_and_conflict_without_ai() -> None:
         "ok",
     )
     tm_buy = DummyTimeModel("BUY")
-    agent_conflict = DecisionAgent(config=DecisionConfig(time_model=tm_buy, min_confluence=2))
+    cfg_conflict = DecisionConfig(time_model=tm_buy, min_confluence=1.0)
+    cfg_conflict.weights.time = 0.5
+    agent_conflict = DecisionAgent(config=cfg_conflict)
     decision, votes, reason = agent_conflict.decide(ts, tech_signal=-1, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "WAIT",
@@ -80,7 +84,7 @@ class DummyAI:
 
 def test_min_confluence_with_ai() -> None:
     ts = datetime(2024, 1, 1)
-    agent = DecisionAgent(config=DecisionConfig(use_ai=True, min_confluence=2))
+    agent = DecisionAgent(config=DecisionConfig(use_ai=True, min_confluence=1.0))
 
     agent.ai = DummyAI(1.0)
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")

--- a/tests/test_decision_fusion_tie.py
+++ b/tests/test_decision_fusion_tie.py
@@ -14,7 +14,9 @@ class DummyTimeModel:
 def test_min_confluence_conflicting_votes_wait() -> None:
     """Conflicting votes with min_confluence=2 should result in WAIT."""
     tm = DummyTimeModel()
-    agent = DecisionAgent(config=DecisionConfig(time_model=tm, min_confluence=2))
+    cfg = DecisionConfig(time_model=tm, min_confluence=2)
+    cfg.weights.time = 0.5
+    agent = DecisionAgent(config=cfg)
     ts = datetime(2024, 1, 1)
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (

--- a/tests/test_live_h1_contract_path.py
+++ b/tests/test_live_h1_contract_path.py
@@ -3,6 +3,8 @@ import json
 import threading
 import time
 
+import pytest
+
 import forest5.live.live_runner as live_runner
 from forest5.live.live_runner import run_live
 import forest5.live.router as router
@@ -112,7 +114,7 @@ def test_h1_contract_arm_and_trigger(tmp_path: Path, monkeypatch):
 
     s = LiveSettings(
         broker=BrokerSettings(type="paper", bridge_dir=str(bridge), symbol="EURUSD", volume=0.01),
-        decision=DecisionSettings(min_confluence=1),
+        decision=DecisionSettings(min_confluence=0.5),
         ai=AISettings(enabled=False, model="gpt-4o-mini", max_tokens=64, context_file=None),
         time=TimeSettings(),
         risk=RiskSettings(max_drawdown=0.5),
@@ -142,4 +144,4 @@ def test_h1_contract_arm_and_trigger(tmp_path: Path, monkeypatch):
     assert registry.arm_index == 1
     assert registry.check_indices == [0, 1]
     assert registry.trigger_index == 1
-    assert created.get("orders") == [("BUY", 0.01, 1.0)]
+    assert created.get("orders") == [("BUY", pytest.approx(0.009), 1.0)]

--- a/tests/test_live_runner_ai_params.py
+++ b/tests/test_live_runner_ai_params.py
@@ -36,7 +36,7 @@ def test_run_live_passes_ai_params(tmp_path: Path, monkeypatch):
 
     settings = LiveSettings(
         broker=BrokerSettings(type="paper", bridge_dir=str(tmp_path), symbol="EURUSD", volume=0.01),
-        decision=DecisionSettings(min_confluence=1),
+        decision=DecisionSettings(min_confluence=0.5),
         ai=AISettings(enabled=True, model="custom-model", max_tokens=99, context_file=None),
         time=TimeSettings(),
         risk=RiskSettings(max_drawdown=0.5),

--- a/tests/test_live_runner_paper_smoke.py
+++ b/tests/test_live_runner_paper_smoke.py
@@ -43,7 +43,7 @@ def test_run_live_paper(tmp_path: Path, capfd):
     bridge = _mk_bridge(tmp_path)
     s = LiveSettings(
         broker=BrokerSettings(type="paper", bridge_dir=str(bridge), symbol="EURUSD", volume=0.01),
-        decision=DecisionSettings(min_confluence=1),
+        decision=DecisionSettings(min_confluence=0.5),
         ai=AISettings(enabled=False, model="gpt-4o-mini", max_tokens=64, context_file=None),
         time=TimeSettings(),
         risk=RiskSettings(max_drawdown=0.5),
@@ -88,7 +88,7 @@ def test_triggered_setup_executes(tmp_path: Path, capfd, monkeypatch):
 
     s = LiveSettings(
         broker=BrokerSettings(type="paper", bridge_dir=str(bridge), symbol="EURUSD", volume=0.01),
-        decision=DecisionSettings(min_confluence=1),
+        decision=DecisionSettings(min_confluence=0.5),
         ai=AISettings(enabled=False, model="gpt-4o-mini", max_tokens=64, context_file=None),
         time=TimeSettings(),
         risk=RiskSettings(max_drawdown=0.5),
@@ -135,7 +135,7 @@ def test_setup_expires_without_trigger(tmp_path: Path, capfd, monkeypatch):
 
     s = LiveSettings(
         broker=BrokerSettings(type="paper", bridge_dir=str(bridge), symbol="EURUSD", volume=0.01),
-        decision=DecisionSettings(min_confluence=1),
+        decision=DecisionSettings(min_confluence=0.5),
         ai=AISettings(enabled=False, model="gpt-4o-mini", max_tokens=64, context_file=None),
         time=TimeSettings(),
         risk=RiskSettings(max_drawdown=0.5),
@@ -159,7 +159,7 @@ def test_setup_expires_without_trigger(tmp_path: Path, capfd, monkeypatch):
 def test_incremental_signal_perf():
     settings = LiveSettings(
         broker=BrokerSettings(type="paper", bridge_dir=".", symbol="EURUSD", volume=0.01),
-        decision=DecisionSettings(min_confluence=1),
+        decision=DecisionSettings(min_confluence=0.5),
         ai=AISettings(enabled=False, model="gpt-4o-mini", max_tokens=64, context_file=None),
         time=TimeSettings(),
         risk=RiskSettings(max_drawdown=0.5),

--- a/tests/test_live_runner_soft_wait.py
+++ b/tests/test_live_runner_soft_wait.py
@@ -65,7 +65,7 @@ def test_run_live_soft_wait(tmp_path: Path, monkeypatch) -> None:
 
     settings = LiveSettings(
         broker=BrokerSettings(type="paper", bridge_dir=str(bridge), symbol="EURUSD", volume=1),
-        decision=DecisionSettings(min_confluence=1),
+        decision=DecisionSettings(min_confluence=0.5),
         ai=AISettings(enabled=False, model="gpt-4o-mini", max_tokens=64, context_file=None),
         time=TimeSettings(),
         risk=RiskSettings(

--- a/tests/test_live_timeonly_paper_smoke.py
+++ b/tests/test_live_timeonly_paper_smoke.py
@@ -45,7 +45,7 @@ def test_live_timeonly_paper_smoke(tmp_path: Path, monkeypatch, capfd) -> None:
             timeframe="1m",
         ),
         strategy=StrategySettings(timeframe="1m"),
-        decision=DecisionSettings(min_confluence=1.0),
+        decision=DecisionSettings(min_confluence=0.5),
         time=TimeSettings(),
     )
 

--- a/tests/test_timeonly_decision_agent.py
+++ b/tests/test_timeonly_decision_agent.py
@@ -32,7 +32,9 @@ def test_timeonly_decision_agent(time_sig: str, tech_sig: int, expected: str) ->
     assert res.decision == expected
     exp_weight = 0.0
     if expected == "BUY":
-        exp_weight = 2.0
+        exp_weight = 1.5
     elif expected == "SELL":
-        exp_weight = -2.0
+        exp_weight = -1.5
+    elif time_sig != "WAIT":
+        exp_weight = 0.5
     assert res.weight == pytest.approx(exp_weight)


### PR DESCRIPTION
## Summary
- tune default decision weights and confidence ranges
- populate missing decision config with new defaults
- align decision agent and tests with updated baseline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acaf4726188326a9c7ae47034053b9