### PR TITLE
Forest 5.0: CLI alignment and validation hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ poetry run forest5 backtest --csv demo.csv --symbol EURUSD --fast 12 --slow 26
 poetry run forest5 backtest --csv demo.csv --symbol EURUSD --strategy h1_ema_rsi_atr \
   --ema-fast 34 --ema-slow 89 --rsi-len 14 --atr-len 14 \
   --t-sep-atr 0.20 --pullback-atr 0.50 --entry-buffer-atr 0.10 \
-  --sl-min-atr 0.90 --rr 1.8
+  --sl-min-atr 0.90 --rr 1.8 --no-engulf --no-pinbar --no-star
 
 # 5) Grid-search
 poetry run forest5 grid --csv demo.csv --symbol EURUSD --fast-values 6:12:6 --slow-values 20:40:10
@@ -112,6 +112,20 @@ Jeżeli nie podasz `--csv`, program spróbuje znaleźć plik w
 `/home/daro/Fxdata/{SYMBOL}_H1.csv` na podstawie wartości `--symbol`. Własną
 lokalizację wskażesz właśnie parametrem `--csv`.
 
+### Narzędzia danych
+
+Pojedynczy plik można przeanalizować komendą:
+
+```bash
+poetry run forest5 data inspect --csv demo.csv --out out_dir
+```
+
+Uzupełnienie brakujących świec do siatki 1H:
+
+```bash
+poetry run forest5 data pad-h1 --csv demo.csv --policy pad --out padded.csv
+```
+
 ## Live trading z MetaTrader 4
 
 1. Zainstaluj i uruchom MT4 (np. pod Wine w katalogu `~/.mt4`).
@@ -128,6 +142,11 @@ lokalizację wskażesz właśnie parametrem `--csv`.
    ```
    W celu testów bez realnych zleceń dopisz `--paper`.
 
+   Komenda `forest5 live preflight` zapisuje plik `handshake_ack.json` w
+   katalogu mostu potwierdzający poprawną wymianę specyfikacji symbolu.
+   Przy włączonym AI brak pliku kontekstu skutkuje ostrzeżeniem i automatycznym
+   wyłączeniem modułu AI.
+
 ## Validate live-config
 
 Przed uruchomieniem handlu można zweryfikować poprawność konfiguracji:
@@ -137,6 +156,8 @@ poetry run forest5 validate live-config --yaml config/live.example.yaml
 ```
 
 Na sukces komenda wypisze komunikat `OK: <symbol> @ <broker>` i zwróci kod 0.
+Błędny typ brokera lub brak wymaganych pól (np. `ai.context_file` przy
+`require_context: true`) zwróci kod różny od zera.
 
 ## Tryb PAPER (smoke test bez MT4)
 

--- a/scripts/optimize_grid.py
+++ b/scripts/optimize_grid.py
@@ -181,8 +181,20 @@ def main() -> None:
     )
     parser.add_argument("--csv", required=True, help="Ścieżka do CSV z danymi OHLC.")
     parser.add_argument("--symbol", default="SYMBOL", help="Symbol (opisowy).")
-    parser.add_argument("--fast", required=True, help='Zakres np. "5-20" albo "5-20:5".')
-    parser.add_argument("--slow", required=True, help='Zakres np. "20-60" albo "20-60:5".')
+    parser.add_argument(
+        "--fast",
+        "--ema-fast",
+        dest="fast",
+        required=True,
+        help='Zakres np. "5-20" albo "5-20:5". Alias: --ema-fast',
+    )
+    parser.add_argument(
+        "--slow",
+        "--ema-slow",
+        dest="slow",
+        required=True,
+        help='Zakres np. "20-60" albo "20-60:5". Alias: --ema-slow',
+    )
     parser.add_argument(
         "--skip-fast-ge-slow", action="store_true", help="Pomiń pary gdzie fast >= slow."
     )

