### PR TITLE
Add time-based setup expiry

### DIFF
--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -94,7 +94,7 @@ def append_bar_and_signal(
                 meta=contract.meta,
             )
             key = getattr(settings.broker, "symbol", "")
-            setup_registry.arm(key, len(df), signal, ctx=ctx)
+            setup_registry.arm(key, len(df), signal, bar_time=idx, ctx=ctx)
             log_event(
                 E_SETUP_ARM,
                 ctx=ctx,
@@ -339,7 +339,13 @@ def run_live(
                                 timeframe=tf,
                                 setup_id=setup_id,
                             )
-                            registry.arm(setup_id, len(df), signal, ctx=ctx_setup)
+                            registry.arm(
+                                setup_id,
+                                len(df),
+                                signal,
+                                bar_time=pd.to_datetime(bar_start, unit="s"),
+                                ctx=ctx_setup,
+                            )
 
                         current_bar = {
                             "start": bar_start,
@@ -355,6 +361,7 @@ def run_live(
                         triggered = setup_registry.check(
                             index=len(df) - 1,
                             price=price,
+                            now=pd.to_datetime(ts, unit="s"),
                             ctx=mk_ctx(),
                         )
                     if triggered:

--- a/src/forest5/signals/h1_ema_rsi_atr.py
+++ b/src/forest5/signals/h1_ema_rsi_atr.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+import pandas as pd
+
 from forest5.core.indicators import atr, ema, rsi
 from .contract import TechnicalSignal
 from .setups import SetupRegistry
@@ -94,9 +96,12 @@ def compute_primary_signal_h1(
     high = df["high"]
     low = df["low"]
 
-    triggered = reg.check(index=idx, price=float(df["high"].iloc[-1]), ctx=ctx)
+    now = df.index[idx]
+    if not isinstance(now, pd.Timestamp):
+        now = pd.Timestamp(now)
+    triggered = reg.check(index=idx, price=float(df["high"].iloc[-1]), now=now, ctx=ctx)
     if not triggered:
-        triggered = reg.check(index=idx, price=float(df["low"].iloc[-1]), ctx=ctx)
+        triggered = reg.check(index=idx, price=float(df["low"].iloc[-1]), now=now, ctx=ctx)
     if triggered:
         return triggered
 
@@ -210,7 +215,7 @@ def compute_primary_signal_h1(
             drivers=drivers,
             meta=meta,
         )
-        reg.arm(p["timeframe"], idx, signal, ctx=ctx)
+        reg.arm(p["timeframe"], idx, signal, bar_time=now, ctx=ctx)
 
     return TechnicalSignal(
         timeframe=p["timeframe"],

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -65,7 +65,7 @@ def test_gap_fill_trailing_and_priority():
         tp=110.0,
         meta={"trailing_atr": 0.5},
     )
-    eng.setups.arm("s1", 0, cand)
+    eng.setups.arm("s1", 0, cand, bar_time=pd.Timestamp("2024-01-01"))
 
     eng.on_bar_open(1)
     assert eng.positions and eng.positions[0]["entry"] == 104.0

--- a/tests/test_live_h1_contract_path.py
+++ b/tests/test_live_h1_contract_path.py
@@ -63,11 +63,11 @@ def test_h1_contract_arm_and_trigger(tmp_path: Path, monkeypatch):
             self.check_indices: list[int] = []
             TriggerRegistry.last = self
 
-        def arm(self, key, index, signal, *, ctx=None):
+        def arm(self, key, index, signal, *, bar_time, ttl_minutes=None, ctx=None):
             self.armed = True
             self.arm_index = index
 
-        def check(self, *, index, price, ctx=None):
+        def check(self, *, index, price, now, ctx=None):
             self.check_indices.append(index)
             if self.armed and index >= (self.arm_index or 0):
                 self.armed = False

--- a/tests/test_live_runner_paper_smoke.py
+++ b/tests/test_live_runner_paper_smoke.py
@@ -69,10 +69,10 @@ def test_triggered_setup_executes(tmp_path: Path, capfd, monkeypatch):
         def __init__(self, *args, **kwargs):
             self.armed = False
 
-        def arm(self, key, index, signal, *, ctx=None):
+        def arm(self, key, index, signal, *, bar_time, ttl_minutes=None, ctx=None):
             self.armed = True
 
-        def check(self, *, index, price, ctx=None):
+        def check(self, *, index, price, now, ctx=None):
             if self.armed:
                 self.armed = False
                 return TriggeredSignal(
@@ -125,10 +125,10 @@ def test_setup_expires_without_trigger(tmp_path: Path, capfd, monkeypatch):
         def __init__(self, *args, **kwargs):
             pass
 
-        def arm(self, key, index, signal, *, ctx=None):
+        def arm(self, key, index, signal, *, bar_time, ttl_minutes=None, ctx=None):
             pass
 
-        def check(self, *, index, price, ctx=None):
+        def check(self, *, index, price, now, ctx=None):
             return None
 
     monkeypatch.setattr(live_runner, "SetupRegistry", NoTriggerRegistry)

--- a/tests/test_logging_setup_trigger_expire.py
+++ b/tests/test_logging_setup_trigger_expire.py
@@ -3,18 +3,20 @@ import logging
 import sys
 from pathlib import Path
 
+from datetime import datetime, timedelta
+
 import pytest
 import structlog
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from forest5.utils.log import (
+from forest5.utils.log import (  # noqa: E402
     TelemetryContext,
     E_SETUP_TRIGGER,
     E_SETUP_EXPIRE,
     R_TIMEOUT,
 )
-from forest5.signals.setups import SetupRegistry, SetupCandidate
+from forest5.signals.setups import SetupRegistry, SetupCandidate  # noqa: E402
 
 
 def test_setup_trigger_and_expire_logging(caplog):
@@ -30,13 +32,16 @@ def test_setup_trigger_and_expire_logging(caplog):
 
     ctx = TelemetryContext(run_id="run1", symbol="EURUSD", timeframe="H1", setup_id="s1")
     sig = SetupCandidate(action="BUY", entry=1.0, sl=0.9, tp=1.1, id="s1")
-    reg.arm("EURUSD", 0, sig, ctx=ctx)
-    reg.check(index=0, price=1.2)
+    t0 = datetime(2024, 1, 1, 0, 0)
+    reg.arm("EURUSD", 0, sig, bar_time=t0, ctx=ctx)
+    reg.check(index=0, price=1.2, now=t0)
 
     ctx2 = TelemetryContext(run_id="run1", symbol="EURUSD", timeframe="H1", setup_id="s2")
     sig2 = SetupCandidate(action="BUY", entry=1.0, sl=0.9, tp=1.1, id="s2")
-    reg.arm("EURUSD", 1, sig2, ctx=ctx2)
-    reg.check(index=2, price=0.95)
+    t1 = t0 + timedelta(minutes=1)
+    reg.arm("EURUSD", 1, sig2, bar_time=t1, ctx=ctx2)
+    t2 = t0 + timedelta(minutes=2)
+    reg.check(index=2, price=0.95, now=t2)
 
     records = [json.loads(r.message) for r in caplog.records]
 

--- a/tests/test_setup_registry.py
+++ b/tests/test_setup_registry.py
@@ -1,5 +1,7 @@
 import pytest
 
+from datetime import datetime, timedelta
+
 from forest5.signals.setups import SetupRegistry, TriggeredSignal
 from forest5.signals.contract import TechnicalSignal
 
@@ -7,42 +9,47 @@ from forest5.signals.contract import TechnicalSignal
 def test_setup_registry_triggers_and_clears() -> None:
     reg = SetupRegistry(ttl_bars=1)
     sig = TechnicalSignal(action="BUY", entry=10.0)
-    setup_id = reg.arm("tf", 0, sig)
-    res = reg.check(index=1, price=11.0)
+    t0 = datetime(2024, 1, 1)
+    setup_id = reg.arm("tf", 0, sig, bar_time=t0)
+    res = reg.check(index=1, price=11.0, now=t0)
     assert isinstance(res, TriggeredSignal)
     assert res.setup_id == setup_id
-    assert reg.check(index=1, price=11.0) is None
+    assert reg.check(index=1, price=11.0, now=t0) is None
 
 
 def test_setup_registry_expires_without_trigger() -> None:
     reg = SetupRegistry(ttl_bars=1)
     sig = TechnicalSignal(action="SELL", entry=5.0)
-    reg.arm("tf", 0, sig)
-    assert reg.check(index=1, price=5.2) is None
-    assert reg.check(index=2, price=4.0) is None
+    t0 = datetime(2024, 1, 1)
+    reg.arm("tf", 0, sig, bar_time=t0)
+    assert reg.check(index=1, price=5.2, now=t0) is None
+    assert reg.check(index=2, price=4.0, now=t0) is None
 
 
 def test_setup_registry_gap_fill_triggers() -> None:
     reg = SetupRegistry(ttl_bars=1)
     sig = TechnicalSignal(action="BUY", entry=10.0)
-    reg.arm("tf", 0, sig)
-    res = reg.check(index=1, price=11.0)
+    t0 = datetime(2024, 1, 1)
+    reg.arm("tf", 0, sig, bar_time=t0)
+    res = reg.check(index=1, price=11.0, now=t0)
     assert isinstance(res, TriggeredSignal)
 
 
 def test_setup_registry_blocked_by_time_removes() -> None:
     reg = SetupRegistry(ttl_bars=1)
     sig = TechnicalSignal(action="BUY", entry=10.0)
-    reg.arm("tf", 0, sig)
-    _ = reg.check(index=1, price=11.0)
-    assert reg.check(index=1, price=11.0) is None
+    t0 = datetime(2024, 1, 1)
+    reg.arm("tf", 0, sig, bar_time=t0)
+    _ = reg.check(index=1, price=11.0, now=t0)
+    assert reg.check(index=1, price=11.0, now=t0) is None
 
 
 def test_setup_registry_returns_trigger_details() -> None:
     reg = SetupRegistry(ttl_bars=1)
     sig = TechnicalSignal(action="BUY", entry=10.0)
-    reg.arm("tf", 0, sig)
-    res = reg.check(index=1, price=10.5)
+    t0 = datetime(2024, 1, 1)
+    reg.arm("tf", 0, sig, bar_time=t0)
+    res = reg.check(index=1, price=10.5, now=t0)
     assert isinstance(res, TriggeredSignal)
     assert res.fill_price == 10.5
     assert res.slippage == pytest.approx(0.5)
@@ -51,23 +58,36 @@ def test_setup_registry_returns_trigger_details() -> None:
 def test_setup_registry_high_low_trigger_and_expire() -> None:
     reg = SetupRegistry(ttl_bars=1)
     sig = TechnicalSignal(action="BUY", entry=10.0)
-    reg.arm("tf", 0, sig)
-    res = reg.check(index=1, high=10.5, low=9.0)
+    t0 = datetime(2024, 1, 1)
+    reg.arm("tf", 0, sig, bar_time=t0)
+    res = reg.check(index=1, high=10.5, low=9.0, now=t0)
     assert isinstance(res, TriggeredSignal)
-    assert reg.check(index=1, price=11.0) is None
+    assert reg.check(index=1, price=11.0, now=t0) is None
 
 
 def test_setup_registry_low_trigger_sell() -> None:
     reg = SetupRegistry(ttl_bars=1)
     sig = TechnicalSignal(action="SELL", entry=5.0)
-    reg.arm("tf", 0, sig)
-    res = reg.check(index=1, low=4.8)
+    t0 = datetime(2024, 1, 1)
+    reg.arm("tf", 0, sig, bar_time=t0)
+    res = reg.check(index=1, low=4.8, now=t0)
     assert isinstance(res, TriggeredSignal)
 
 
 def test_setup_registry_high_low_expire_without_trigger() -> None:
     reg = SetupRegistry(ttl_bars=1)
     sig = TechnicalSignal(action="BUY", entry=10.0)
-    reg.arm("tf", 0, sig)
-    assert reg.check(index=1, high=9.5, low=9.0) is None
-    assert reg.check(index=2, price=11.0) is None
+    t0 = datetime(2024, 1, 1)
+    reg.arm("tf", 0, sig, bar_time=t0)
+    assert reg.check(index=1, high=9.5, low=9.0, now=t0) is None
+    assert reg.check(index=2, price=11.0, now=t0) is None
+
+
+def test_setup_registry_ttl_minutes_expires() -> None:
+    reg = SetupRegistry(ttl_bars=10)
+    sig = TechnicalSignal(action="BUY", entry=10.0, ttl_minutes=1)
+    t0 = datetime(2024, 1, 1, 0, 0)
+    reg.arm("tf", 0, sig, bar_time=t0)
+    t1 = t0 + timedelta(minutes=2)
+    assert reg.check(index=1, price=9.0, now=t1) is None
+    assert reg.check(index=2, price=11.0, now=t1) is None


### PR DESCRIPTION
## Summary
- Track armed setups with timestamps using new `SetupRecord`
- Allow `arm` and `check` to handle bar timestamps and time-to-live in minutes
- Update registry clients and tests for time-based setup expiration

## Testing
- `pre-commit run --files src/forest5/signals/setups.py src/forest5/backtest/engine.py src/forest5/signals/h1_ema_rsi_atr.py src/forest5/live/live_runner.py tests/test_setup_registry.py tests/test_logging_setup_trigger_expire.py tests/test_engine.py tests/test_live_runner_paper_smoke.py tests/test_live_h1_contract_path.py` *(fails: bandit - subprocess warnings in src/forest5/cli.py)*
- `pytest tests/test_setup_registry.py tests/test_logging_setup_trigger_expire.py tests/test_engine.py tests/test_live_runner_paper_smoke.py tests/test_live_h1_contract_path.py tests/test_h1_ema_rsi_atr_signal.py`


------
https://chatgpt.com/codex/tasks/task_e_68ada173f7948326974c18be6005f0fd