### PR TITLE
feat(cli): expand grid range parsing and aliases

### DIFF
--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -175,10 +175,10 @@ def cmd_grid(args: argparse.Namespace) -> int:
     if args.time_from is not None or args.time_to is not None:
         df = df.loc[args.time_from : args.time_to]
 
-    fast_vals = span_or_list(args.fast_values, int)
-    slow_vals = span_or_list(args.slow_values, int)
-    risk_vals = args.risk_values if args.risk_values else None
-    max_dd_vals = args.max_dd_values if args.max_dd_values else None
+    fast_vals = [int(v) for v in args.fast_values]
+    slow_vals = [int(v) for v in args.slow_values]
+    risk_vals = [float(v) for v in args.risk_values] if args.risk_values else None
+    max_dd_vals = [float(v) for v in args.max_dd_values] if args.max_dd_values else None
 
     if args.seed is not None:
         random.seed(args.seed)
@@ -197,20 +197,20 @@ def cmd_grid(args: argparse.Namespace) -> int:
         max_dd=float(args.max_dd),
         fee=float(args.fee),
         slippage=float(args.slippage),
-        atr_period=int(args.atr_period),
+        atr_period=int(args.atr_period[0]),
         atr_multiple=float(args.atr_multiple),
         use_rsi=bool(args.use_rsi),
-        rsi_period=int(args.rsi_period),
+        rsi_period=int(args.rsi_period[0]),
         rsi_oversold=int(args.rsi_oversold),
         rsi_overbought=int(args.rsi_overbought),
-        t_sep_atr=float(args.t_sep_atr),
-        pullback_atr=float(args.pullback_atr),
-        entry_buffer_atr=float(args.entry_buffer_atr),
+        t_sep_atr=float(args.t_sep_atr[0]),
+        pullback_atr=float(args.pullback_atr[0]),
+        entry_buffer_atr=float(args.entry_buffer_atr[0]),
         sl_atr=float(args.sl_atr),
-        sl_min_atr=float(args.sl_min_atr),
-        rr=float(args.rr),
-        q_low=float(args.q_low),
-        q_high=float(args.q_high),
+        sl_min_atr=float(args.sl_min_atr[0]),
+        rr=float(args.rr[0]),
+        q_low=float(args.q_low[0]),
+        q_high=float(args.q_high[0]),
         time_model=args.time_model,
         min_confluence=float(args.min_confluence),
         n_jobs=int(args.jobs),
@@ -225,6 +225,9 @@ def cmd_grid(args: argparse.Namespace) -> int:
         kwargs["risk_values"] = risk_vals
     if max_dd_vals:
         kwargs["max_dd_values"] = max_dd_vals
+    if len(args.rsi_period) > 1:
+        kwargs.pop("rsi_period", None)
+        kwargs["rsi_period_values"] = [int(v) for v in args.rsi_period]
     if args.debug_dir:
         kwargs["debug_dir"] = args.debug_dir
     if args.seed is not None:
@@ -557,14 +560,18 @@ def build_parser() -> argparse.ArgumentParser:
     p_gr.add_argument(
         "--ema-fast",
         "--fast-values",
+        "--fast",
         dest="fast_values",
+        type=span_or_list,
         required=True,
         help="Np. 5:20:1 lub 5,8,13",
     )
     p_gr.add_argument(
         "--ema-slow",
         "--slow-values",
+        "--slow",
         dest="slow_values",
+        type=span_or_list,
         required=True,
         help="Np. 10:60:2 lub 12,26",
     )
@@ -575,13 +582,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_gr.add_argument(
         "--risk-values",
-        type=lambda s: span_or_list(s, float),
+        type=span_or_list,
         default=None,
         help="Lista wartości ryzyka, np. 0.01,0.02",
     )
     p_gr.add_argument(
         "--max-dd-values",
-        type=lambda s: span_or_list(s, float),
+        type=span_or_list,
         default=None,
         help="Lista wartości max DD, np. 0.2,0.3",
     )
