### PR TITLE
Align pattern configuration keys with PatternSettings

### DIFF
--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -323,9 +323,9 @@ def cmd_grid(args: argparse.Namespace) -> int:
             sl_min_atr=float(args.sl_min_atr[0]),
             rr=float(args.rr[0]),
             patterns={
-                "engulf": {"enabled": bool(args.pat_engulf)},
-                "pinbar": {"enabled": bool(args.pat_pinbar)},
-                "star": {"enabled": bool(args.pat_star)},
+                "engulfing": args.pat_engulf,
+                "pinbar": args.pat_pinbar,
+                "stars": args.pat_star,
             },
         ),
         risk=dict(
@@ -417,9 +417,9 @@ def cmd_walkforward(args: argparse.Namespace) -> int:
             sl_min_atr=args.sl_min_atr,
             rr=args.rr,
             patterns={
-                "engulf": {"enabled": bool(args.pat_engulf)},
-                "pinbar": {"enabled": bool(args.pat_pinbar)},
-                "star": {"enabled": bool(args.pat_star)},
+                "engulfing": args.pat_engulf,
+                "pinbar": args.pat_pinbar,
+                "stars": args.pat_star,
             },
         ),
         risk=dict(


### PR DESCRIPTION
## Summary
- Replace nested pattern configuration with direct boolean mapping keyed by `engulfing`, `pinbar`, and `stars`

## Testing
- `pytest -q tests/test_cli.py tests/test_cli_aliases.py tests/test_cli_grid_from_to.py tests/test_cli_grid_options.py tests/test_cli_h1_policy.py tests/test_grid_resume.py tests/test_cli_walkforward.py tests/test_walkforward_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68af587bd778832684e7cf30d437af5d