### PR TITLE
feat: report median time delta for H1 indexes

### DIFF
--- a/src/forest5/utils/timeindex.py
+++ b/src/forest5/utils/timeindex.py
@@ -79,10 +79,12 @@ def ensure_h1(df: pd.DataFrame, policy: str = "strict") -> Tuple[pd.DataFrame, d
     df = df.copy()
     idx_utc = _to_utc(df.index)
     step = pd.Timedelta("1h")
-    deltas = idx_utc.to_series().diff().dropna()
+    deltas = pd.Series(idx_utc[1:] - idx_utc[:-1])
     irregular = (deltas != step).any()
     gaps = report_gaps(idx_utc, "1h")
-    median_minutes = float(deltas.median().total_seconds() / 60.0) if len(deltas) else 60.0
+    median_minutes = (
+        float(deltas.median() / pd.Timedelta(minutes=1)) if not deltas.empty else 60.0
+    )
 
     if irregular:
         if policy == "strict":

--- a/src/forest5/utils/timeindex.py
+++ b/src/forest5/utils/timeindex.py
@@ -82,9 +82,7 @@ def ensure_h1(df: pd.DataFrame, policy: str = "strict") -> Tuple[pd.DataFrame, d
     deltas = pd.Series(idx_utc[1:] - idx_utc[:-1])
     irregular = (deltas != step).any()
     gaps = report_gaps(idx_utc, "1h")
-    median_minutes = (
-        float(deltas.median() / pd.Timedelta(minutes=1)) if not deltas.empty else 60.0
-    )
+    median_minutes = float(deltas.median() / pd.Timedelta(minutes=1)) if not deltas.empty else 60.0
 
     if irregular:
         if policy == "strict":

--- a/tests/test_h1_policies.py
+++ b/tests/test_h1_policies.py
@@ -18,6 +18,7 @@ def test_pad_inserts_missing_row():
     out, meta = ensure_h1(_gap_df(), policy="pad")
     assert len(out) == 3
     assert meta["gaps"][0].missing == 1
+    assert meta["median_bar_minutes"] == 120.0
     assert out.isna().any().any()
 
 
@@ -25,3 +26,4 @@ def test_drop_discards_missing_period():
     out, meta = ensure_h1(_gap_df(), policy="drop")
     assert len(out) == 2
     assert meta["gaps"][0].missing == 1
+    assert meta["median_bar_minutes"] == 120.0

--- a/tests/test_timeindex.py
+++ b/tests/test_timeindex.py
@@ -26,6 +26,7 @@ def test_ensure_h1_pad_reports_gap():
     out, meta = ensure_h1(_sample_df(), policy="pad")
     assert len(out) == 4
     assert len(meta["gaps"]) == 1
+    assert meta["median_bar_minutes"] == 180.0
     gap = meta["gaps"][0]
     assert gap.missing == 2
     assert gap.start == pd.Timestamp("2020-01-01 00:00", tz="UTC")


### PR DESCRIPTION
## Summary
- calculate median time delta between index entries
- expose median bar duration (minutes) via ensure_h1 metadata
- test metadata reporting for H1 utilities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adafdbb67c8326b3b5098edec9655d