@@ -591,28 +598,29 @@ def build_parser() -> argparse.ArgumentParser:
     p_gr.add_argument("--fee", action=PercentAction, default=0.0005, help="Prowizja %")
     p_gr.add_argument("--slippage", action=PercentAction, default=0.0, help="Poślizg %")
 
-    p_gr.add_argument("--atr-len", "--atr-period", dest="atr_period", type=int, default=14)
+    p_gr.add_argument("--atr-len", "--atr-period", dest="atr_period", type=span_or_list, default=[14])
     p_gr.add_argument("--atr-multiple", type=float, default=2.0)
 
     p_gr.add_argument("--use-rsi", action="store_true", help="Włącz filtr RSI")
-    p_gr.add_argument("--rsi-len", "--rsi-period", dest="rsi_period", type=int, default=14)
+    p_gr.add_argument("--rsi-len", "--rsi-period", dest="rsi_period", type=span_or_list, default=[14])
     p_gr.add_argument("--rsi-oversold", type=int, default=30, choices=range(0, 101))
     p_gr.add_argument("--rsi-overbought", type=int, default=70, choices=range(0, 101))
 
-    p_gr.add_argument("--t-sep-atr", dest="t_sep_atr", type=float, default=0.5)
+    p_gr.add_argument("--t-sep-atr", dest="t_sep_atr", type=span_or_list, default=[0.5])
     p_gr.add_argument(
         "--pullback-atr",
         "--pullback-to-ema-fast-atr",
         dest="pullback_atr",
-        type=float,
-        default=0.5,
+        type=span_or_list,
+        default=[0.5],
     )
-    p_gr.add_argument("--entry-buffer-atr", dest="entry_buffer_atr", type=float, default=0.1)
+    p_gr.add_argument("--entry-buffer-atr", dest="entry_buffer_atr", type=span_or_list, default=[0.1])
     p_gr.add_argument("--sl-atr", dest="sl_atr", type=float, default=1.0)
-    p_gr.add_argument("--sl-min-atr", dest="sl_min_atr", type=float, default=0.0)
-    p_gr.add_argument("--rr", dest="rr", type=float, default=2.0)
-    p_gr.add_argument("--q-low", dest="q_low", type=float, default=0.1)
-    p_gr.add_argument("--q-high", dest="q_high", type=float, default=0.9)
+    p_gr.add_argument("--sl-min-atr", dest="sl_min_atr", type=span_or_list, default=[0.0])
+    p_gr.add_argument("--rr", dest="rr", type=span_or_list, default=[2.0])
+    p_gr.add_argument("--trailing-atr", dest="trailing_atr", type=span_or_list, default=[0.0])
+    p_gr.add_argument("--q-low", dest="q_low", type=span_or_list, default=[0.1])
+    p_gr.add_argument("--q-high", dest="q_high", type=span_or_list, default=[0.9])
     p_gr.add_argument("--no-engulf", dest="pat_engulf", action="store_false", default=True)
     p_gr.add_argument("--no-pinbar", dest="pat_pinbar", action="store_false", default=True)
     p_gr.add_argument("--no-star", dest="pat_star", action="store_false", default=True)

--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -598,11 +598,15 @@ def build_parser() -> argparse.ArgumentParser:
     p_gr.add_argument("--fee", action=PercentAction, default=0.0005, help="Prowizja %")
     p_gr.add_argument("--slippage", action=PercentAction, default=0.0, help="Poślizg %")
 
-    p_gr.add_argument("--atr-len", "--atr-period", dest="atr_period", type=span_or_list, default=[14])
+    p_gr.add_argument(
+        "--atr-len", "--atr-period", dest="atr_period", type=span_or_list, default=[14]
+    )
     p_gr.add_argument("--atr-multiple", type=float, default=2.0)
 
     p_gr.add_argument("--use-rsi", action="store_true", help="Włącz filtr RSI")
