### PR TITLE
Add MT4 preflight handshake utilities and CLI preflight command

### DIFF
--- a/tests/test_live_preflight.py
+++ b/tests/test_live_preflight.py
@@ -1,0 +1,61 @@
+import json
+import threading
+import time
+
+from forest5.cli import main
+
+
+def _prepare_bridge(tmp_path):
+    for d in ["commands", "results", "state", "ticks"]:
+        (tmp_path / d).mkdir()
+    return tmp_path
+
+
+def _sample_specs():
+    return {
+        "digits": 5,
+        "point": 0.00001,
+        "tick_size": 0.00001,
+        "min_lot": 0.01,
+        "lot_step": 0.01,
+        "contract_size": 100000,
+        "stop_level": 10,
+        "freeze_level": 0,
+    }
+
+
+def test_cli_live_preflight(tmp_path):
+    bridge = _prepare_bridge(tmp_path)
+
+    def writer():
+        # wait for request file
+        cmd_dir = bridge / "commands"
+        while True:
+            reqs = list(cmd_dir.glob("req_*.json"))
+            if reqs:
+                uid = reqs[0].stem.split("_")[1]
+                ack = bridge / "results" / f"ack_{uid}.json"
+                ack.write_text(json.dumps(_sample_specs()), encoding="utf-8")
+                break
+            time.sleep(0.01)
+
+    t = threading.Thread(target=writer)
+    t.start()
+    rc = main(
+        [
+            "live",
+            "preflight",
+            "--bridge-dir",
+            str(bridge),
+            "--symbol",
+            "EURUSD",
+            "--timeout",
+            "1",
+        ]
+    )
+    t.join()
+    assert rc == 0
+
+    specs_path = bridge / "symbol_specs.json"
+    specs = json.loads(specs_path.read_text())
+    assert specs["digits"] == 5

--- a/tests/test_mt4_broker_handshake.py
+++ b/tests/test_mt4_broker_handshake.py
@@ -1,0 +1,51 @@
+import json
+import time
+
+from forest5.live.mt4_broker import MT4Broker
+
+
+def _prepare_bridge(tmp_path):
+    for d in ["commands", "results", "state", "ticks"]:
+        (tmp_path / d).mkdir()
+    return tmp_path
+
+
+def _sample_specs():
+    return {
+        "digits": 5,
+        "point": 0.00001,
+        "tick_size": 0.00001,
+        "min_lot": 0.01,
+        "lot_step": 0.01,
+        "contract_size": 100000,
+        "stop_level": 10,
+        "freeze_level": 0,
+    }
+
+
+def test_request_and_ack(tmp_path):
+    bridge = _prepare_bridge(tmp_path)
+    broker = MT4Broker(bridge_dir=bridge, symbol="EURUSD", timeout_sec=1.0)
+    broker.connect()
+    uid = broker.request_specs()
+
+    ack_path = bridge / "results" / f"ack_{uid}.json"
+    ack_path.write_text(json.dumps(_sample_specs()), encoding="utf-8")
+
+    specs = broker.await_ack(uid, timeout=0.5)
+    assert specs["digits"] == 5
+
+
+def test_await_ack_timeout(tmp_path):
+    bridge = _prepare_bridge(tmp_path)
+    broker = MT4Broker(bridge_dir=bridge, symbol="EURUSD", timeout_sec=0.2)
+    broker.connect()
+    uid = broker.request_specs()
+
+    start = time.time()
+    try:
+        broker.await_ack(uid, timeout=0.2)
+        assert False, "expected timeout"
+    except TimeoutError:
+        pass
+    assert time.time() - start >= 0.2


### PR DESCRIPTION
## Summary
- extend `MT4Broker` with file-based preflight handshake (`request_specs`, `await_ack`, `validate_specs`)
- add `forest5 live preflight` command with new parser structure and default grid output location near CSV
- include tests covering broker handshake and CLI preflight workflow

## Testing
- `ruff check src/forest5/cli.py --fix`
- `black src/forest5/cli.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aef831e3708326aeeb14eab0de8688