### PR TITLE
Log backtest order rejection events

### DIFF
--- a/tests/test_engine_order_rejection.py
+++ b/tests/test_engine_order_rejection.py
@@ -1,0 +1,68 @@
+import pandas as pd
+from unittest.mock import patch
+
+from forest5.backtest.engine import BacktestEngine
+from forest5.config import BacktestSettings
+from forest5.signals.setups import TriggeredSignal
+from forest5.utils.log import E_ORDER_REJECTED
+
+
+def _make_engine() -> BacktestEngine:
+    df = pd.DataFrame({
+        "open": [1.0],
+        "high": [1.0],
+        "low": [1.0],
+        "close": [1.0],
+    })
+    settings = BacktestSettings()
+    return BacktestEngine(df, settings)
+
+
+def test_open_order_rejected_logs_event():
+    eng = _make_engine()
+    sig = TriggeredSignal(
+        setup_id="s1",
+        action="BUY",
+        entry=1.0,
+        sl=0.0,
+        tp=2.0,
+        meta={"qty": 0.0},
+    )
+    with patch("forest5.backtest.engine.log_event") as le:
+        eng._open_position(sig, entry=1.0, index=0)
+    le.assert_called_once()
+    event, ctx = le.call_args[0][:2]
+    kwargs = le.call_args[1]
+    assert event == E_ORDER_REJECTED
+    assert kwargs["reason"] == "qty_zero"
+    assert kwargs["client_order_id"]
+    assert ctx.setup_id == "s1"
+
+
+def test_close_order_rejected_logs_event():
+    eng = _make_engine()
+    pos = {
+        "id": "s1",
+        "action": "BUY",
+        "entry": 1.0,
+        "sl": 0.0,
+        "tp": 2.0,
+        "orig_sl": 0.0,
+        "orig_tp": 2.0,
+        "open_index": 0,
+        "horizon": 0,
+        "meta": {},
+        "ticket": 1,
+        "client_order_id": "cid1",
+        "qty": 0.0,
+    }
+    with patch("forest5.backtest.engine.log_event") as le:
+        eng._close_position(pos, price=1.0)
+    le.assert_called_once()
+    event, ctx = le.call_args[0][:2]
+    kwargs = le.call_args[1]
+    assert event == E_ORDER_REJECTED
+    assert kwargs["reason"] == "qty_zero"
+    assert kwargs["client_order_id"]
+    assert ctx.setup_id == "s1"
+

--- a/tests/test_logging_order_flow.py
+++ b/tests/test_logging_order_flow.py
@@ -7,6 +7,7 @@ from forest5.live.router import PaperBroker, submit_order
 from forest5.utils.log import (
     E_ORDER_ACK,
     E_ORDER_FILLED,
+    E_ORDER_REJECTED,
     E_ORDER_SUBMITTED,
     TelemetryContext,
     new_id,
@@ -40,4 +41,27 @@ def test_order_flow_logging(caplog):
     for r in records:
         assert r.get("client_order_id") == cid
     # restore default print logger for other tests
+    structlog.configure(processors=processors)
+
+
+def test_order_flow_rejected_logging(caplog):
+    processors = [
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.add_log_level,
+        structlog.processors.dict_tracebacks,
+        structlog.processors.JSONRenderer(),
+    ]
+    setup_logger()
+    structlog.configure(processors=processors, logger_factory=structlog.stdlib.LoggerFactory())
+    broker = PaperBroker()
+    broker.connect()
+    ctx = TelemetryContext(run_id="test_run", symbol="EURUSD")
+    cid = new_id("cl")
+
+    with caplog.at_level(logging.INFO):
+        submit_order(broker, "BUY", 0.0, price=1.2345, ctx=ctx, client_order_id=cid)
+
+    records = [json.loads(r.message) for r in caplog.records]
+    assert [r["event"] for r in records] == [E_ORDER_REJECTED]
+    assert records[0].get("client_order_id") == cid
     structlog.configure(processors=processors)


### PR DESCRIPTION
## Summary
- log `E_ORDER_REJECTED` with client order ids when backtest trades have non-positive size
- support quantity tracking on positions and apply qty to equity calculation
- cover rejection logging in tests and expand order flow tests

## Testing
- `pytest tests/test_logging_order_flow.py tests/test_engine_order_rejection.py -q`
- `pytest tests/test_engine.py -q`
- `pytest tests/test_contract_sl_tp_preservation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68acc451537483268acdf0b7eeaf1bd8