-    p_gr.add_argument("--rsi-len", "--rsi-period", dest="rsi_period", type=span_or_list, default=[14])
+    p_gr.add_argument(
+        "--rsi-len", "--rsi-period", dest="rsi_period", type=span_or_list, default=[14]
+    )
     p_gr.add_argument("--rsi-oversold", type=int, default=30, choices=range(0, 101))
     p_gr.add_argument("--rsi-overbought", type=int, default=70, choices=range(0, 101))
 
@@ -614,7 +618,9 @@ def build_parser() -> argparse.ArgumentParser:
         type=span_or_list,
         default=[0.5],
     )
-    p_gr.add_argument("--entry-buffer-atr", dest="entry_buffer_atr", type=span_or_list, default=[0.1])
+    p_gr.add_argument(
+        "--entry-buffer-atr", dest="entry_buffer_atr", type=span_or_list, default=[0.1]
+    )
     p_gr.add_argument("--sl-atr", dest="sl_atr", type=float, default=1.0)
     p_gr.add_argument("--sl-min-atr", dest="sl_min_atr", type=span_or_list, default=[0.0])
     p_gr.add_argument("--rr", dest="rr", type=span_or_list, default=[2.0])

--- a/tests/test_cli_grid_ranges.py
+++ b/tests/test_cli_grid_ranges.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+import pandas as pd
+
+from forest5.cli import build_parser
+
+
+def _write_csv(path: Path) -> Path:
+    idx = pd.date_range("2020-01-01", periods=3, freq="h")
+    df = pd.DataFrame({
+        "time": idx,
+        "open": [1.0, 1.1, 1.2],
+        "high": [1.1, 1.2, 1.3],
+        "low": [0.9, 1.0, 1.1],
+        "close": [1.0, 1.1, 1.2],
+    })
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_grid_range_parsing(tmp_path):
+    csv_path = _write_csv(tmp_path / "data.csv")
+    parser = build_parser()
+    args = parser.parse_args([
+        "grid",
+        "--csv", str(csv_path),
+        "--symbol", "EURUSD",
+        "--ema-fast", "1-3",
+        "--ema-slow", "4,5",
+        "--rsi-len", "7:9:1",
+        "--atr-len", "10",
+        "--t-sep-atr", "0.5-1.0:0.25",
+        "--pullback-atr", "0.5",
+        "--entry-buffer-atr", "0.1",
+        "--sl-min-atr", "0.2",
+        "--rr", "1.5",
+        "--trailing-atr", "0.5",
+        "--q-low", "0.1",
+        "--q-high", "0.9",
+    ])
+    assert args.fast_values == [1, 2, 3]
+    assert args.slow_values == [4, 5]
+    assert args.rsi_period == [7, 8, 9]
+    assert args.atr_period == [10]
+    assert args.t_sep_atr == [0.5, 0.75, 1.0]
+    assert args.pullback_atr == [0.5]
+    assert args.entry_buffer_atr == [0.1]
+    assert args.sl_min_atr == [0.2]
+    assert args.rr == [1.5]
+    assert args.trailing_atr == [0.5]
+    assert args.q_low == [0.1]
+    assert args.q_high == [0.9]
+
+
+def test_grid_fast_slow_alias(tmp_path):
+    csv_path = _write_csv(tmp_path / "data.csv")
+    parser = build_parser()
+    args = parser.parse_args([
+        "grid",
+        "--csv", str(csv_path),
+        "--symbol", "EURUSD",
+        "--fast", "12",
+        "--slow", "24",
+    ])
+    assert args.fast_values == [12]
+    assert args.slow_values == [24]

--- a/tests/test_cli_grid_ranges.py
+++ b/tests/test_cli_grid_ranges.py
@@ -6,13 +6,15 @@ from forest5.cli import build_parser
 
 def _write_csv(path: Path) -> Path:
     idx = pd.date_range("2020-01-01", periods=3, freq="h")