--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -330,9 +330,9 @@ def cmd_grid(args: argparse.Namespace) -> int:
             sl_min_atr=float(args.sl_min_atr[0]),
             rr=float(args.rr[0]),
             patterns={
-                "engulf": {"enabled": bool(args.pat_engulf)},
-                "pinbar": {"enabled": bool(args.pat_pinbar)},
-                "star": {"enabled": bool(args.pat_star)},
+                "engulfing": bool(args.pat_engulf),
+                "pinbar": bool(args.pat_pinbar),
+                "stars": bool(args.pat_star),
             },
         ),
         risk=dict(
@@ -424,9 +424,9 @@ def cmd_walkforward(args: argparse.Namespace) -> int:
             sl_min_atr=args.sl_min_atr,
             rr=args.rr,
             patterns={
-                "engulf": {"enabled": bool(args.pat_engulf)},
-                "pinbar": {"enabled": bool(args.pat_pinbar)},
-                "star": {"enabled": bool(args.pat_star)},
+                "engulfing": bool(args.pat_engulf),
+                "pinbar": bool(args.pat_pinbar),
+                "stars": bool(args.pat_star),
             },
         ),
         risk=dict(

--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -560,9 +560,7 @@ def cmd_data_inspect(args: argparse.Namespace) -> int:
     for path in paths:
         sep, dec, has_header = sniff_csv_dialect(path)
         header = "yes" if has_header else "no"
-        df = read_ohlc_csv_smart(
-            path, time_col=args.time_col, sep=args.sep, decimal=args.decimal
-        )
+        df = read_ohlc_csv_smart(path, time_col=args.time_col, sep=args.sep, decimal=args.decimal)
         lines = [f"dialect: sep='{sep}' decimal='{dec}' header={header}"]
         lines.append(f"schema: {', '.join(df.columns)}")
         if df.empty:
@@ -754,9 +752,7 @@ def build_parser() -> argparse.ArgumentParser:
     g_pad.add_argument("--csv", type=Path, help="Plik CSV do uzupełnienia")
     p_pad.add_argument("--out-dir", type=Path, help="Katalog wyjściowy")
     p_pad.add_argument("--out", type=Path, help="Plik wyjściowy")
-    p_pad.add_argument(
-        "--policy", choices=("strict", "pad"), default="pad", help="Polityka braków"
-    )
+    p_pad.add_argument("--policy", choices=("strict", "pad"), default="pad", help="Polityka braków")
     p_pad.set_defaults(func=cmd_data_pad_h1)
 
     # backtest

--- a/src/forest5/config.py
+++ b/src/forest5/config.py
@@ -72,6 +72,7 @@ class AISettings(BaseModel):
     model: str = "gpt-4o-mini"
     max_tokens: int = 256
     context_file: str | None = None
+    require_context: bool = False
 
 
 class TimeOnlySettings(BaseModel):

--- a/src/forest5/config/strategy.py
+++ b/src/forest5/config/strategy.py
@@ -35,6 +35,9 @@ class PatternSettings(BaseModel):
     boost_conf: float = 0.20
     boost_score: float = 0.20
     gate: bool = False
+    engulfing: bool = True
+    pinbar: bool = True
+    stars: bool = True
 
 
 class ProfileSettings(BaseModel):

--- a/src/forest5/signals/factory.py
+++ b/src/forest5/signals/factory.py
@@ -63,6 +63,17 @@ def compute_signal(
         return confirm_with_candles(base, candles)
     if name == "h1_ema_rsi_atr":
         params = getattr(strategy, "params", None)
+        patt = getattr(strategy, "patterns", None)
+        if patt is not None:
+            if hasattr(patt, "model_dump"):
+                patt_cfg = patt.model_dump()
+            else:
+                patt_cfg = dict(patt)
+            if hasattr(params, "model_dump"):
+                params = params.model_dump()
+            elif hasattr(params, "dict"):
+                params = params.dict()
+            params = {**(params or {}), "patterns": patt_cfg}
         res = compute_primary_signal_h1(df, params, ctx=ctx)
         if compat_int:
             from .compat import contract_to_int

--- a/tests/test_cli_backtest_disable_patterns.py
+++ b/tests/test_cli_backtest_disable_patterns.py
@@ -1,0 +1,72 @@
+import pandas as pd
+from types import SimpleNamespace
+from forest5.cli import build_parser, cmd_backtest
+
+
+def _write_csv(path):
+    idx = pd.date_range("2020-01-01", periods=5, freq="h")
+    df = pd.DataFrame(
+        {
+            "time": idx,
+            "open": [1, 1.1, 1.2, 1.3, 1.4],
+            "high": [1.1, 1.2, 1.3, 1.4, 1.5],
+            "low": [0.9, 1.0, 1.1, 1.2, 1.3],
+            "close": [1.0, 1.1, 1.2, 1.3, 1.4],
+        }
+    )
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_backtest_disable_patterns(tmp_path, monkeypatch):
+    csv_path = _write_csv(tmp_path / "data.csv")
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "backtest",
+            "--csv",
+            str(csv_path),
+            "--symbol",
+            "EURUSD",
+            "--strategy",
+            "h1_ema_rsi_atr",
+            "--ema-fast",
+            "12",
+            "--ema-slow",
+            "34",
+            "--rsi-len",
+            "14",
+            "--atr-len",
+            "14",
+            "--t-sep-atr",
+            "0.2",
+            "--pullback-atr",
+            "0.5",
+            "--entry-buffer-atr",
+            "0.1",
+            "--sl-min-atr",
+            "0.9",
+            "--rr",
+            "1.8",
+            "--no-engulf",
+            "--no-pinbar",
+            "--no-star",
+        ]
+    )
+    captured = {}
+
+    def fake_run_backtest(df, settings, symbol, price_col, atr_period, atr_multiple):
+        captured["settings"] = settings
+        return SimpleNamespace(
+            equity_curve=pd.Series([1.0, 1.1]),
+            max_dd=0.0,
+            trades=SimpleNamespace(trades=[]),
+        )
+
+    monkeypatch.setattr("forest5.cli.run_backtest", fake_run_backtest)
+    rc = cmd_backtest(args)
+    assert rc == 0
+    pats = captured["settings"].strategy.patterns
+    assert pats.engulfing is False
+    assert pats.pinbar is False
+    assert pats.stars is False

