### PR TITLE
Normalize hourly indices for CSV IO

### DIFF
--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -35,6 +35,7 @@ from forest5.utils.io import (
     sniff_csv_dialect,
     atomic_to_csv,
     atomic_write_json,
+    normalize_ohlc_h1,
 )
 from forest5.utils.timeindex import ensure_h1
 from forest5.utils.argparse_ext import (
@@ -95,6 +96,7 @@ def load_ohlc_csv(
 
     df = read_ohlc_csv(path, time_col=time_col, sep=sep)
     df, meta = ensure_h1(df, policy=policy)
+    df = normalize_ohlc_h1(df, policy=policy)
     return df, meta
 
 
@@ -138,6 +140,7 @@ def cmd_backtest(args: argparse.Namespace) -> int:
 
     df = read_ohlc_csv(csv_path, time_col=args.time_col, sep=args.sep)
     df, time_meta = ensure_h1(df, policy=args.h1_policy)
+    df = normalize_ohlc_h1(df, policy=args.h1_policy)
     if args.time_from is not None or args.time_to is not None:
         df = df.loc[args.time_from : args.time_to]
 
@@ -250,6 +253,7 @@ def cmd_grid(args: argparse.Namespace) -> int:
 
     df = read_ohlc_csv(csv_path, time_col=args.time_col, sep=args.sep)
     df, time_meta = ensure_h1(df, policy=args.h1_policy)
+    df = normalize_ohlc_h1(df, policy=args.h1_policy)
     if args.time_from is not None or args.time_to is not None:
         df = df.loc[args.time_from : args.time_to]
 
@@ -716,6 +720,7 @@ def cmd_data_pad_h1(args: argparse.Namespace) -> int:
         df = read_ohlc_csv_smart(path)
         try:
             df, _ = ensure_h1(df, policy=args.policy)
+            df = normalize_ohlc_h1(df, policy=args.policy)
         except ValueError as exc:
             print(str(exc), file=sys.stderr)
             return 1
@@ -733,6 +738,7 @@ def cmd_data_pad_h1(args: argparse.Namespace) -> int:
         df = read_ohlc_csv_smart(path)
         try:
             df, _ = ensure_h1(df, policy=args.policy)
+            df = normalize_ohlc_h1(df, policy=args.policy)
         except ValueError as exc:
             print(f"{path.name}: {exc}", file=sys.stderr)
             rc = 1

--- a/tests/test_h1_strict_regression.py
+++ b/tests/test_h1_strict_regression.py
@@ -1,0 +1,23 @@
+import pandas as pd
+from pathlib import Path
+
+from forest5.utils.io import normalize_ohlc_h1
+
+
+def test_normalize_strict_from_padded(tmp_path: Path):
+    idx = pd.date_range("2020-01-01 00:00", periods=5, freq="1h")
+    df = pd.DataFrame(
+        {
+            "open": [1, 2, 3, 4, 5],
+            "high": [1, 2, 3, 4, 5],
+            "low": [1, 2, 3, 4, 5],
+            "close": [1, 2, 3, 4, 5],
+            "volume": [10, 10, 10, 10, 10],
+        },
+        index=idx,
+    ).drop(idx[2])
+    padded = normalize_ohlc_h1(df.copy(), policy="pad")
+    assert pd.infer_freq(padded.index) == "h"
+    strict = normalize_ohlc_h1(padded.copy(), policy="strict")
+    assert pd.infer_freq(strict.index) == "h"
+    assert not strict.isna().any().any()


### PR DESCRIPTION
## Summary
- add `normalize_ohlc_h1` to enforce regular 1h indices and fill missing OHLC bars
- update CLI commands to normalise with H1 policy
- add regression test for strict mode after padding

## Testing
- `poetry run ruff check .`
- `poetry run black --check .`
- `poetry run pytest tests/test_h1_strict_regression.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0724ca9088326b07cec6195b05ea0