### PR TITLE
feat: add ttl support to H1 signal

### DIFF
--- a/src/forest5/signals/h1_ema_rsi_atr.py
+++ b/src/forest5/signals/h1_ema_rsi_atr.py
@@ -40,6 +40,7 @@ DEFAULT_PARAMS: dict[str, Any] = {
     "rr": 2.0,  # risk–reward ratio
     "timeframe": "H1",
     "horizon_minutes": 240,
+    "ttl_minutes": None,
 }
 
 
@@ -82,6 +83,7 @@ def compute_primary_signal_h1(
         return TechnicalSignal(
             timeframe=p["timeframe"],
             horizon_minutes=p["horizon_minutes"],
+            ttl_minutes=p.get("ttl_minutes"),
             technical_score=0.0,
             confidence_tech=0.0,
             drivers=[],
@@ -103,6 +105,7 @@ def compute_primary_signal_h1(
         return TechnicalSignal(
             timeframe=p["timeframe"],
             horizon_minutes=p["horizon_minutes"],
+            ttl_minutes=p.get("ttl_minutes"),
             technical_score=0.0,
             confidence_tech=0.0,
             drivers=[],
@@ -188,6 +191,7 @@ def compute_primary_signal_h1(
                 return TechnicalSignal(
                     timeframe=p["timeframe"],
                     horizon_minutes=p["horizon_minutes"],
+                    ttl_minutes=p.get("ttl_minutes"),
                     technical_score=0.0,
                     confidence_tech=0.0,
                     drivers=[],
@@ -200,6 +204,7 @@ def compute_primary_signal_h1(
             sl=sl,
             tp=tp,
             horizon_minutes=p["horizon_minutes"],
+            ttl_minutes=p.get("ttl_minutes"),
             technical_score=technical_score,
             confidence_tech=confidence_tech,
             drivers=drivers,
@@ -210,6 +215,7 @@ def compute_primary_signal_h1(
     return TechnicalSignal(
         timeframe=p["timeframe"],
         horizon_minutes=p["horizon_minutes"],
+        ttl_minutes=p.get("ttl_minutes"),
         technical_score=0.0,
         confidence_tech=0.0,
         drivers=[],

--- a/tests/test_h1_ema_rsi_atr_signal.py
+++ b/tests/test_h1_ema_rsi_atr_signal.py
@@ -198,3 +198,11 @@ def test_h1_signal_patterns_gate(monkeypatch, base_params):
     res = compute_primary_signal_h1(df2, params, registry=reg)
     assert res.action == "KEEP"
     assert not reg._setups
+
+
+def test_h1_signal_ttl_passthrough(base_params):
+    params = {**base_params, "ttl_minutes": 30}
+    df = _make_df()
+    reg = SetupRegistry()
+    res = compute_primary_signal_h1(df, params, registry=reg)
+    assert res.ttl_minutes == 30


### PR DESCRIPTION
## Summary
- allow specifying ttl_minutes in H1 EMA/RSI/ATR default params
- propagate ttl_minutes when building TechnicalSignal instances
- test ttl_minutes passthrough

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad9e6ee11c8326a34952938c7979f0