### PR TITLE
Finalize deterministic combo_id and grid resume logic

### DIFF
--- a/src/forest5/backtest/grid.py
+++ b/src/forest5/backtest/grid.py
@@ -9,13 +9,14 @@ import random
 from copy import deepcopy
 import time
 from datetime import timedelta
-import math
 
 import numpy as np
 import pandas as pd
 from joblib import Memory, Parallel, delayed
 from rich.console import Console
 from rich.progress import Progress, BarColumn, TextColumn
+
+import math
 
 from ..config import BacktestSettings
 from .engine import run_backtest

--- a/src/forest5/backtest/grid.py
+++ b/src/forest5/backtest/grid.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from itertools import product
 from pathlib import Path
-from typing import Iterable, Any, Dict, List
+from typing import Iterable, Any, Dict, List, Mapping
 import json
 import random
 from copy import deepcopy
 import time
-import math
 from datetime import timedelta
+import math
 
 import numpy as np
 import pandas as pd
@@ -19,6 +19,28 @@ from rich.progress import Progress, BarColumn, TextColumn
 
 from ..config import BacktestSettings
 from .engine import run_backtest
+
+
+def build_combo_id(params: Mapping[str, Any]) -> str:
+    """Return a stable unique id for a parameter set."""
+
+    def norm(v: Any) -> str:
+        if v is None:
+            return "null"
+        if isinstance(v, bool):
+            return "1" if v else "0"
+        if isinstance(v, (int,)):
+            return str(v)
+        if isinstance(v, float):
+            vv = 0.0 if abs(v) < 1e-15 else round(v, 10)
+            s = f"{vv:.10f}"
+            return s.rstrip("0").rstrip(".") if "." in s else s
+        if isinstance(v, (list, tuple)):
+            return ",".join(norm(x) for x in v)
+        return str(v)
+
+    items = sorted((k, params[k]) for k in params.keys())
+    return "|".join(f"{k}={norm(v)}" for k, v in items)
 
 
 def _compute_metrics(equity: pd.Series) -> tuple[float, float, float]:

--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -5,8 +5,10 @@ import os
 import re
 import sys
 import random
+import json
+import math
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Dict, Any
 
 import numpy as np
 import pandas as pd
@@ -19,8 +21,8 @@ from forest5.config import (
     load_live_settings,
 )
 from forest5.backtest.engine import run_backtest
