### PR TITLE
Add time index utilities and gap-aware loaders

### DIFF
--- a/src/forest5/utils/io.py
+++ b/src/forest5/utils/io.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pandas as pd
 
 from ..config import get_data_dir
+from .timeindex import ensure_h1
 
 DATA_DIR = get_data_dir()
 
@@ -283,7 +284,7 @@ def read_ohlc_csv(
     return df
 
 
-def load_symbol_csv(symbol: str, data_dir: Path | str | None = None) -> pd.DataFrame:
+def load_symbol_csv(symbol: str, data_dir: Path | str | None = None) -> tuple[pd.DataFrame, dict]:
     """Load OHLC data for ``symbol`` from ``data_dir``.
 
     Parameters
@@ -299,8 +300,9 @@ def load_symbol_csv(symbol: str, data_dir: Path | str | None = None) -> pd.DataF
 
     Returns
     -------
-    pd.DataFrame
-        Data loaded via :func:`read_ohlc_csv`.
+    tuple
+        ``(df, meta)`` where ``df`` is the loaded data and ``meta`` contains
+        gap information from :func:`~forest5.utils.timeindex.ensure_h1`.
 
     Raises
     ------
@@ -324,4 +326,6 @@ def load_symbol_csv(symbol: str, data_dir: Path | str | None = None) -> pd.DataF
     except csv.Error:
         pass
 
-    return read_ohlc_csv(path, has_header=has_header)
+    df = read_ohlc_csv(path, has_header=has_header)
+    df, meta = ensure_h1(df)
+    return df, meta

--- a/src/forest5/utils/timeindex.py
+++ b/src/forest5/utils/timeindex.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import pandas as pd
+
+
+@dataclass
+class GapInfo:
+    """Information about a gap in a :class:`pandas.DatetimeIndex`.
+
+    Attributes
+    ----------
+    start:
+        Timestamp before the gap (UTC).
+    end:
+        Timestamp after the gap (UTC).
+    missing:
+        Number of missing expected periods between ``start`` and ``end``.
+    """
+
+    start: pd.Timestamp
+    end: pd.Timestamp
+    missing: int
+
+
+def _to_utc(idx: pd.DatetimeIndex) -> pd.DatetimeIndex:
+    """Return ``idx`` converted to UTC and sorted."""
+    idx = pd.DatetimeIndex(idx).sort_values()
+    if idx.tz is None:
+        return idx.tz_localize("UTC")
+    return idx.tz_convert("UTC")
+
+
+def report_gaps(idx: pd.DatetimeIndex, expected: str = "1h") -> List[GapInfo]:
+    """Return information about gaps greater than ``expected``.
+
+    ``idx`` is first converted to UTC to avoid false positives around DST
+    transitions.
+    """
+
+    idx_utc = _to_utc(idx)
+    step = pd.Timedelta(expected)
+    gaps: List[GapInfo] = []
+    for prev, cur in zip(idx_utc[:-1], idx_utc[1:]):
+        delta = cur - prev
+        if delta > step:
+            missing = int(delta / step) - 1
+            gaps.append(GapInfo(start=prev, end=cur, missing=missing))
+    return gaps
+
+
+def ensure_h1(df: pd.DataFrame, policy: str = "strict") -> Tuple[pd.DataFrame, dict]:
+    """Ensure ``df`` has a 1-hourly index.
+
+    Parameters
+    ----------
+    df:
+        Data indexed by :class:`pandas.DatetimeIndex`.
+    policy:
+        ``'strict'`` raises :class:`ValueError` if the index is irregular.
+        ``'pad'`` inserts missing rows with ``NaN`` values. ``'drop'`` removes
+        rows corresponding to missing periods.
+
+    Returns
+    -------
+    tuple
+        ``(df_out, meta)`` where ``meta['gaps']`` contains a list of
+        :class:`GapInfo` entries describing gaps greater than 1 hour.
+    """
+
+    if not isinstance(df.index, pd.DatetimeIndex):
+        raise ValueError("Index must be DatetimeIndex with 1H step")
+
+    if df.empty:
+        return df.copy(), {"gaps": []}
+
+    df = df.copy()
+    idx_utc = _to_utc(df.index)
+    step = pd.Timedelta("1h")
+    deltas = idx_utc.to_series().diff().dropna()
+    irregular = (deltas != step).any()
+    gaps = report_gaps(idx_utc, "1h")
+
+    if irregular:
+        if policy == "strict":
+            raise ValueError("Index must have 1H frequency")
+        full = pd.date_range(idx_utc[0], idx_utc[-1], freq=step, tz="UTC")
+        df.index = idx_utc
+        df = df[~df.index.duplicated(keep="first")]
+        df = df.reindex(full)
+        if policy == "drop":
+            df = df.dropna()
+    else:
+        df.index = idx_utc
+
+    df.index = df.index.tz_localize(None)
+    df.index.name = "time"
+    return df, {"gaps": gaps}

--- a/tests/test_load_symbol_csv.py
+++ b/tests/test_load_symbol_csv.py
@@ -15,7 +15,7 @@ def test_load_symbol_csv_no_header(tmp_path):
         )
     )
 
-    df = load_symbol_csv("eurusd", data_dir=data_dir)
+    df, meta = load_symbol_csv("eurusd", data_dir=data_dir)
     expected = pd.to_datetime(
         [
             "2020-01-01 00:00",
@@ -26,6 +26,7 @@ def test_load_symbol_csv_no_header(tmp_path):
     assert isinstance(df.index, pd.DatetimeIndex)
     assert df.index.equals(expected)
     assert len(df) == 2
+    assert meta["gaps"] == []
 
 
 def test_load_symbol_csv_rejects_unknown_symbol(tmp_path):

--- a/tests/test_timeindex.py
+++ b/tests/test_timeindex.py
@@ -1,0 +1,32 @@
+import pandas as pd
+import pytest
+
+from forest5.utils.timeindex import ensure_h1
+
+
+def _sample_df():
+    idx = pd.to_datetime(["2020-01-01 00:00", "2020-01-01 03:00"])
+    return pd.DataFrame(
+        {
+            "open": [1, 2],
+            "high": [1, 2],
+            "low": [1, 2],
+            "close": [1, 2],
+        },
+        index=idx,
+    )
+
+
+def test_ensure_h1_strict_raises():
+    with pytest.raises(ValueError):
+        ensure_h1(_sample_df(), policy="strict")
+
+
+def test_ensure_h1_pad_reports_gap():
+    out, meta = ensure_h1(_sample_df(), policy="pad")
+    assert len(out) == 4
+    assert len(meta["gaps"]) == 1
+    gap = meta["gaps"][0]
+    assert gap.missing == 2
+    assert gap.start == pd.Timestamp("2020-01-01 00:00", tz="UTC")
+    assert gap.end == pd.Timestamp("2020-01-01 03:00", tz="UTC")


### PR DESCRIPTION
## Summary
- add new `timeindex` utilities with `GapInfo`, `report_gaps`, and `ensure_h1`
- ensure OHLC loaders call `ensure_h1` and return gap metadata
- cover gap handling with new tests

## Testing
- `pre-commit run --files src/forest5/utils/timeindex.py src/forest5/cli.py src/forest5/utils/io.py tests/test_load_symbol_csv.py tests/test_timeindex.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad6232a8e08326830941628576b4a3