-    df = pd.DataFrame({
-        "time": idx,
-        "open": [1.0, 1.1, 1.2],
-        "high": [1.1, 1.2, 1.3],
-        "low": [0.9, 1.0, 1.1],
-        "close": [1.0, 1.1, 1.2],
-    })
+    df = pd.DataFrame(
+        {
+            "time": idx,
+            "open": [1.0, 1.1, 1.2],
+            "high": [1.1, 1.2, 1.3],
+            "low": [0.9, 1.0, 1.1],
+            "close": [1.0, 1.1, 1.2],
+        }
+    )
     df.to_csv(path, index=False)
     return path
 
@@ -20,23 +22,39 @@ def _write_csv(path: Path) -> Path:
 def test_grid_range_parsing(tmp_path):
     csv_path = _write_csv(tmp_path / "data.csv")
     parser = build_parser()
-    args = parser.parse_args([
-        "grid",
-        "--csv", str(csv_path),
-        "--symbol", "EURUSD",
-        "--ema-fast", "1-3",
-        "--ema-slow", "4,5",
-        "--rsi-len", "7:9:1",
-        "--atr-len", "10",
-        "--t-sep-atr", "0.5-1.0:0.25",
-        "--pullback-atr", "0.5",
-        "--entry-buffer-atr", "0.1",
-        "--sl-min-atr", "0.2",
-        "--rr", "1.5",
-        "--trailing-atr", "0.5",
-        "--q-low", "0.1",
-        "--q-high", "0.9",
-    ])
+    args = parser.parse_args(
+        [
+            "grid",
+            "--csv",
+            str(csv_path),
+            "--symbol",
+            "EURUSD",
+            "--ema-fast",
+            "1-3",
+            "--ema-slow",
+            "4,5",
+            "--rsi-len",
+            "7:9:1",
+            "--atr-len",
+            "10",
+            "--t-sep-atr",
+            "0.5-1.0:0.25",
+            "--pullback-atr",
+            "0.5",
+            "--entry-buffer-atr",
+            "0.1",
+            "--sl-min-atr",
+            "0.2",
+            "--rr",
+            "1.5",
+            "--trailing-atr",
+            "0.5",
+            "--q-low",
+            "0.1",
+            "--q-high",
+            "0.9",
+        ]
+    )
     assert args.fast_values == [1, 2, 3]
     assert args.slow_values == [4, 5]
     assert args.rsi_period == [7, 8, 9]
@@ -54,12 +72,18 @@ def test_grid_range_parsing(tmp_path):
 def test_grid_fast_slow_alias(tmp_path):
     csv_path = _write_csv(tmp_path / "data.csv")
     parser = build_parser()
-    args = parser.parse_args([
-        "grid",
-        "--csv", str(csv_path),
-        "--symbol", "EURUSD",
-        "--fast", "12",
-        "--slow", "24",
-    ])
+    args = parser.parse_args(
+        [
+            "grid",
+            "--csv",
+            str(csv_path),
+            "--symbol",
+            "EURUSD",
+            "--fast",
+            "12",
+            "--slow",
+            "24",
+        ]
+    )
     assert args.fast_values == [12]
     assert args.slow_values == [24]

--- a/tests/test_parse_span_or_list.py
+++ b/tests/test_parse_span_or_list.py
@@ -3,40 +3,31 @@ import pytest
 
 from forest5.utils.argparse_ext import span_or_list
 
-
 def test_int_positive_range():
-    assert span_or_list("1-3", int) == [1, 2, 3]
-
+    assert span_or_list('1-3') == [1, 2, 3]
 
 def test_int_negative_range():
-    assert span_or_list("-3--1", int) == [-3, -2, -1]
-
+    assert span_or_list('-3--1') == [-3, -2, -1]
 
 def test_int_list():
-    assert span_or_list("1,4,7", int) == [1, 4, 7]
-
+    assert span_or_list('1,4,7') == [1, 4, 7]
 
 def test_int_colon_syntax():
