### PR TITLE
feat: add candlestick pattern params to grid/backtest

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,24 @@ poetry run forest5 backtest --csv demo.csv --symbol EURUSD --strategy h1_ema_rsi
 # 5) Grid-search
 poetry run forest5 grid --csv demo.csv --symbol EURUSD --fast-values 6:12:6 --slow-values 20:40:10
 
+# 5b) Grid-search z progami formacji świecowych
+poetry run forest5 grid --csv demo.csv --symbol EURUSD \
+  --fast-values 6 --slow-values 20 \
+  --engulf-eps-atr 0.03,0.05 --pinbar-wick-dom 0.55,0.60 \
+  --star-reclaim-min 0.50,0.62 --dry-run
+
 # 6) Inspekcja pojedynczego pliku i uzupełnianie braków
 poetry run forest5 data inspect --csv demo.csv --out out_dir
 poetry run forest5 data pad-h1 --csv demo.csv --policy pad --out demo_filled.csv
 
 # 7) Wyłączenie detektorów świecowych w backteście
 poetry run forest5 backtest --csv demo.csv --symbol EURUSD --strategy h1_ema_rsi_atr --no-pinbar
+
+# 7b) Backtest z progami formacji świecowych
+poetry run forest5 backtest --csv demo.csv --symbol EURUSD --strategy h1_ema_rsi_atr \
+  --engulf-eps-atr 0.05 --engulf-body-ratio-min 1.1 \
+  --pinbar-wick-dom 0.60 --pinbar-body-max 0.30 --pinbar-opp-wick-max 0.20 \
+  --star-reclaim-min 0.62 --star-mid-small-max 0.40
 
 # 8) Walidacja konfiguracji live
 poetry run forest5 validate live-config --yaml config/live.example.yaml

--- a/src/forest5/config/strategy.py
+++ b/src/forest5/config/strategy.py
@@ -25,6 +25,17 @@ class H1EmaRsiAtrParams(BaseModel):
     timeframe: str = "H1"
     horizon_minutes: int = 240
 
+    engulf_eps_atr: float | None = 0.05
+    engulf_body_ratio_min: float | None = 1.0
+    pinbar_wick_dom: float | None = 0.60
+    pinbar_body_max: float | None = 0.30
+    pinbar_opp_wick_max: float | None = 0.20
+    star_reclaim_min: float | None = 0.62
+    star_mid_small_max: float | None = 0.40
+    enable_engulf: bool = True
+    enable_pinbar: bool = True
+    enable_star: bool = True
+
     def __getitem__(self, item: str) -> Any:  # pragma: no cover - convenience
         return getattr(self, item)
 
@@ -96,6 +107,18 @@ class BaseStrategySettings(BaseModel):
     timeframe: str | None = None
     horizon_minutes: int | None = None
 
+    # Optional overrides for pattern detectors
+    engulf_eps_atr: float | None = None
+    engulf_body_ratio_min: float | None = None
+    pinbar_wick_dom: float | None = None
+    pinbar_body_max: float | None = None
+    pinbar_opp_wick_max: float | None = None
+    star_reclaim_min: float | None = None
+    star_mid_small_max: float | None = None
+    enable_engulf: bool | None = None
+    enable_pinbar: bool | None = None
+    enable_star: bool | None = None
+
     @model_validator(mode="after")
     def _map_h1_params(self) -> "BaseStrategySettings":
         if self.name != "h1_ema_rsi_atr":
@@ -120,6 +143,16 @@ class BaseStrategySettings(BaseModel):
             "rr",
             "timeframe",
             "horizon_minutes",
+            "engulf_eps_atr",
+            "engulf_body_ratio_min",
+            "pinbar_wick_dom",
+            "pinbar_body_max",
+            "pinbar_opp_wick_max",
+            "star_reclaim_min",
+            "star_mid_small_max",
+            "enable_engulf",
+            "enable_pinbar",
+            "enable_star",
         ):
             value = getattr(self, field, None)
             if value is not None:

--- a/src/forest5/signals/patterns/pinbar.py
+++ b/src/forest5/signals/patterns/pinbar.py
@@ -5,17 +5,35 @@ from __future__ import annotations
 import pandas as pd
 
 
