### PR TITLE
Add numbers import to grid options test

### DIFF
--- a/tests/test_cli_grid_options.py
+++ b/tests/test_cli_grid_options.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import numbers
 import pandas as pd
 import pytest
 
@@ -131,3 +132,4 @@ def test_cli_grid_additional_options(tmp_path, monkeypatch):
     assert kw["resume"] is True
     assert kw["chunks"] == 3
     assert kw["chunk_id"] == 2
+    assert isinstance(kw["min_confluence"], numbers.Number)


### PR DESCRIPTION
## Summary
- add `numbers` import to CLI grid options test and use it to verify numeric min_confluence

## Testing
- `python -m ruff check tests/test_cli_grid_options.py`
- `pytest tests/test_cli_grid_options.py::test_cli_grid_additional_options -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae246002fc83269623b8f8910f0a0a