### PR TITLE
Add tests for CSV parsing and H1 policy handling

### DIFF
--- a/tests/test_csv_dialect_sniff.py
+++ b/tests/test_csv_dialect_sniff.py
@@ -1,0 +1,25 @@
+import pytest
+
+from forest5.utils.io import read_ohlc_csv_smart, sniff_csv_dialect
+
+
+def test_separator_detection(tmp_path):
+    path = tmp_path / "data.csv"
+    path.write_text(
+        "time;open;high;low;close\n" "2020-01-01 00:00;1.0;1.0;1.0;1.0\n",
+        encoding="utf-8",
+    )
+    sep, decimal, has_header = sniff_csv_dialect(path)
+    assert sep == ";"
+    assert decimal == "."
+    assert has_header is True
+
+
+def test_numeric_parsing(tmp_path):
+    path = tmp_path / "comma.csv"
+    path.write_text(
+        "time;open;high;low;close\n" "2020-01-01 00:00;1,23;1,23;1,23;1,23\n",
+        encoding="utf-8",
+    )
+    df = read_ohlc_csv_smart(path)
+    assert df["open"].iloc[0] == pytest.approx(1.23)

--- a/tests/test_csv_infer_schema.py
+++ b/tests/test_csv_infer_schema.py
@@ -1,0 +1,36 @@
+import pytest
+
+from forest5.utils.io import read_ohlc_csv_smart
+
+
+def test_headerless_csv(tmp_path):
+    path = tmp_path / "no_header.csv"
+    path.write_text(
+        "2020-01-01 00:00,1,1,1,1,10\n" "2020-01-01 01:00,1,1,1,1,11\n",
+        encoding="utf-8",
+    )
+    df = read_ohlc_csv_smart(path)
+    assert list(df.columns) == ["open", "high", "low", "close", "volume"]
+    assert len(df) == 2
+
+
+def test_column_aliases(tmp_path):
+    path = tmp_path / "aliases.csv"
+    path.write_text(
+        "Date,Time,O,H,L,C,V\n" "2020-01-01,00:00,1,2,0,1,5\n" "2020-01-01,01:00,1,2,0,1,6\n",
+        encoding="utf-8",
+    )
+    df = read_ohlc_csv_smart(path)
+    assert list(df.columns) == ["open", "high", "low", "close", "volume"]
+    assert len(df) == 2
+
+
+def test_decimal_commas(tmp_path):
+    path = tmp_path / "commas.csv"
+    path.write_text(
+        "time;open;high;low;close\n" "2020-01-01 00:00;1,1;2,2;0,9;1,0\n",
+        encoding="utf-8",
+    )
+    df = read_ohlc_csv_smart(path)
+    assert df["open"].iloc[0] == pytest.approx(1.1)
+    assert df["high"].iloc[0] == pytest.approx(2.2)

--- a/tests/test_data_subcommands.py
+++ b/tests/test_data_subcommands.py
@@ -1,0 +1,46 @@
+import pandas as pd
+
+from forest5.cli import main
+
+
+def test_data_inspect_smoke(tmp_path):
+    csv = tmp_path / "data.csv"
+    df = pd.DataFrame(
+        {
+            "time": pd.date_range("2020-01-01", periods=2, freq="h"),
+            "open": [1, 1.1],
+            "high": [1, 1.1],
+            "low": [1, 1.1],
+            "close": [1, 1.1],
+        }
+    )
+    df.to_csv(csv, index=False)
+    rc = main(["data", "inspect", "--csv", str(csv)])
+    assert rc == 0
+
+
+def test_data_normalize_smoke(tmp_path):
+    in_dir = tmp_path / "in"
+    out_dir = tmp_path / "out"
+    in_dir.mkdir()
+    (in_dir / "raw.csv").write_text(
+        "Date,Time,O,H,L,C\n" "2020-01-01,00:00,1,2,0,1\n",
+        encoding="utf-8",
+    )
+    rc = main(["data", "normalize", "--input-dir", str(in_dir), "--out-dir", str(out_dir)])
+    assert rc == 0
+    assert (out_dir / "raw.csv").exists()
+
+
+def test_data_pad_h1_smoke(tmp_path):
+    in_dir = tmp_path / "in"
+    out_dir = tmp_path / "out"
+    in_dir.mkdir()
+    (in_dir / "pad.csv").write_text(
+        "time,open,high,low,close\n" "2020-01-01 00:00,1,1,1,1\n" "2020-01-01 02:00,1,1,1,1\n",
+        encoding="utf-8",
+    )
+    rc = main(["data", "pad-h1", "--input-dir", str(in_dir), "--out-dir", str(out_dir)])
+    assert rc == 0
+    df = pd.read_csv(out_dir / "pad.csv")
+    assert len(df) == 3

--- a/tests/test_h1_policies.py
+++ b/tests/test_h1_policies.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import pytest
+
+from forest5.utils.timeindex import ensure_h1
+
+
+def _gap_df():
+    idx = pd.to_datetime(["2020-01-01 00:00", "2020-01-01 02:00"])
+    return pd.DataFrame({"open": [1.0, 1.2]}, index=idx)
+
+
+def test_strict_raises_on_gap():
+    with pytest.raises(ValueError):
+        ensure_h1(_gap_df(), policy="strict")
+
+
+def test_pad_inserts_missing_row():
+    out, meta = ensure_h1(_gap_df(), policy="pad")
+    assert len(out) == 3
+    assert meta["gaps"][0].missing == 1
+    assert out.isna().any().any()
+
+
+def test_drop_discards_missing_period():
+    out, meta = ensure_h1(_gap_df(), policy="drop")
+    assert len(out) == 2
+    assert meta["gaps"][0].missing == 1


### PR DESCRIPTION
## Summary
- test CSV schema inference for headerless files, column aliases and decimal comma values
- exercise dialect sniffing and numeric parsing of semicolon-delimited data
- cover `ensure_h1` strict/pad/drop policies and CLI usage via backtest, grid, and data subcommands

## Testing
- `ruff check .`
- `black --check .`
- `pytest tests/test_csv_infer_schema.py tests/test_csv_dialect_sniff.py tests/test_h1_policies.py tests/test_cli_h1_policy.py tests/test_data_subcommands.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad6c8a04f08326a1b08f03e7985139