-from forest5.backtest.grid import run_grid
-from forest5.grid.engine import plan_param_grid
+from forest5.backtest.grid import build_combo_id
+from forest5.grid.engine import plan_param_grid, run_grid
 from forest5.live.live_runner import run_live
 from forest5.utils.io import (
     read_ohlc_csv,
@@ -29,7 +31,13 @@ from forest5.utils.io import (
     sniff_csv_dialect,
 )
 from forest5.utils.timeindex import ensure_h1
-from forest5.utils.argparse_ext import PercentAction, span_or_list, EnumAction, positive_int
+from forest5.utils.argparse_ext import (
+    PercentAction,
+    span_or_list,
+    enum_bool,
+    positive_int,
+    validate_chunks,
+)
 from forest5.utils.log import (
     setup_logger,
 )
@@ -163,6 +171,12 @@ def cmd_backtest(args: argparse.Namespace) -> int:
 
 
 def cmd_grid(args: argparse.Namespace) -> int:
+    try:
+        validate_chunks(args.chunks, args.chunk_id)
+    except argparse.ArgumentTypeError as exc:  # pragma: no cover - argparse style
+        print(str(exc), file=sys.stderr)
+        return 2
+
     if args.csv:
         csv_path = Path(args.csv)
     else:
@@ -178,11 +192,6 @@ def cmd_grid(args: argparse.Namespace) -> int:
     if args.time_from is not None or args.time_to is not None:
         df = df.loc[args.time_from : args.time_to]
 
-    fast_vals = [int(v) for v in args.fast_values]
-    slow_vals = [int(v) for v in args.slow_values]
-    risk_vals = [float(v) for v in args.risk_values] if args.risk_values else None
-    max_dd_vals = [float(v) for v in args.max_dd_values] if args.max_dd_values else None
-
     if args.seed is not None:
         random.seed(args.seed)
         np.random.seed(args.seed)
@@ -191,118 +200,130 @@ def cmd_grid(args: argparse.Namespace) -> int:
         print(f"Plik modelu czasu nie istnieje: {args.time_model}")
         sys.exit(1)
 
-    kwargs = dict(
-        symbol=args.symbol,
-        fast_values=fast_vals,
-        slow_values=slow_vals,
-        capital=float(args.capital),
-        risk=float(args.risk),
-        max_dd=float(args.max_dd),
-        fee=float(args.fee),
-        slippage=float(args.slippage),
-        atr_period=int(args.atr_period[0]),
-        atr_multiple=float(args.atr_multiple),
-        use_rsi=bool(args.use_rsi),
-        rsi_period=int(args.rsi_period[0]),
-        rsi_oversold=int(args.rsi_oversold),
-        rsi_overbought=int(args.rsi_overbought),
-        t_sep_atr=float(args.t_sep_atr[0]),
-        pullback_atr=float(args.pullback_atr[0]),
-        entry_buffer_atr=float(args.entry_buffer_atr[0]),
-        sl_atr=float(args.sl_atr),
-        sl_min_atr=float(args.sl_min_atr[0]),
-        rr=float(args.rr[0]),
-        q_low=float(args.q_low[0]),
-        q_high=float(args.q_high[0]),
-        time_model=args.time_model,
-        min_confluence=float(args.min_confluence),
-        n_jobs=int(args.jobs),
-        resume=args.resume,
-        chunks=int(args.chunks),
-    )
-    if args.chunk_id is not None:
-        kwargs["chunk_id"] = int(args.chunk_id)
-    kwargs["strategy"] = args.strategy
-    kwargs["patterns"] = {
-        "engulf": {"enabled": bool(args.pat_engulf)},
-        "pinbar": {"enabled": bool(args.pat_pinbar)},
-        "star": {"enabled": bool(args.pat_star)},
-    }
-    if args.h1_policy == "drop":
-        step = meta.get("median_bar_minutes")
-        if step:
-            kwargs["setup_ttl_minutes"] = int(step)
-    if risk_vals:
-        kwargs["risk_values"] = risk_vals
-    if max_dd_vals:
-        kwargs["max_dd_values"] = max_dd_vals
+    fast_vals = [int(v) for v in args.fast_values]
+    slow_vals = [int(v) for v in args.slow_values]
+    param_ranges: Dict[str, list[Any]] = {"fast": fast_vals, "slow": slow_vals}
+    if args.risk_values:
+        param_ranges["risk"] = [float(v) for v in args.risk_values]
+    if args.max_dd_values:
+        param_ranges["max_dd"] = [float(v) for v in args.max_dd_values]
     if len(args.rsi_period) > 1:
-        kwargs.pop("rsi_period", None)
-        kwargs["rsi_period_values"] = [int(v) for v in args.rsi_period]
-    if args.debug_dir:
-        kwargs["debug_dir"] = args.debug_dir
-    if args.seed is not None:
-        kwargs["seed"] = int(args.seed)
+        param_ranges["rsi_period"] = [int(v) for v in args.rsi_period]
+
+    combos_all = plan_param_grid(param_ranges, filter_fn=lambda c: c["fast"] < c["slow"])
+    out_dir = Path(args.out or "out").resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    results_path = out_dir / "results.csv"
+    meta_path = out_dir / "meta.json"
+
+    done_df = None
+    done_ids: set[str] = set()
+    if args.resume in ("auto", True) and results_path.exists():
+        done_df = pd.read_csv(results_path)
+        param_names = list(param_ranges.keys())
+        if "combo_id" not in done_df.columns:
+            done_df["combo_id"] = [
+                build_combo_id({k: row.get(k) for k in param_names if k in row})
+                for row in done_df.to_dict("records")
+            ]
+        done_ids = set(done_df["combo_id"].astype(str))
+        print(
+            f"[resume] skipping {len(done_ids)} of {len(combos_all)} combos already in results.csv"
+        )
+
+    combos = combos_all
+    if args.chunks is not None and args.chunk_id is not None:
+        size = math.ceil(len(combos_all) / args.chunks)
+        start = (args.chunk_id - 1) * size
+        end = args.chunk_id * size
+        combos = combos_all.iloc[start:end]
+        if args.dry_run:
+            combos.to_csv(
+                out_dir / f"plan_shard_{args.chunk_id:02d}of{args.chunks:02d}.csv",
+                index=False,
+            )
+
+    if done_ids:
+        combos = combos[~combos["combo_id"].astype(str).isin(done_ids)]
 
     if args.dry_run:
-        param_ranges = {"fast": fast_vals, "slow": slow_vals}
-        if risk_vals:
-            param_ranges["risk"] = risk_vals
-        if max_dd_vals:
-            param_ranges["max_dd"] = max_dd_vals
-        if len(args.rsi_period) > 1:
-            param_ranges["rsi_period"] = [int(v) for v in args.rsi_period]
-        combos = plan_param_grid(param_ranges, filter_fn=lambda c: c["fast"] < c["slow"])
-        combos.to_csv("plan.csv", index=False)
-        from datetime import datetime, timezone
-        import json
-        import subprocess
-
-        git_rev = "unknown"
-        try:  # pragma: no cover - best effort
-            git_rev = (
-                subprocess.check_output(
-                    ["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.DEVNULL
-                )
-                .decode()
-                .strip()
-            )
-        except Exception:  # pragma: no cover
-            pass
-
+        combos_all.to_csv(out_dir / "plan.csv", index=False)
         meta = {
-            "timestamp_utc": datetime.now(timezone.utc).isoformat(),
-            "git": git_rev,
             "symbol": args.symbol,
-            "period": {
-                "start": df.index[0].isoformat(),
-                "end": df.index[-1].isoformat(),
-            },
-            "seed": int(args.seed) if args.seed is not None else None,
-            "total_combos": int(len(combos)),
+            "seed": args.seed,
+            "total_combos": int(len(combos_all)),
         }
-        Path("meta.json").write_text(json.dumps(meta))
-        print(len(combos))
+        meta_path.write_text(json.dumps(meta, indent=2))
+        print(len(combos_all))
         return 0
 
-    out = run_grid(df, **kwargs)
+    settings = BacktestSettings(
+        symbol=args.symbol,
+        timeframe="1h",
+        strategy=dict(
+            name=args.strategy,
+            fast=fast_vals[0],
+            slow=slow_vals[0],
+            use_rsi=bool(args.use_rsi),
+            rsi_period=int(args.rsi_period[0]),
+            rsi_oversold=int(args.rsi_oversold),
+            rsi_overbought=int(args.rsi_overbought),
+            t_sep_atr=float(args.t_sep_atr[0]),
+            pullback_atr=float(args.pullback_atr[0]),
+            entry_buffer_atr=float(args.entry_buffer_atr[0]),
+            sl_atr=float(args.sl_atr),
+            sl_min_atr=float(args.sl_min_atr[0]),
+            rr=float(args.rr[0]),
+            patterns={
+                "engulf": {"enabled": bool(args.pat_engulf)},
+                "pinbar": {"enabled": bool(args.pat_pinbar)},
+                "star": {"enabled": bool(args.pat_star)},
+            },
+        ),
+        risk=dict(
+            initial_capital=float(args.capital),
+            risk_per_trade=float(args.risk),
+            max_drawdown=float(args.max_dd),
+            fee_perc=float(args.fee),
+            slippage_perc=float(args.slippage),
+        ),
+        atr_period=int(args.atr_period[0]),
+        atr_multiple=float(args.atr_multiple),
+        debug_dir=args.debug_dir,
+    )
+    settings.time.q_low = float(args.q_low[0])
+    settings.time.q_high = float(args.q_high[0])
+    settings.time.model.enabled = bool(args.time_model)
+    settings.time.model.path = args.time_model
+    settings.time.fusion_min_confluence = float(args.min_confluence)
+    if args.h1_policy == "drop" and settings.setup_ttl_minutes is None:
+        step = meta.get("median_bar_minutes")
+        if step:
+            settings.setup_ttl_minutes = int(step)
 
-    # sortuj wg RAR / Sharpe jeśli dostępne, inaczej equity_end
-    sort_cols = [c for c in ("rar", "sharpe", "equity_end") if c in out.columns]
-    if sort_cols:
-        out = out.sort_values(by=sort_cols, ascending=False)
+    new_results = run_grid(df, combos, settings, jobs=int(args.jobs), seed=args.seed)
 
-    head = out.head(args.top)
-    print(head)
+    if done_df is not None:
+        merged = pd.concat([done_df, new_results], ignore_index=True)
+        merged = merged.drop_duplicates(subset=["combo_id"], keep="last")
+    else:
+        merged = new_results
 
-    if args.out:
-        out_path = Path(args.out)
-        if out_path.suffix.lower() in (".parquet", ".pq"):
-            out.to_parquet(out_path, index=False)
-        else:
-            out.to_csv(out_path, index=False)
-        print(f"Zapisano wyniki grid do: {out_path.resolve()}")
+    sort_keys = [c for c in ["rar", "sharpe", "equity_end", "pnl_net"] if c in merged.columns]
+    merged = merged.sort_values(by=sort_keys, ascending=[False] * len(sort_keys))
+    merged.to_csv(results_path, index=False)
 
+    topn = int(args.top or 20)
+    merged.head(topn).to_csv(out_dir / "results_top.csv", index=False)
+    print("\n=== TOP", topn, "===\n", merged.head(topn).to_string(index=False))
+
+    meta = {
+        "symbol": args.symbol,
+        "seed": getattr(args, "seed", None),
+        "total_combos": int(len(combos_all)),
+        "completed_combos": int(len(merged)),
+    }
+    meta_path.write_text(json.dumps(meta, indent=2))
     return 0
 
 
@@ -696,15 +717,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_gr.add_argument(
         "--resume",
-        action=EnumAction,
-        choices={"auto": "auto", "true": True, "false": False},
+        type=enum_bool,
         default="auto",
         help="Wznów poprzedni bieg (auto korzysta z istniejących wyników)",
     )
     p_gr.add_argument(
         "--chunks",
         type=positive_int,
-        default=1,
+        default=None,
         help="Podziel siatkę parametrów na N części",
     )
     p_gr.add_argument(

--- a/src/forest5/examples/synthetic.py
+++ b/src/forest5/examples/synthetic.py
@@ -5,7 +5,15 @@ import numpy as np
 import pandas as pd
 
 
+def _norm_freq(freq: str) -> str:
+    f = str(freq).strip()
+    if not f:
+        raise ValueError("freq required")
+    return f.lower()
+
+
 def generate_ohlc(periods: int = 100, start_price: float = 100.0, freq: str = "D") -> pd.DataFrame:
+    freq = _norm_freq(freq)
     idx = pd.date_range("2024-01-01", periods=periods, freq=freq)
     rnd = np.random.default_rng(42)
     ret = rnd.normal(0, 0.01, size=periods)

--- a/src/forest5/utils/argparse_ext.py
+++ b/src/forest5/utils/argparse_ext.py
@@ -69,6 +69,28 @@ def positive_int(value: str) -> int:
     return iv
 
 
+def enum_bool(value: str) -> bool | str | None:
+    """Parse boolean values including an 'auto' sentinel."""
+
+    v = str(value).strip().lower()
+    if v == "auto":
+        return "auto"
+    if v in {"true", "t", "1", "yes", "y"}:
+        return True
+    if v in {"false", "f", "0", "no", "n"}:
+        return False
+    raise argparse.ArgumentTypeError("must be one of: auto,true,false")
+
+
+def validate_chunks(chunks: int | None, chunk_id: int | None) -> None:
+    """Ensure chunk arguments are either both set or both omitted."""
+
+    if (chunks is None) ^ (chunk_id is None):
+        raise argparse.ArgumentTypeError("--chunks and --chunk-id must be used together")
+    if chunks is not None and (chunk_id < 1 or chunk_id > chunks):
+        raise argparse.ArgumentTypeError("--chunk-id must be between 1 and --chunks")
+
+
 def span_or_list(spec: str, type_fn: type | None = None) -> list:
     """Parse a numeric span or comma separated list.
 

--- a/tests/test_cli_aliases.py
+++ b/tests/test_cli_aliases.py
@@ -25,11 +25,11 @@ def test_cli_grid_pullback_alias(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_run_grid(df, symbol, fast_values, slow_values, **kwargs):
-        captured.update(kwargs)
-        return pd.DataFrame(
-            [{"fast": 1, "slow": 2, "equity_end": 1.0, "max_dd": 0.0, "cagr": 0.0, "rar": 0.0}]
-        )
+    def fake_run_grid(df, combos, settings, **kwargs):
+        captured["pullback_atr"] = settings.strategy.pullback_atr
+        row = combos.iloc[0].to_dict()
+        row.update({"equity_end": 1.0, "dd": 0.0, "cagr": 0.0, "rar": 0.0})
+        return pd.DataFrame([row])
 
     monkeypatch.setattr("forest5.cli.run_grid", fake_run_grid)
 

--- a/tests/test_cli_grid_dry_run.py
+++ b/tests/test_cli_grid_dry_run.py
@@ -54,6 +54,8 @@ def test_cli_grid_dry_run(tmp_path, monkeypatch, capsys):
     assert called is False
     out = capsys.readouterr().out.strip().splitlines()
     assert out[-1] == "4"
-    assert (tmp_path / "plan.csv").exists()
-    meta = json.loads((tmp_path / "meta.json").read_text())
+    plan_path = tmp_path / "out" / "plan.csv"
+    meta_path = tmp_path / "out" / "meta.json"
+    assert plan_path.exists()
+    meta = json.loads(meta_path.read_text())
     assert meta["total_combos"] == 4

--- a/tests/test_cli_grid_from_to.py
+++ b/tests/test_cli_grid_from_to.py
@@ -44,11 +44,12 @@ def test_cli_grid_respects_from_to(tmp_path, monkeypatch):
 
     captured_df = {}
 
-    def fake_run_grid(df, **kwargs):
+    def fake_run_grid(df, combos, settings, **kwargs):
         captured_df["df"] = df
-        return pd.DataFrame(
-            [{"fast": 1, "slow": 2, "equity_end": 0.0, "max_dd": 0.0, "cagr": 0.0, "rar": 0.0}]
-        )
+        # Return a minimal DataFrame preserving expected columns
+        row = combos.iloc[0].to_dict()
+        row.update({"equity_end": 0.0, "dd": 0.0, "cagr": 0.0, "rar": 0.0})
+        return pd.DataFrame([row])
 
     monkeypatch.setattr("forest5.cli.run_grid", fake_run_grid)
 

--- a/tests/test_cli_h1_policy.py
+++ b/tests/test_cli_h1_policy.py
@@ -127,9 +127,9 @@ def test_grid_h1_policy(tmp_path, monkeypatch, policy, expected_len, expected_tt
 
     captured = {}
 
-    def fake_run_grid(df, symbol, fast_values, slow_values, **kwargs):
+    def fake_run_grid(df, combos, settings, **kwargs):
         captured["len"] = len(df)
-        captured["ttl"] = kwargs.get("setup_ttl_minutes")
+        captured["ttl"] = settings.setup_ttl_minutes
         return pd.DataFrame([])
 
     monkeypatch.setattr("forest5.cli.run_grid", fake_run_grid)

--- a/tests/test_grid_dryrun_plan.py
+++ b/tests/test_grid_dryrun_plan.py
@@ -42,8 +42,8 @@ def test_grid_dryrun_plan(tmp_path, monkeypatch, capsys):
     assert rc == 0
     out_lines = capsys.readouterr().out.strip().splitlines()
     assert out_lines[-1] == "4"
-    plan_path = tmp_path / "plan.csv"
-    meta_path = tmp_path / "meta.json"
+    plan_path = tmp_path / "out" / "plan.csv"
+    meta_path = tmp_path / "out" / "meta.json"
     assert plan_path.exists()
     assert meta_path.exists()
     df_plan = pd.read_csv(plan_path)

--- a/tests/test_grid_resume.py
+++ b/tests/test_grid_resume.py
@@ -1,0 +1,56 @@
+import json
+
+import pandas as pd
+
+from forest5.cli import build_parser, cmd_grid
+from forest5.examples.synthetic import generate_ohlc
+
+
+def test_grid_resume(tmp_path, capsys):
+    df = generate_ohlc(periods=50, start_price=100.0, freq="H")
+    csv_path = tmp_path / "data.csv"
+    df.to_csv(csv_path, index_label="time")
+
+    parser = build_parser()
+    base = [
+        "grid",
+        "--csv",
+        str(csv_path),
+        "--symbol",
+        "EURUSD",
+        "--fast-values",
+        "21,34",
+        "--slow-values",
+        "89,144",
+        "--out",
+        str(tmp_path),
+        "--seed",
+        "1",
+    ]
+
+    args1 = parser.parse_args(base + ["--chunks", "2", "--chunk-id", "1"])
+    rc1 = cmd_grid(args1)
+    assert rc1 == 0
+    res_path = tmp_path / "results.csv"
+    assert res_path.exists()
+    assert len(pd.read_csv(res_path)) == 2
+
+    capsys.readouterr()
+    args2 = parser.parse_args(base + ["--chunks", "2", "--chunk-id", "2", "--resume", "auto"])
+    rc2 = cmd_grid(args2)
+    assert rc2 == 0
+    out = capsys.readouterr().out
+    assert "skipping 2 of 4" in out
+
+    merged = pd.read_csv(res_path)
+    assert merged["combo_id"].nunique() == 4
+
+    top_path = tmp_path / "results_top.csv"
+    assert top_path.exists()
+    top_df = pd.read_csv(top_path)
+    assert len(top_df) <= int(args2.top or 20)
+
+    meta = json.loads((tmp_path / "meta.json").read_text())
+    assert meta["seed"] == 1
+    assert meta["total_combos"] == 4
+    assert meta["completed_combos"] == 4


### PR DESCRIPTION
## Summary
- avoid nondeterministic set comparisons in grid CLI test by using sorted numeric lists
- normalize synthetic OHLC frequency strings to lowercase
- adjust grid resume flow to report skipped combos before chunking

## Testing
- `pytest tests/test_cli_grid_options.py::test_cli_grid_additional_options tests/test_grid_resume.py::test_grid_resume -q`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68adecd0a33883269913045fdc943292