### PR TITLE
Normalize frequency input in synthetic data example

### DIFF
--- a/src/forest5/examples/synthetic.py
+++ b/src/forest5/examples/synthetic.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 
 def generate_ohlc(periods: int = 100, start_price: float = 100.0, freq: str = "D") -> pd.DataFrame:
+    freq = freq.lower()
     idx = pd.date_range("2024-01-01", periods=periods, freq=freq)
     rnd = np.random.default_rng(42)
     ret = rnd.normal(0, 0.01, size=periods)


### PR DESCRIPTION
## Summary
- Ensure frequency strings are lowercase before generating date ranges in `generate_ohlc`

## Testing
- `pytest tests/test_grid_resume.py::test_grid_resume -q` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae02e76f9083268454bee9b8fa2ba7