### PR TITLE
feat: add broker adjusted stops event

### DIFF
--- a/docs/15_logging_schema.json
+++ b/docs/15_logging_schema.json
@@ -7,9 +7,18 @@
     "level": {"type": "string"},
     "symbol": {"type": "string"},
     "action": {"type": "string"},
+    "run_id": {"type": ["string", "null"]},
+    "setup_id": {"type": ["string", "null"]},
+    "client_order_id": {"type": ["string", "null"]},
+    "ticket": {"type": ["number", "null"]},
     "side": {"type": "string"},
+    "entry": {"type": ["number", "null"]},
+    "sl": {"type": ["number", "null"]},
+    "tp": {"type": ["number", "null"]},
     "qty": {"type": "number"},
     "price": {"type": "number"},
+    "reason": {"type": ["string", "null"]},
+    "ts": {"type": ["number", "null"]},
     "latency_ms": {"type": "number"},
     "error": {"type": ["string", "null"]},
     "context": {"type": ["object", "null"]},
@@ -84,6 +93,133 @@
         "fill_price": {"type": "number"},
         "slippage": {"type": "number"},
         "reason": {"type": "string"}
+      },
+      "required": ["event"]
+    }
+    ,
+    "order_submitted": {
+      "type": "object",
+      "properties": {
+        "event": {"const": "order_submitted"},
+        "run_id": {"type": "string"},
+        "setup_id": {"type": "string"},
+        "client_order_id": {"type": "string"},
+        "ticket": {"type": "number"},
+        "side": {"type": "string"},
+        "entry": {"type": "number"},
+        "sl": {"type": "number"},
+        "tp": {"type": "number"},
+        "qty": {"type": "number"},
+        "reason": {"type": "string"},
+        "ts": {"type": "number"}
+      },
+      "required": ["event"]
+    },
+    "order_ack": {
+      "type": "object",
+      "properties": {
+        "event": {"const": "order_ack"},
+        "run_id": {"type": "string"},
+        "setup_id": {"type": "string"},
+        "client_order_id": {"type": "string"},
+        "ticket": {"type": "number"},
+        "side": {"type": "string"},
+        "entry": {"type": "number"},
+        "sl": {"type": "number"},
+        "tp": {"type": "number"},
+        "qty": {"type": "number"},
+        "reason": {"type": "string"},
+        "ts": {"type": "number"}
+      },
+      "required": ["event"]
+    },
+    "order_filled": {
+      "type": "object",
+      "properties": {
+        "event": {"const": "order_filled"},
+        "run_id": {"type": "string"},
+        "setup_id": {"type": "string"},
+        "client_order_id": {"type": "string"},
+        "ticket": {"type": "number"},
+        "side": {"type": "string"},
+        "entry": {"type": "number"},
+        "sl": {"type": "number"},
+        "tp": {"type": "number"},
+        "qty": {"type": "number"},
+        "reason": {"type": "string"},
+        "ts": {"type": "number"}
+      },
+      "required": ["event"]
+    },
+    "order_rejected": {
+      "type": "object",
+      "properties": {
+        "event": {"const": "order_rejected"},
+        "run_id": {"type": "string"},
+        "setup_id": {"type": "string"},
+        "client_order_id": {"type": "string"},
+        "ticket": {"type": "number"},
+        "side": {"type": "string"},
+        "entry": {"type": "number"},
+        "sl": {"type": "number"},
+        "tp": {"type": "number"},
+        "qty": {"type": "number"},
+        "reason": {"type": "string"},
+        "ts": {"type": "number"}
+      },
+      "required": ["event"]
+    },
+    "order_timeout": {
+      "type": "object",
+      "properties": {
+        "event": {"const": "order_timeout"},
+        "run_id": {"type": "string"},
+        "setup_id": {"type": "string"},
+        "client_order_id": {"type": "string"},
+        "ticket": {"type": "number"},
+        "side": {"type": "string"},
+        "entry": {"type": "number"},
+        "sl": {"type": "number"},
+        "tp": {"type": "number"},
+        "qty": {"type": "number"},
+        "reason": {"type": "string"},
+        "ts": {"type": "number"}
+      },
+      "required": ["event"]
+    },
+    "order_retry": {
+      "type": "object",
+      "properties": {
+        "event": {"const": "order_retry"},
+        "run_id": {"type": "string"},
+        "setup_id": {"type": "string"},
+        "client_order_id": {"type": "string"},
+        "ticket": {"type": "number"},
+        "side": {"type": "string"},
+        "entry": {"type": "number"},
+        "sl": {"type": "number"},
+        "tp": {"type": "number"},
+        "qty": {"type": "number"},
+        "reason": {"type": "string"},
+        "ts": {"type": "number"}
+      },
+      "required": ["event"]
+    },
+    "broker_adjusted_stops": {
+      "type": "object",
+      "properties": {
+        "event": {"const": "broker_adjusted_stops"},
+        "run_id": {"type": "string"},
+        "setup_id": {"type": "string"},
+        "client_order_id": {"type": "string"},
+        "ticket": {"type": "number"},
+        "side": {"type": "string"},
+        "entry": {"type": "number"},
+        "sl": {"type": "number"},
+        "tp": {"type": "number"},
+        "qty": {"type": "number"},
+        "reason": {"type": "string"},
+        "ts": {"type": "number"}
       },
       "required": ["event"]
     }

