### PR TITLE
Add grid planning dry-run output

### DIFF
--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -245,7 +245,8 @@ def cmd_grid(args: argparse.Namespace) -> int:
         combos = plan_param_grid(param_ranges, filter_fn=lambda c: c["fast"] < c["slow"])
         combos.to_csv("plan.csv", index=False)
         from datetime import datetime, timezone
-        import subprocess, json
+        import json
+        import subprocess
 
         git_rev = "unknown"
         try:  # pragma: no cover - best effort

--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -20,6 +20,7 @@ from forest5.config import (
 )
 from forest5.backtest.engine import run_backtest
 from forest5.backtest.grid import run_grid
+from forest5.grid.engine import plan_param_grid
 from forest5.live.live_runner import run_live
 from forest5.utils.io import (
     read_ohlc_csv,
@@ -234,7 +235,43 @@ def cmd_grid(args: argparse.Namespace) -> int:
         kwargs["seed"] = int(args.seed)
 
     if args.dry_run:
-        print("dry-run", kwargs)
+        param_ranges = {"fast": fast_vals, "slow": slow_vals}
+        if risk_vals:
+            param_ranges["risk"] = risk_vals
+        if max_dd_vals:
+            param_ranges["max_dd"] = max_dd_vals
+        if len(args.rsi_period) > 1:
+            param_ranges["rsi_period"] = [int(v) for v in args.rsi_period]
+        combos = plan_param_grid(param_ranges, filter_fn=lambda c: c["fast"] < c["slow"])
+        combos.to_csv("plan.csv", index=False)
+        from datetime import datetime, timezone
+        import subprocess, json
+
+        git_rev = "unknown"
+        try:  # pragma: no cover - best effort
+            git_rev = (
+                subprocess.check_output(
+                    ["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.DEVNULL
+                )
+                .decode()
+                .strip()
+            )
+        except Exception:  # pragma: no cover
+            pass
+
+        meta = {
+            "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+            "git": git_rev,
+            "symbol": args.symbol,
+            "period": {
+                "start": df.index[0].isoformat(),
+                "end": df.index[-1].isoformat(),
+            },
+            "seed": int(args.seed) if args.seed is not None else None,
+            "total_combos": int(len(combos)),
+        }
+        Path("meta.json").write_text(json.dumps(meta))
+        print(len(combos))
         return 0
 
     out = run_grid(df, **kwargs)

--- a/src/forest5/grid/__init__.py
+++ b/src/forest5/grid/__init__.py
@@ -1,0 +1,3 @@
+from .engine import plan_param_grid
+
+__all__ = ["plan_param_grid"]

--- a/src/forest5/grid/engine.py
+++ b/src/forest5/grid/engine.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from itertools import product
+from typing import Dict, Iterable, Any, Callable
+
+import pandas as pd
+
+
+def plan_param_grid(
+    param_ranges: Dict[str, Iterable[Any]],
+    *,
+    filter_fn: Callable[[Dict[str, Any]], bool] | None = None,
+) -> pd.DataFrame:
+    """Enumerate parameter combinations and assign a ``combo_id``.
+
+    Parameters
+    ----------
+    param_ranges:
+        Mapping from parameter name to an iterable of possible values.
+    filter_fn:
+        Optional predicate to discard combinations.  It receives a dict of
+        parameters and should return ``True`` to keep the combination.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame where each row represents a parameter combination and the
+        first column ``combo_id`` is a unique identifier.
+    """
+
+    keys = sorted(param_ranges.keys())
+    combos = [dict(zip(keys, vals)) for vals in product(*[param_ranges[k] for k in keys])]
+    if filter_fn is not None:
+        combos = [c for c in combos if filter_fn(c)]
+    df = pd.DataFrame(combos)
+    df.insert(0, "combo_id", range(len(df)))
+    return df


### PR DESCRIPTION
## Summary
- Add grid planner to enumerate parameter combinations with `combo_id`
- Extend `grid` CLI dry-run to emit `plan.csv` and `meta.json`
- Cover planning behaviour with new tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad8420d2c883268196af7430349edc