--- a/tests/test_cli_data_single_file.py
+++ b/tests/test_cli_data_single_file.py
@@ -24,19 +24,13 @@ def test_data_inspect_single_file(tmp_path):
 def test_data_pad_h1_single_file(tmp_path):
     csv = tmp_path / "pad.csv"
     csv.write_text(
-        "time,open,high,low,close\n"
-        "2020-01-01 00:00,1,1,1,1\n"
-        "2020-01-01 02:00,1,1,1,1\n",
+        "time,open,high,low,close\n" "2020-01-01 00:00,1,1,1,1\n" "2020-01-01 02:00,1,1,1,1\n",
         encoding="utf-8",
     )
     out_csv = tmp_path / "out.csv"
-    rc = main(
-        ["data", "pad-h1", "--csv", str(csv), "--policy", "strict", "--out", str(out_csv)]
-    )
+    rc = main(["data", "pad-h1", "--csv", str(csv), "--policy", "strict", "--out", str(out_csv)])
     assert rc != 0
-    rc = main(
-        ["data", "pad-h1", "--csv", str(csv), "--policy", "pad", "--out", str(out_csv)]
-    )
+    rc = main(["data", "pad-h1", "--csv", str(csv), "--policy", "pad", "--out", str(out_csv)])
     assert rc == 0
     df = pd.read_csv(out_csv)
     assert len(df) == 3

--- a/tests/test_cli_data_single_file.py
+++ b/tests/test_cli_data_single_file.py
@@ -1,0 +1,43 @@
+import pandas as pd
+from forest5.cli import main
+
+
+def test_data_inspect_single_file(tmp_path):
+    csv = tmp_path / "data.csv"
+    df = pd.DataFrame(
+        {
+            "time": pd.date_range("2020-01-01", periods=2, freq="h"),
+            "open": [1, 1.1],
+            "high": [1, 1.1],
+            "low": [1, 1.1],
+            "close": [1, 1.1],
+        }
+    )
+    df.to_csv(csv, index=False)
+    out_dir = tmp_path / "out"
+    rc = main(["data", "inspect", "--csv", str(csv), "--out", str(out_dir)])
+    assert rc == 0
+    assert (out_dir / "data.txt").exists()
+    assert (out_dir / "data.json").exists()
+
+
+def test_data_pad_h1_single_file(tmp_path):
+    csv = tmp_path / "pad.csv"
+    csv.write_text(
+        "time,open,high,low,close\n"
+        "2020-01-01 00:00,1,1,1,1\n"
+        "2020-01-01 02:00,1,1,1,1\n",
+        encoding="utf-8",
+    )
+    out_csv = tmp_path / "out.csv"
+    rc = main(
+        ["data", "pad-h1", "--csv", str(csv), "--policy", "strict", "--out", str(out_csv)]
+    )
+    assert rc != 0
+    rc = main(
+        ["data", "pad-h1", "--csv", str(csv), "--policy", "pad", "--out", str(out_csv)]
+    )
+    assert rc == 0
+    df = pd.read_csv(out_csv)
+    assert len(df) == 3
+    assert "2020-01-01 01:00:00" in df["time"].tolist()