-def detect(df: pd.DataFrame, atr: float) -> dict | None:
+def detect(
+    df: pd.DataFrame,
+    atr: float,
+    *,
+    wick_dom: float = 0.60,
+    body_max: float = 0.30,
+    opp_wick_max: float = 0.20,
+) -> dict | None:
     """Detect bullish or bearish pinbar pattern."""
-    if len(df) < 1:
+
+    if len(df) < 1 or atr <= 0:
         return None
 
     c = df.iloc[-1]
+    rng = c.high - c.low
+    if rng <= 0:
+        return None
     body = abs(c.close - c.open)
     upper = c.high - max(c.open, c.close)
     lower = min(c.open, c.close) - c.low
 
-    if upper <= body and lower >= 2 * body:
+    body_frac = body / rng
+    upper_frac = upper / rng
+    lower_frac = lower / rng
+
+    if body_frac > body_max:
+        return None
+
+    if lower_frac >= wick_dom and upper_frac <= opp_wick_max:
         score = lower / atr
         return {
             "type": "bullish_pinbar",
@@ -24,7 +42,7 @@ def detect(df: pd.DataFrame, atr: float) -> dict | None:
             "score": float(score),
         }
 
-    if lower <= body and upper >= 2 * body:
+    if upper_frac >= wick_dom and lower_frac <= opp_wick_max:
         score = upper / atr
         return {
             "type": "bearish_pinbar",

--- a/src/forest5/signals/patterns/stars.py
+++ b/src/forest5/signals/patterns/stars.py
@@ -5,9 +5,16 @@ from __future__ import annotations
 import pandas as pd
 
 
-def detect(df: pd.DataFrame, atr: float) -> dict | None:
+def detect(
+    df: pd.DataFrame,
+    atr: float,
+    *,
+    reclaim_min: float = 0.62,
+    mid_small_max: float = 0.40,
+) -> dict | None:
     """Detect morning star (bullish) or evening star (bearish) pattern."""
-    if len(df) < 3:
+
+    if len(df) < 3 or atr <= 0:
         return None
 
     a = df.iloc[-3]
@@ -17,35 +24,33 @@ def detect(df: pd.DataFrame, atr: float) -> dict | None:
     body_a = abs(a.close - a.open)
     body_b = abs(b.close - b.open)
     body_c = abs(c.close - c.open)
+    if body_a <= 0:
+        return None
+
+    mid_ratio = body_b / body_a
 
     # Morning star
-    if (
-        a.close < a.open
-        and body_a > body_b
-        and c.close > c.open
-        and c.close >= (a.open + a.close) / 2
-    ):
-        score = (body_a + body_c) / atr
-        return {
-            "type": "morning_star",
-            "hi": float(max(a.high, b.high, c.high)),
-            "lo": float(min(a.low, b.low, c.low)),
-            "score": float(score),
-        }
+    if a.close < a.open and c.close > c.open:
+        reclaim = (c.close - a.close) / body_a
+        if reclaim >= reclaim_min and mid_ratio <= mid_small_max:
+            score = (body_a + body_c) / atr
+            return {
+                "type": "morning_star",
+                "hi": float(max(a.high, b.high, c.high)),
+                "lo": float(min(a.low, b.low, c.low)),
+                "score": float(score),
+            }
 
     # Evening star
-    if (
-        a.close > a.open
-        and body_a > body_b
-        and c.close < c.open
-        and c.close <= (a.open + a.close) / 2
-    ):
-        score = (body_a + body_c) / atr
-        return {
-            "type": "evening_star",
-            "hi": float(max(a.high, b.high, c.high)),
-            "lo": float(min(a.low, b.low, c.low)),
-            "score": float(score),
-        }
+    if a.close > a.open and c.close < c.open:
+        reclaim = (a.close - c.close) / body_a
+        if reclaim >= reclaim_min and mid_ratio <= mid_small_max:
+            score = (body_a + body_c) / atr
+            return {
+                "type": "evening_star",
+                "hi": float(max(a.high, b.high, c.high)),
+                "lo": float(min(a.low, b.low, c.low)),
+                "score": float(score),
+            }
 
     return None

--- a/src/forest5/utils/argparse_ext.py
+++ b/src/forest5/utils/argparse_ext.py
@@ -185,3 +185,24 @@ def span_or_list(spec: str, type_fn: type | None = None) -> list:
         raise argparse.ArgumentTypeError(
             f"Invalid range: {spec}. Expected formats: lo-hi[:step] or lo:hi:step",
         ) from ex
+
+
+class SpanOrList:
+    """Callable wrapper converting span/list specs using ``span_or_list``.
+
+    Parameters
+    ----------
+    type_fn:
+        Type to cast parsed values to.  Example::
+
+            parser.add_argument("--foo", type=SpanOrList(float))
+
+    The callable returned by argparse will then parse inputs like
+    ``1-3`` or ``1,2,3`` into a list of ``float`` values.
+    """
+
+    def __init__(self, type_fn: type | None = None) -> None:
+        self.type_fn = type_fn
+
+    def __call__(self, spec: str) -> list:
+        return span_or_list(spec, self.type_fn)

--- a/tests/test_cli_grid_options.py
+++ b/tests/test_cli_grid_options.py
@@ -114,3 +114,79 @@ def test_cli_grid_additional_options(tmp_path, monkeypatch):
     assert settings.atr_multiple == 3
     assert settings.time.model.path == model_path
     assert settings.time.fusion_min_confluence == pytest.approx(2.0)
+
+
+def test_pattern_flags_parse(tmp_path):
+    csv_path = _write_csv(tmp_path / "data.csv")
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "grid",
+            "--csv",
+            str(csv_path),
+            "--symbol",
+            "EURUSD",
+            "--fast-values",
+            "2",
+            "--slow-values",
+            "5",
+            "--engulf-eps-atr",
+            "0.03,0.05",
+            "--engulf-body-ratio-min",
+            "1.0,1.1",
+            "--pinbar-wick-dom",
+            "0.55,0.60",
+            "--pinbar-body-max",
+            "0.25,0.30",
+            "--pinbar-opp-wick-max",
+            "0.15,0.20",
+            "--star-reclaim-min",
+            "0.50,0.62",
+            "--star-mid-small-max",
+            "0.30,0.40",
+            "--no-star",
+        ]
+    )
+    assert args.engulf_eps_atr == [0.03, 0.05]
+    assert args.engulf_body_ratio_min == [1.0, 1.1]
+    assert args.pinbar_wick_dom == [0.55, 0.60]
+    assert args.pinbar_body_max == [0.25, 0.30]
+    assert args.pinbar_opp_wick_max == [0.15, 0.20]
+    assert args.star_reclaim_min == [0.50, 0.62]
+    assert args.star_mid_small_max == [0.30, 0.40]
+    assert args.no_star is True
+
+
+def test_backtest_pattern_flags_parse(tmp_path):
+    csv_path = _write_csv(tmp_path / "data.csv")
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "backtest",
+            "--csv",
+            str(csv_path),
+            "--symbol",
+            "EURUSD",
+            "--strategy",
+            "h1_ema_rsi_atr",
+            "--engulf-eps-atr",
+            "0.05",
+            "--engulf-body-ratio-min",
+            "1.1",
+            "--pinbar-wick-dom",
+            "0.6",
+            "--pinbar-body-max",
+            "0.3",
+            "--pinbar-opp-wick-max",
+            "0.2",
+            "--star-reclaim-min",
+            "0.62",
+            "--star-mid-small-max",
+            "0.4",
+            "--no-engulf",
+        ]
+    )
+    assert args.engulf_eps_atr == pytest.approx(0.05)
+    assert args.pinbar_wick_dom == pytest.approx(0.6)
+    assert args.star_mid_small_max == pytest.approx(0.4)
+    assert args.no_engulf is True

