### PR TITLE
feat: add H1 data policy and diagnostics

### DIFF
--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -405,9 +405,7 @@ def add_data_source_args(parser: argparse.ArgumentParser) -> None:
         "--h1-policy",
         choices=("strict", "pad", "drop"),
         default="strict",
-        help=(
-            "Jak traktować braki 1H: 'strict' = błąd, 'pad' = wstaw NaN, 'drop' = usuń"
-        ),
+        help=("Jak traktować braki 1H: 'strict' = błąd, 'pad' = wstaw NaN, 'drop' = usuń"),
     )
 
 

--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -21,10 +21,15 @@ from forest5.config import (
 from forest5.backtest.engine import run_backtest
 from forest5.backtest.grid import run_grid
 from forest5.live.live_runner import run_live
-from forest5.utils.io import read_ohlc_csv, load_symbol_csv
+from forest5.utils.io import read_ohlc_csv, load_symbol_csv, read_ohlc_csv_smart
 from forest5.utils.timeindex import ensure_h1
 from forest5.utils.argparse_ext import PercentAction, span_or_list
-from forest5.utils.log import setup_logger
+from forest5.utils.log import (
+    setup_logger,
+    log_event,
+    E_DATA_CSV_SCHEMA,
+    E_DATA_TIME_GAPS,
+)
 
 
 # Backwards compatibility – old name used in previous versions/tests
@@ -76,7 +81,14 @@ def cmd_backtest(args: argparse.Namespace) -> int:
         print(f"CSV file not found: {csv_path}", file=sys.stderr)
         return 1
 
-    df, _meta = load_ohlc_csv(csv_path, time_col=args.time_col, sep=args.sep)
+    df = read_ohlc_csv_smart(csv_path, time_col=args.time_col, sep=args.sep)
+    log_event(E_DATA_CSV_SCHEMA, path=str(csv_path), notes=df.attrs.get("notes", []))
+    df, meta = ensure_h1(df, policy=args.h1_policy)
+    gaps = [
+        {"start": g.start.isoformat(), "end": g.end.isoformat(), "missing": g.missing}
+        for g in meta.get("gaps", [])
+    ]
+    log_event(E_DATA_TIME_GAPS, path=str(csv_path), gaps=gaps)
 
     settings = BacktestSettings(
         symbol=args.symbol,
@@ -136,9 +148,23 @@ def cmd_backtest(args: argparse.Namespace) -> int:
 
 def cmd_grid(args: argparse.Namespace) -> int:
     if args.csv:
-        df, _meta = load_ohlc_csv(args.csv, time_col=args.time_col, sep=args.sep)
+        csv_path = Path(args.csv)
     else:
-        df, _meta = load_symbol_csv(args.symbol, data_dir=args.data_dir)
+        data_dir = get_data_dir(args.data_dir)
+        csv_path = data_dir / f"{args.symbol}_H1.csv"
+
+    if not csv_path.exists():
+        print(f"CSV file not found: {csv_path}", file=sys.stderr)
+        return 1
+
+    df = read_ohlc_csv_smart(csv_path, time_col=args.time_col, sep=args.sep)
+    log_event(E_DATA_CSV_SCHEMA, path=str(csv_path), notes=df.attrs.get("notes", []))
+    df, meta = ensure_h1(df, policy=args.h1_policy)
+    gaps = [
+        {"start": g.start.isoformat(), "end": g.end.isoformat(), "missing": g.missing}
+        for g in meta.get("gaps", [])
+    ]
+    log_event(E_DATA_TIME_GAPS, path=str(csv_path), gaps=gaps)
 
     fast_vals = span_or_list(args.fast_values, int)
     slow_vals = span_or_list(args.slow_values, int)
@@ -373,6 +399,14 @@ def add_data_source_args(parser: argparse.ArgumentParser) -> None:
         help=(
             "Symbol (np. EURUSD). Używany do automatycznego wyszukania danych w "
             f"{DEFAULT_DATA_DIR}/<SYMBOL>_H1.csv"
+        ),
+    )
+    parser.add_argument(
+        "--h1-policy",
+        choices=("strict", "pad", "drop"),
+        default="strict",
+        help=(
+            "Jak traktować braki 1H: 'strict' = błąd, 'pad' = wstaw NaN, 'drop' = usuń"
         ),
     )
 

--- a/src/forest5/utils/log.py
+++ b/src/forest5/utils/log.py
@@ -32,6 +32,10 @@ E_ORDER_CANCELLED = "order_cancelled"
 # Generic error/diagnostics events.
 E_ERROR = "error"
 
+# Data loading and validation events.
+E_DATA_CSV_SCHEMA = "data_csv_schema"
+E_DATA_TIME_GAPS = "data_time_gaps"
+
 
 # -- Reason codes ----------------------------------------------------------
 # Reason codes provide additional colour for a given event.  As with the event

--- a/tests/test_cli_grid_dry_run.py
+++ b/tests/test_cli_grid_dry_run.py
@@ -52,8 +52,8 @@ def test_cli_grid_dry_run(tmp_path, monkeypatch, capsys):
     assert rc == 0
     assert called is False
 
-    out = capsys.readouterr().out.strip()
-    assert out.startswith("dry-run")
-    kw = ast.literal_eval(out.split("dry-run ", 1)[1])
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out[-1].startswith("dry-run")
+    kw = ast.literal_eval(out[-1].split("dry-run ", 1)[1])
     combos = len(kw["fast_values"]) * len(kw["slow_values"])
     assert combos == 4

--- a/tests/test_cli_h1_policy.py
+++ b/tests/test_cli_h1_policy.py
@@ -51,4 +51,3 @@ def test_h1_policy_pad_drop(tmp_path, monkeypatch, policy, expected):
     cmd_backtest(args)
 
     assert captured["len"] == expected
-

--- a/tests/test_cli_h1_policy.py
+++ b/tests/test_cli_h1_policy.py
@@ -1,0 +1,54 @@
+import pandas as pd
+import pytest
+from types import SimpleNamespace
+
+from forest5.cli import build_parser, cmd_backtest
+
+
+def _write_gap_csv(path):
+    idx = pd.to_datetime(["2020-01-01 00:00", "2020-01-01 02:00"])
+    df = pd.DataFrame(
+        {
+            "time": idx,
+            "open": [1.0, 1.2],
+            "high": [1.1, 1.3],
+            "low": [0.9, 1.1],
+            "close": [1.0, 1.2],
+        }
+    )
+    df.to_csv(path, index=False)
+    return path
+
+
+@pytest.mark.parametrize("policy, expected", [("pad", 3), ("drop", 2)])
+def test_h1_policy_pad_drop(tmp_path, monkeypatch, policy, expected):
+    csv_path = _write_gap_csv(tmp_path / "data.csv")
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "backtest",
+            "--csv",
+            str(csv_path),
+            "--symbol",
+            "EURUSD",
+            "--h1-policy",
+            policy,
+        ]
+    )
+
+    captured = {}
+
+    def fake_run_backtest(df, settings, symbol, price_col, atr_period, atr_multiple):
+        captured["len"] = len(df)
+        return SimpleNamespace(
+            equity_curve=pd.Series([1.0]),
+            max_dd=0.0,
+            trades=SimpleNamespace(trades=[]),
+        )
+
+    monkeypatch.setattr("forest5.cli.run_backtest", fake_run_backtest)
+
+    cmd_backtest(args)
+
+    assert captured["len"] == expected
+


### PR DESCRIPTION
## Summary
- add `--h1-policy` option for handling missing 1H periods
- read OHLC data via smart CSV reader and log schema & gap diagnostics
- cover H1 policies in CLI tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad656240ac83268e6db4e2a3063bb5