--- a/src/forest5/live/mt4_broker.py
+++ b/src/forest5/live/mt4_broker.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from .router import OrderRouter, OrderResult
 from ..utils.log import (
+    E_BROKER_ADJUSTED_STOPS,
     E_ORDER_ACK,
     E_ORDER_FILLED,
     E_ORDER_REJECTED,
@@ -280,7 +281,7 @@ class MT4Broker(OrderRouter):
                 new_tp = price_for_stops + stop_level
             if new_sl != old_sl or new_tp != old_tp:
                 log.info(
-                    "broker_adjusted_stops",
+                    E_BROKER_ADJUSTED_STOPS,
                     old_sl=old_sl,
                     old_tp=old_tp,
                     new_sl=new_sl,

--- a/src/forest5/utils/log.py
+++ b/src/forest5/utils/log.py
@@ -24,6 +24,7 @@ E_ORDER_FILLED = "order_filled"
 E_ORDER_REJECTED = "order_rejected"
 E_ORDER_TIMEOUT = "order_timeout"
 E_ORDER_RETRY = "order_retry"
+E_BROKER_ADJUSTED_STOPS = "broker_adjusted_stops"
 # Legacy event names kept for backward compatibility.
 E_ORDER_PLACED = "order_placed"
 E_ORDER_CANCELLED = "order_cancelled"

--- a/tests/test_mt4_broker_stop_level.py
+++ b/tests/test_mt4_broker_stop_level.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from forest5.live.mt4_broker import MT4Broker
+from forest5.utils.log import E_BROKER_ADJUSTED_STOPS
 
 
 def test_stop_level_clamps_sl_tp(tmp_path: Path, capfd) -> None:
@@ -23,7 +24,7 @@ def test_stop_level_clamps_sl_tp(tmp_path: Path, capfd) -> None:
     assert data["sl"] == pytest.approx(1.2340)
     assert data["tp"] == pytest.approx(1.2350)
     captured = capfd.readouterr()
-    assert "broker_adjusted_stops" in captured.out
+    assert E_BROKER_ADJUSTED_STOPS in captured.out
 
 
 def test_wait_for_result_returns_adjusted_stops(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add E_BROKER_ADJUSTED_STOPS event constant
- document order-related logging schema and broker stop adjustments
- use new constant in MT4 broker and tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acbeb065c88326b475c7a5be196cd2