### PR TITLE
Clamp decision weights

### DIFF
--- a/tests/test_contract_confidence.py
+++ b/tests/test_contract_confidence.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from forest5.decision import _normalize_tech_input
 from forest5.signals.contract import TechnicalSignal
 
@@ -29,3 +31,13 @@ def test_int_legacy_path_unchanged() -> None:
     assert vote.direction == 1
     assert vote.weight == 1.0
     assert vote.meta == {"mode": "int"}
+
+
+def test_weight_clamped_to_cap() -> None:
+    cfg = DummyCfg()
+    cfg.decision.tech.conf_cap = 0.7
+    cfg.decision.weights.tech = 2.0
+    sig = TechnicalSignal(action="BUY", technical_score=1.0, confidence_tech=1.0)
+    vote = _normalize_tech_input(sig, cfg)
+
+    assert vote.weight == pytest.approx(0.7)

--- a/tests/test_decision_agent.py
+++ b/tests/test_decision_agent.py
@@ -142,3 +142,21 @@ def test_decision_agent_handles_custom_dataclass_with_string_action() -> None:
         "ok",
         0.9,
     )
+
+
+def test_ai_weight_clamped_to_bounds() -> None:
+    ts = datetime(2024, 1, 1)
+    cfg = DecisionConfig()
+    cfg.weights.ai = 5.0
+    agent = DecisionAgent(config=cfg)
+
+    class DummyAI:
+        def analyse(self, context: str, symbol: str):
+            return {"score": 1.0, "confidence_ai": 1.0}
+
+    agent.ai = DummyAI()
+
+    res = agent.decide(ts, tech_signal=1, value=0.0, symbol="EURUSD")
+    votes = {v["source"]: v for v in res.details["votes"]}
+
+    assert votes["ai"]["weight"] == 0.9

--- a/tests/test_normalize_tech_input.py
+++ b/tests/test_normalize_tech_input.py
@@ -34,7 +34,7 @@ def test_normalize_dataclass_clamp_cap() -> None:
     sig = TechnicalSignal(action="BUY", technical_score=3.0, confidence_tech=0.95)
     vote = _normalize_tech_input(sig, cfg)
     assert vote.direction == 1
-    assert vote.weight == 0.9 * 1.5
+    assert vote.weight == 0.9
     assert vote.score == 3.0
     assert vote.meta["mode"] == "dataclass"
 


### PR DESCRIPTION
## Summary
- Clamp technical vote weight after applying weight multiplier
- Clamp AI vote weights using configuration confidence bounds
- Add tests for weight clipping

## Testing
- `pytest tests/test_contract_confidence.py tests/test_decision_agent.py tests/test_normalize_tech_input.py`


------
https://chatgpt.com/codex/tasks/task_e_68acb512032483268d3af6973dde1719