--- a/tests/test_cli_help_sanity.py
+++ b/tests/test_cli_help_sanity.py
@@ -49,3 +49,15 @@ def test_backtest_help_mentions_strategy(capsys):
     out = _run_and_capture(["backtest", "--help"], capsys)
     assert "--strategy" in out
     assert "h1_ema_rsi_atr" in out
+
+
+def test_backtest_help_mentions_patterns(capsys):
+    out = _run_and_capture(["backtest", "--help"], capsys)
+    assert "--engulf-eps-atr" in out
+    assert "--pinbar-wick-dom" in out
+
+
+def test_grid_help_mentions_patterns(capsys):
+    out = _run_and_capture(["grid", "--help"], capsys)
+    assert "--star-mid-small-max" in out
+    assert "--pinbar-body-max" in out

--- a/tests/test_patterns_cli_integration.py
+++ b/tests/test_patterns_cli_integration.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from forest5.cli import build_parser, cmd_backtest
+
+
+def _write_csv(path: Path) -> Path:
+    idx = pd.date_range("2020-01-01", periods=5, freq="h")
+    df = pd.DataFrame(
+        {
+            "time": idx,
+            "open": [1, 1.1, 1.2, 1.3, 1.4],
+            "high": [1.1, 1.2, 1.3, 1.4, 1.5],
+            "low": [0.9, 1.0, 1.1, 1.2, 1.3],
+            "close": [1.0, 1.1, 1.2, 1.3, 1.4],
+        }
+    )
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_backtest_passes_pattern_params(tmp_path, monkeypatch):
+    csv_path = _write_csv(tmp_path / "data.csv")
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "backtest",
+            "--csv",
+            str(csv_path),
+            "--symbol",
+            "EURUSD",
+            "--strategy",
+            "h1_ema_rsi_atr",
+            "--engulf-eps-atr",
+            "0.05",
+            "--pinbar-wick-dom",
+            "0.6",
+            "--star-reclaim-min",
+            "0.62",
+        ]
+    )
+
+    captured: dict[str, dict] = {}
+
+    monkeypatch.setattr(
+        "forest5.signals.patterns.registry.enable_engulfing",
+        lambda **kw: captured.setdefault("engulf", kw),
+    )
+    monkeypatch.setattr(
+        "forest5.signals.patterns.registry.enable_pinbar",
+        lambda **kw: captured.setdefault("pinbar", kw),
+    )
+    monkeypatch.setattr(
+        "forest5.signals.patterns.registry.enable_stars",
+        lambda **kw: captured.setdefault("stars", kw),
+    )
+
+    def fake_run_backtest(df, settings, symbol, price_col, atr_period, atr_multiple):
+        from forest5.signals.h1_ema_rsi_atr import compute_primary_signal_h1
+
+        compute_primary_signal_h1(df, params=settings.strategy)
+        return SimpleNamespace(
+            equity_curve=pd.Series([1.0, 1.1]),
+            max_dd=0.0,
+            trades=SimpleNamespace(trades=[]),
+        )
+
+    monkeypatch.setattr("forest5.cli.run_backtest", fake_run_backtest)
+
+    rc = cmd_backtest(args)
+    assert rc == 0


