### PR TITLE
Short-circuit on missing technical signal

### DIFF
--- a/src/forest5/decision.py
+++ b/src/forest5/decision.py
@@ -266,6 +266,11 @@ class DecisionAgent:
         votes: list[DecisionVote] = []
         cfg = SimpleNamespace(decision=self.config)
 
+        tech_vote = _normalize_tech_input(tech_signal, cfg)
+        if tech_vote.direction == 0:
+            return DecisionResult("WAIT", 0.0, "no_tech_signal")
+        votes.append(tech_vote)
+
         if self.config.time_model:
             tm_res = self.config.time_model.decide(ts, value)
             if isinstance(tm_res, tuple):
@@ -283,8 +288,6 @@ class DecisionAgent:
                     score=float(tm_weight),
                 )
             )
-
-        votes.append(_normalize_tech_input(tech_signal, cfg))
 
         if self.ai:
             ai_sent = self.ai.analyse(context_text, symbol)

--- a/tests/test_decision_agent.py
+++ b/tests/test_decision_agent.py
@@ -17,6 +17,19 @@ def test_decision_agent_waits_when_time_model_waits() -> None:
     assert reason == "timeonly_wait"
 
 
+class _DummyTimeModel:
+    def decide(self, ts, value: float) -> str:  # pragma: no cover - simple stub
+        return "BUY"
+
+
+def test_decision_agent_waits_without_tech_signal() -> None:
+    ts = datetime(2024, 1, 1)
+    agent = DecisionAgent(config=DecisionConfig(time_model=_DummyTimeModel()))
+    for sig in ("KEEP", None):
+        decision, votes, reason = agent.decide(ts, tech_signal=sig, value=1.0, symbol="EURUSD")
+        assert (decision, votes, reason) == ("WAIT", {}, "no_tech_signal")
+
+
 def test_decision_agent_majority_and_tie() -> None:
     time_model = TimeOnlyModel({0: (-1.0, 1.0)}, q_low=-1.0, q_high=1.0)
     cfg = DecisionConfig(time_model=time_model)

--- a/tests/test_decision_fusion_min_confluence.py
+++ b/tests/test_decision_fusion_min_confluence.py
@@ -37,7 +37,8 @@ def test_min_confluence_requires_both_votes() -> None:
         {"tech": 1, "time": 1},
         "ok",
     )
-    decision, votes, reason = agent.decide(ts, tech_signal=0, value=1.0, symbol="EURUSD")
+    agent2 = DecisionAgent(config=DecisionConfig(min_confluence=1.4))
+    decision, votes, reason = agent2.decide(ts, tech_signal=1, value=1.0, symbol="EURUSD")
     assert (decision, votes, reason) == (
         "WAIT",
         {},


### PR DESCRIPTION
## Summary
- skip time/AI votes when technical signal gives no direction
- test that `tech_signal` of KEEP or `None` yields WAIT despite other votes
- update min confluence test to account for missing technical signal behavior

## Testing
- `pytest tests/test_decision_agent.py tests/test_decision_fusion_min_confluence.py tests/test_decision_fusion_tie.py`
- `pre-commit run --files src/forest5/decision.py tests/test_decision_agent.py tests/test_decision_fusion_min_confluence.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acb39ee5388326abfe964e16dcf473