### PR TITLE
feat(cli): add EnumAction and positive int helpers

### DIFF
--- a/src/forest5/backtest/grid.py
+++ b/src/forest5/backtest/grid.py
@@ -102,7 +102,7 @@ def run_grid(
     debug_dir: Path | None = None,
     seed: int | None = None,
     setup_ttl_minutes: int | None = None,
-    resume: str = "auto",
+    resume: bool | str = "auto",
     chunks: int = 1,
     chunk_id: int | None = None,
 ) -> pd.DataFrame:

--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -29,7 +29,7 @@ from forest5.utils.io import (
     sniff_csv_dialect,
 )
 from forest5.utils.timeindex import ensure_h1
-from forest5.utils.argparse_ext import PercentAction, span_or_list
+from forest5.utils.argparse_ext import PercentAction, span_or_list, EnumAction, positive_int
 from forest5.utils.log import (
     setup_logger,
 )
@@ -51,13 +51,6 @@ class SafeHelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawText
         # '%(foo)s', which argparse uses to inject defaults.
         help_text = re.sub(r"%(?!\()", "%%", help_text)
         return help_text % params
-
-
-def _positive_int(value: str) -> int:
-    iv = int(value)
-    if iv < 1:
-        raise argparse.ArgumentTypeError("must be >= 1")
-    return iv
 
 
 # ---------------------------- CSV loading helpers ----------------------------
@@ -703,19 +696,20 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_gr.add_argument(
         "--resume",
-        choices=("auto", "true", "false"),
+        action=EnumAction,
+        choices={"auto": "auto", "true": True, "false": False},
         default="auto",
         help="Wznów poprzedni bieg (auto korzysta z istniejących wyników)",
     )
     p_gr.add_argument(
         "--chunks",
-        type=_positive_int,
+        type=positive_int,
         default=1,
         help="Podziel siatkę parametrów na N części",
     )
     p_gr.add_argument(
         "--chunk-id",
-        type=_positive_int,
+        type=positive_int,
         default=None,
         help="Uruchom tylko wybrany fragment siatki (1-indexed)",
     )

--- a/tests/test_cli_grid_options.py
+++ b/tests/test_cli_grid_options.py
@@ -104,6 +104,6 @@ def test_cli_grid_additional_options(tmp_path, monkeypatch):
     assert kw["atr_multiple"] == 3
     assert kw["time_model"] == model_path
     assert kw["min_confluence"] == pytest.approx(2.0)
-    assert kw["resume"] == "true"
+    assert kw["resume"] is True
     assert kw["chunks"] == 3
     assert kw["chunk_id"] == 2


### PR DESCRIPTION
## Summary
- add `EnumAction` for mapping string choices to canonical values
- add `positive_int` validator and use for grid chunk options
- parse `--resume` via new EnumAction and adjust tests

## Testing
- `pytest tests/test_cli_grid_options.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade23e49fc8326a69a31a04d81a1aa