### PR DESCRIPTION
## Summary
- expose ATR-based thresholds and enable flags for engulfing, pinbar and star patterns in `grid` and `backtest` CLI
- wire pattern overrides into strategy params and registry detectors
- document pattern parameters and add CLI tests

## Testing
- `poetry run ruff check .`
- `poetry run black --check .`
- `poetry run pytest -q`
- `PYTHONPATH=src poetry run python src/forest5/cli.py grid --csv demo.csv --symbol EURUSD --ema-fast 2 --ema-slow 5   --engulf-eps-atr 0.03,0.05 --engulf-body-ratio-min 1.0,1.1   --pinbar-wick-dom 0.55,0.60 --pinbar-body-max 0.25,0.30 --pinbar-opp-wick-max 0.15,0.20   --star-reclaim-min 0.50,0.62 --star-mid-small-max 0.30,0.40   --no-engulf --no-pinbar --no-star --dry-run --out out_demo`
- `PYTHONPATH=src poetry run python src/forest5/cli.py backtest --csv demo.csv --symbol EURUSD --strategy h1_ema_rsi_atr   --engulf-eps-atr 0.05 --engulf-body-ratio-min 1.1   --pinbar-wick-dom 0.60 --pinbar-body-max 0.30 --pinbar-opp-wick-max 0.20   --star-reclaim-min 0.62 --star-mid-small-max 0.40 --export-equity out_bt.csv`

------
https://chatgpt.com/codex/tasks/task_e_68b194ab15f88326a9192c754c5001b3