--- a/tests/test_live_preflight_ack.py
+++ b/tests/test_live_preflight_ack.py
@@ -1,0 +1,57 @@
+import json
+import threading
+import time
+from forest5.cli import main
+
+
+def _prepare_bridge(tmp_path):
+    for d in ["commands", "results", "state", "ticks"]:
+        (tmp_path / d).mkdir()
+    return tmp_path
+
+
+def _sample_specs():
+    return {
+        "digits": 5,
+        "point": 0.00001,
+        "tick_size": 0.00001,
+        "min_lot": 0.01,
+        "lot_step": 0.01,
+        "contract_size": 100000,
+        "stop_level": 10,
+        "freeze_level": 0,
+    }
+
+
+def test_live_preflight_ack(tmp_path, capsys):
+    bridge = _prepare_bridge(tmp_path)
+
+    def writer():
+        cmd_dir = bridge / "commands"
+        while True:
+            reqs = list(cmd_dir.glob("req_*.json"))
+            if reqs:
+                uid = reqs[0].stem.split("_")[1]
+                ack = bridge / "results" / f"ack_{uid}.json"
+                ack.write_text(json.dumps(_sample_specs()), encoding="utf-8")
+                break
+            time.sleep(0.01)
+
+    t = threading.Thread(target=writer)
+    t.start()
+    rc = main([
+        "live",
+        "preflight",
+        "--bridge-dir",
+        str(bridge),
+        "--symbol",
+        "EURUSD",
+        "--timeout",
+        "1",
+    ])
+    t.join()
+    assert rc == 0
+    ack_file = bridge / "handshake_ack.json"
+    assert ack_file.exists()
+    out = capsys.readouterr().out
+    assert "preflight_ack" in out

--- a/tests/test_live_preflight_ack.py
+++ b/tests/test_live_preflight_ack.py
@@ -39,16 +39,18 @@ def test_live_preflight_ack(tmp_path, capsys):
 
     t = threading.Thread(target=writer)
     t.start()
-    rc = main([
-        "live",
-        "preflight",
-        "--bridge-dir",
-        str(bridge),
-        "--symbol",
-        "EURUSD",
-        "--timeout",
-        "1",
-    ])
+    rc = main(
+        [
+            "live",
+            "preflight",
+            "--bridge-dir",
+            str(bridge),
+            "--symbol",
+            "EURUSD",
+            "--timeout",
+            "1",
+        ]
+    )
     t.join()
     assert rc == 0
     ack_file = bridge / "handshake_ack.json"