-    assert span_or_list("8:16:1", int) == [8, 9, 10, 11, 12, 13, 14, 15, 16]
-
+    assert span_or_list('8:16:1') == [8, 9, 10, 11, 12, 13, 14, 15, 16]
 
 def test_float_range_colon():
-    assert span_or_list("1:2:0.5", float) == [1.0, 1.5, 2.0]
-
+    assert span_or_list('1:2:0.5') == [1.0, 1.5, 2.0]
 
 def test_float_range_dash():
-    assert span_or_list("1.0-2.0:0.5", float) == [1.0, 1.5, 2.0]
-
+    assert span_or_list('1.0-2.0:0.5') == [1.0, 1.5, 2.0]
 
 def test_float_range_non_divisible():
-    assert span_or_list("0:1:0.3", float) == pytest.approx([0.0, 0.3, 0.6, 0.9, 1.0])
-
+    assert span_or_list('0:1:0.3') == pytest.approx([0.0, 0.3, 0.6, 0.9, 1.0])
 
 def test_step_error():
     with pytest.raises(argparse.ArgumentTypeError):
-        span_or_list("1-5:0", int)
-
+        span_or_list('1-5:0')
 
 def test_hi_less_than_lo():
     with pytest.raises(argparse.ArgumentTypeError):
-        span_or_list("5-3", int)
+        span_or_list('5-3')

--- a/tests/test_parse_span_or_list.py
+++ b/tests/test_parse_span_or_list.py
@@ -3,31 +3,40 @@ import pytest
 
 from forest5.utils.argparse_ext import span_or_list
 
+
 def test_int_positive_range():
-    assert span_or_list('1-3') == [1, 2, 3]
+    assert span_or_list("1-3") == [1, 2, 3]
+
 
 def test_int_negative_range():
-    assert span_or_list('-3--1') == [-3, -2, -1]
+    assert span_or_list("-3--1") == [-3, -2, -1]
+
 
 def test_int_list():
-    assert span_or_list('1,4,7') == [1, 4, 7]
+    assert span_or_list("1,4,7") == [1, 4, 7]
+
 
 def test_int_colon_syntax():
-    assert span_or_list('8:16:1') == [8, 9, 10, 11, 12, 13, 14, 15, 16]
+    assert span_or_list("8:16:1") == [8, 9, 10, 11, 12, 13, 14, 15, 16]
+
 
 def test_float_range_colon():
-    assert span_or_list('1:2:0.5') == [1.0, 1.5, 2.0]
+    assert span_or_list("1:2:0.5") == [1.0, 1.5, 2.0]
+
 
 def test_float_range_dash():
-    assert span_or_list('1.0-2.0:0.5') == [1.0, 1.5, 2.0]
+    assert span_or_list("1.0-2.0:0.5") == [1.0, 1.5, 2.0]
+
 
 def test_float_range_non_divisible():
-    assert span_or_list('0:1:0.3') == pytest.approx([0.0, 0.3, 0.6, 0.9, 1.0])
+    assert span_or_list("0:1:0.3") == pytest.approx([0.0, 0.3, 0.6, 0.9, 1.0])
+
 
 def test_step_error():
     with pytest.raises(argparse.ArgumentTypeError):
-        span_or_list('1-5:0')
+        span_or_list("1-5:0")
+
 
 def test_hi_less_than_lo():
     with pytest.raises(argparse.ArgumentTypeError):
-        span_or_list('5-3')
+        span_or_list("5-3")


### PR DESCRIPTION
## Summary
- extend `span_or_list` to autodetect ints/floats
- allow grid CLI options to accept ranges via `type=span_or_list`
- add `--fast`/`--slow` aliases and tests for range parsing

## Testing
- `pytest tests/test_parse_span_or_list.py tests/test_cli_grid_ranges.py tests/test_cli_grid_options.py tests/test_cli_aliases.py tests/test_cli_grid_from_to.py tests/test_cli_grid_dry_run.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad7fb012808326bb8e27c769b994ab