--- a/tests/test_live_runner_ai_context_missing.py
+++ b/tests/test_live_runner_ai_context_missing.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from forest5.live.live_runner import run_live
+from forest5.live.settings import (
+    LiveSettings,
+    BrokerSettings,
+    DecisionSettings,
+    AISettings,
+    TimeSettings,
+    RiskSettings,
+)
+
+
+def test_ai_context_missing_warn(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    settings = LiveSettings(
+        broker=BrokerSettings(type="paper", bridge_dir=str(tmp_path), symbol="EURUSD", volume=0.01),
+        decision=DecisionSettings(min_confluence=0.5),
+        ai=AISettings(enabled=True, context_file=str(tmp_path / "missing.txt")),
+        time=TimeSettings(),
+        risk=RiskSettings(max_drawdown=0.5),
+    )
+    run_live(settings, max_steps=0, timeout=0)
+    out = capsys.readouterr().out
+    assert "ai_context_missing_warn" in out

--- a/tests/test_live_runner_ai_context_missing.py
+++ b/tests/test_live_runner_ai_context_missing.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from forest5.live.live_runner import run_live
 from forest5.live.settings import (
     LiveSettings,

--- a/tests/test_optimize_grid_aliases.py
+++ b/tests/test_optimize_grid_aliases.py
@@ -1,5 +1,4 @@
 import sys
-import pandas as pd
 import importlib.util
 from pathlib import Path
 import pytest
@@ -14,8 +13,10 @@ spec.loader.exec_module(optimize_grid)
 def test_optimize_grid_aliases(tmp_path, monkeypatch):
     csv = tmp_path / "d.csv"
     csv.write_text("time,open,high,low,close\n", encoding="utf-8")
+
     def fake_load_csv(p):
         raise SystemExit(0)
+
     monkeypatch.setattr(optimize_grid, "_load_csv", fake_load_csv)
     for fast, slow in [("--fast", "--slow"), ("--ema-fast", "--ema-slow")]:
         argv = [

--- a/tests/test_optimize_grid_aliases.py
+++ b/tests/test_optimize_grid_aliases.py
@@ -1,0 +1,34 @@
+import sys
+import pandas as pd
+import importlib.util
+from pathlib import Path
+import pytest
+
+path = Path(__file__).resolve().parents[1] / "scripts" / "optimize_grid.py"
+spec = importlib.util.spec_from_file_location("optimize_grid_module", path)
+optimize_grid = importlib.util.module_from_spec(spec)
+sys.modules["optimize_grid_module"] = optimize_grid
+spec.loader.exec_module(optimize_grid)
+
+
+def test_optimize_grid_aliases(tmp_path, monkeypatch):
+    csv = tmp_path / "d.csv"
+    csv.write_text("time,open,high,low,close\n", encoding="utf-8")
+    def fake_load_csv(p):
+        raise SystemExit(0)
+    monkeypatch.setattr(optimize_grid, "_load_csv", fake_load_csv)
+    for fast, slow in [("--fast", "--slow"), ("--ema-fast", "--ema-slow")]:
+        argv = [
+            "optimize_grid.py",
+            "--csv",
+            str(csv),
+            "--symbol",
+            "EURUSD",
+            fast,
+            "5-10",
+            slow,
+            "20-30",
+        ]
+        monkeypatch.setattr(sys, "argv", argv)
+        with pytest.raises(SystemExit):
+            optimize_grid.main()


### PR DESCRIPTION
## Summary
- Add single-file support for `data inspect` and `data pad-h1`
- Allow disabling candlestick patterns in backtests
- Harden `validate live-config` with enum and field checks
- Create MT4 preflight acknowledgment artefact and log
- Warn and auto-disable AI when context file is missing
- Support `--ema-fast/--ema-slow` aliases in `scripts/optimize_grid.py`
- Sync README with new CLI options and behaviours

## Testing
- `poetry run pytest -q tests/test_cli_data.py tests/test_cli_h1_policy.py tests/test_cli_data_single_file.py`
- `poetry run pytest -q tests/test_cli_backtest_strategy_h1.py tests/test_cli_backtest_disable_patterns.py`
- `poetry run pytest -q tests/test_config_live.py tests/test_live_example_yaml_shape.py tests/test_validate_ready.py`
- `PYTHONPATH=src python src/forest5/cli.py validate live-config --yaml out/stress/live.bad.yaml` *(fails as expected)*
- `poetry run pytest -q tests/test_live_preflight.py tests/test_live_preflight_ack.py`
- `poetry run pytest -q tests/test_live_runner_ai_params.py tests/test_live_runner_ai_context_missing.py`
- `poetry run pytest -q tests/test_optimize_grid_aliases.py`
- `poetry run pytest -q tests/test_cli_help_sanity.py`
- `PYTHONPATH=src python src/forest5/cli.py --help`
- `PYTHONPATH=src python src/forest5/cli.py data --help`


------
https://chatgpt.com/codex/tasks/task_e_68af4db22d8883269b08ae3aa4f79fd5