### PR TITLE
Forest 5: unify H1 backtests on contract engine + CLI/tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ dist/
 
 # outputs
 out/
+out_*/
+out_runs/
+out_data_inspect/
+Fxdata/
+fxdata/
 *.csv
 !docs/equity.csv
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{ include = "forest5", from = "src" }]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.10,<3.14"
 pandas = "^2.2"
 numpy = "^2.0"
 pyyaml = "^6.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,21 @@ target-version = "py311"
 
 [tool.black]
 line-length = 100
+extend-exclude = '''
+(
+  ^Fxdata/|
+  ^fxdata/|
+  ^out/|
+  ^out_runs/|
+  ^out_data_inspect/|
+  ^out_.*/|
+  ^node_modules/|
+  ^\.venv/|
+  ^\.cache/|
+  ^\.pytest_cache/|
+  ^\.ruff_cache/
+)
+'''
 
 [build-system]
 requires = ["poetry-core"]

--- a/scripts/batch_normalize_dir.py
+++ b/scripts/batch_normalize_dir.py
@@ -32,4 +32,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/scripts/batch_normalize_dir.py
+++ b/scripts/batch_normalize_dir.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from forest5.cli import main as forest5_main
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        prog="batch-normalize-dir",
+        description="Example: normalize all CSVs in a directory to 1H schema",
+    )
+    p.add_argument("--input-dir", type=Path, required=True)
+    p.add_argument("--out-dir", type=Path, required=True)
+    p.add_argument("--policy", choices=("strict", "pad"), default="pad")
+    args = p.parse_args()
+
+    # Delegate to forest5 CLI data normalize command
+    return forest5_main(
+        [
+            "data",
+            "normalize",
+            "--input-dir",
+            str(args.input_dir),
+            "--out-dir",
+            str(args.out_dir),
+        ]
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/scripts/debug_h1_decision.py
+++ b/scripts/debug_h1_decision.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import argparse
 from collections import Counter
-from dataclasses import asdict
 from typing import Any
 
 import pandas as pd
@@ -45,7 +44,6 @@ def run_debug(
     events: list[dict] = []
     counts = Counter()
     armed = 0
-    triggers = 0
     for i in range(len(df)):
         collector = TraceCollector()
         _ = compute_primary_signal_h1(df.iloc[: i + 1], params, collector=collector)
@@ -104,7 +102,7 @@ def main() -> int:
         rr=args.rr,
     )
     # Pretty print
-    print("Bars:", out["total_bars"], "Armed:", out["armed"]) 
+    print("Bars:", out["total_bars"], "Armed:", out["armed"])
     print("Reasons:")
     for k, v in sorted(out["counts"].items(), key=lambda kv: (-kv[1], kv[0])):
         print(f"  {k}: {v}")

--- a/scripts/debug_h1_decision.py
+++ b/scripts/debug_h1_decision.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from dataclasses import asdict
+from typing import Any
+
+import pandas as pd
+
+from forest5.utils.io import read_ohlc_csv
+from forest5.signals.h1_ema_rsi_atr import compute_primary_signal_h1
+from forest5.utils.debugger import TraceCollector
+
+
+def run_debug(
+    csv: str,
+    start: str | None,
+    ema_fast: int,
+    ema_slow: int,
+    rsi_len: int,
+    atr_len: int,
+    t_sep_atr: float,
+    pullback_atr: float,
+    entry_buffer_atr: float,
+    sl_min_atr: float,
+    rr: float,
+) -> dict[str, Any]:
+    df = read_ohlc_csv(csv)
+    if start:
+        df = df.loc[pd.Timestamp(start) :]
+
+    params = dict(
+        ema_fast=ema_fast,
+        ema_slow=ema_slow,
+        rsi_period=rsi_len,
+        atr_period=atr_len,
+        t_sep_atr=t_sep_atr,
+        pullback_atr=pullback_atr,
+        entry_buffer_atr=entry_buffer_atr,
+        sl_min_atr=sl_min_atr,
+        rr=rr,
+    )
+
+    events: list[dict] = []
+    counts = Counter()
+    armed = 0
+    triggers = 0
+    for i in range(len(df)):
+        collector = TraceCollector()
+        _ = compute_primary_signal_h1(df.iloc[: i + 1], params, collector=collector)
+        for ev in collector.events:
+            # ev: {time,stage,reason,...}
+            events.append(ev)
+            stage = ev.get("stage")
+            reason = ev.get("reason")
+            if stage == "setup_candidate" and reason:
+                counts[reason] += 1
+            if stage == "setup_trigger" and reason == "armed":
+                armed += 1
+            if stage == "pattern" and reason == "pattern_trigger_hit":
+                counts["pattern_ok"] += 1
+            if stage == "pattern" and reason == "pattern_trigger_miss":
+                counts["pattern_miss"] += 1
+
+    # Aggregate reasons
+    summary = {
+        "total_bars": len(df),
+        "armed": armed,
+        "counts": dict(counts),
+    }
+    # Top 10 most recent candidate notes for inspection
+    sample = [e for e in events if e.get("stage") in ("setup_candidate", "pattern")][-10:]
+    summary["sample_tail"] = sample
+    return summary
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser("debug-h1-decision")
+    ap.add_argument("--csv", required=True)
+    ap.add_argument("--from", dest="start", default=None)
+    ap.add_argument("--ema-fast", type=int, default=34)
+    ap.add_argument("--ema-slow", type=int, default=89)
+    ap.add_argument("--rsi-len", type=int, default=14)
+    ap.add_argument("--atr-len", type=int, default=14)
+    ap.add_argument("--t-sep-atr", type=float, default=0.5)
+    ap.add_argument("--pullback-atr", type=float, default=0.5)
+    ap.add_argument("--entry-buffer-atr", type=float, default=0.1)
+    ap.add_argument("--sl-min-atr", type=float, default=0.0)
+    ap.add_argument("--rr", type=float, default=2.0)
+    args = ap.parse_args()
+
+    out = run_debug(
+        csv=args.csv,
+        start=args.start,
+        ema_fast=args.ema_fast,
+        ema_slow=args.ema_slow,
+        rsi_len=args.rsi_len,
+        atr_len=args.atr_len,
+        t_sep_atr=args.t_sep_atr,
+        pullback_atr=args.pullback_atr,
+        entry_buffer_atr=args.entry_buffer_atr,
+        sl_min_atr=args.sl_min_atr,
+        rr=args.rr,
+    )
+    # Pretty print
+    print("Bars:", out["total_bars"], "Armed:", out["armed"]) 
+    print("Reasons:")
+    for k, v in sorted(out["counts"].items(), key=lambda kv: (-kv[1], kv[0])):
+        print(f"  {k}: {v}")
+    print("\nSample tail events:")
+    for e in out["sample_tail"]:
+        print(e)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/h1_mini_grid.py
+++ b/scripts/h1_mini_grid.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from forest5.config import BacktestSettings
+from forest5.backtest.engine import run_backtest
+from forest5.utils.io import read_ohlc_csv
+from forest5.utils.timeindex import ensure_h1
+from forest5.utils.io import normalize_ohlc_h1
+
+
+def run_single(
+    csv: Path,
+    symbol: str,
+    start: str,
+    *,
+    ema_fast: int,
+    ema_slow: int,
+    rsi_len: int,
+    atr_len: int,
+    t_sep_atr: float,
+    pullback_atr: float,
+    entry_buffer_atr: float,
+    rr: float,
+    entry_mode: str,
+    ttl_bars: int,
+    use_ema_gates: bool,
+) -> dict:
+    df = read_ohlc_csv(csv)
+    df = df.loc[pd.Timestamp(start) :]
+    df, _ = ensure_h1(df, policy="pad")
+    df = normalize_ohlc_h1(df, policy="pad")
+
+    settings = BacktestSettings(
+        symbol=symbol,
+        timeframe="1h",
+        strategy=dict(
+            name="h1_ema_rsi_atr",
+            ema_fast=ema_fast,
+            ema_slow=ema_slow,
+            atr_period=atr_len,
+            rsi_period=rsi_len,
+            t_sep_atr=t_sep_atr,
+            pullback_atr=pullback_atr,
+            entry_buffer_atr=entry_buffer_atr,
+            rr=rr,
+            entry_mode=entry_mode,
+            use_ema_gates=use_ema_gates,
+        ),
+        setup_ttl_bars=int(ttl_bars),
+    )
+    res = run_backtest(df, settings)
+    eq_end = float(res.equity_curve.iloc[-1]) if not res.equity_curve.empty else 0.0
+    trades = len(res.trades.trades)
+    ret = eq_end / settings.risk.initial_capital - 1.0
+    return dict(
+        symbol=symbol,
+        ema_fast=ema_fast,
+        ema_slow=ema_slow,
+        t_sep_atr=t_sep_atr,
+        pullback_atr=pullback_atr,
+        entry_buffer_atr=entry_buffer_atr,
+        rr=rr,
+        entry_mode=entry_mode,
+        ttl_bars=ttl_bars,
+        use_ema_gates=use_ema_gates,
+        equity_end=eq_end,
+        return_pct=ret,
+        max_dd=float(res.max_dd),
+        trades=trades,
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser("h1-mini-grid")
+    ap.add_argument("--data-dir", type=Path, default=Path("repos/forest-5.0/Fxdata"))
+    ap.add_argument("--symbols", nargs="+", default=["EURUSD", "GBPUSD", "USDJPY", "EURJPY"])
+    ap.add_argument("--from", dest="start", default="2024-01-01")
+    ap.add_argument("--out", type=Path, default=Path("repos/forest-5.0/out_runs/h1_mini_grid.csv"))
+    args = ap.parse_args()
+
+    combos = []
+    for use_ema in (True, False):
+        for entry_mode in ("breakout", "close", "close_next"):
+            for entry_buffer_atr in (0.0, 0.05):
+                combos.append(
+                    dict(use_ema_gates=use_ema, entry_mode=entry_mode, entry_buffer_atr=entry_buffer_atr)
+                )
+
+    rows: list[dict] = []
+    for sym in args.symbols:
+        csv = args.data_dir / f"{sym}_H1.csv"
+        for cmb in combos:
+            row = run_single(
+                csv,
+                sym,
+                args.start,
+                ema_fast=12,
+                ema_slow=34,
+                rsi_len=14,
+                atr_len=14,
+                t_sep_atr=0.2,
+                pullback_atr=1.2,
+                entry_buffer_atr=cmb["entry_buffer_atr"],
+                rr=1.5,
+                entry_mode=cmb["entry_mode"],
+                ttl_bars=2,
+                use_ema_gates=cmb["use_ema_gates"],
+            )
+            rows.append(row)
+
+    df = pd.DataFrame(rows)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(args.out, index=False)
+    print(df)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/h1_mini_grid.py
+++ b/scripts/h1_mini_grid.py
@@ -2,9 +2,7 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import asdict
 from pathlib import Path
-from typing import Iterable
 
 import pandas as pd
 
@@ -90,7 +88,11 @@ def main() -> int:
         for entry_mode in ("breakout", "close", "close_next"):
             for entry_buffer_atr in (0.0, 0.05):
                 combos.append(
-                    dict(use_ema_gates=use_ema, entry_mode=entry_mode, entry_buffer_atr=entry_buffer_atr)
+                    dict(
+                        use_ema_gates=use_ema,
+                        entry_mode=entry_mode,
+                        entry_buffer_atr=entry_buffer_atr,
+                    )
                 )
 
     rows: list[dict] = []

--- a/src/forest5/backtest/engine.py
+++ b/src/forest5/backtest/engine.py
@@ -27,7 +27,6 @@ from ..signals.setups import SetupRegistry, TriggeredSignal
 from .risk import RiskManager
 from .tradebook import TradeBook
 from ..time_only import TimeOnlyModel
-from ..signals.fusion import _to_sign
 from ..decision_core import fuse_with_time as _fuse_with_time
 
 
@@ -431,7 +430,11 @@ class BacktestEngine:
 
         # Record close in TradeBook mirroring pnl realization
         self.tradebook.add(
-            time=self.df.index[pos.get("open_index", 0)] if pos.get("open_index") is not None else self.df.index[0],
+            time=(
+                self.df.index[pos.get("open_index", 0)]
+                if pos.get("open_index") is not None
+                else self.df.index[0]
+            ),
             price_open=float(pos["entry"]),
             qty=qty,
             side=("SELL" if pos["action"] == "BUY" else "BUY"),
@@ -441,7 +444,11 @@ class BacktestEngine:
             tp=(float(pos.get("tp")) if pos.get("tp") is not None else None),
             reason_close=reason,
             setup_id=str(pos.get("id", "")),
-            pattern=(pos.get("meta", {}) or {}).get("pattern") if isinstance(pos.get("meta"), dict) else None,
+            pattern=(
+                (pos.get("meta", {}) or {}).get("pattern")
+                if isinstance(pos.get("meta"), dict)
+                else None
+            ),
         )
 
     # ------------------------------------------------------------------
@@ -683,6 +690,7 @@ def run_backtest(
         except Exception:
             ema_fast, ema_slow, rsi_len = 21, 55, 14
         from ..core.indicators import ema as _ema, rsi as _rsi, ema_col_name, rsi_col_name
+
         df[ema_col_name(ema_fast)] = _ema(df["close"], ema_fast).astype("float32")
         df[ema_col_name(ema_slow)] = _ema(df["close"], ema_slow).astype("float32")
         df[rsi_col_name(rsi_len)] = _rsi(df["close"], rsi_len).astype("float32")

--- a/src/forest5/backtest/grid.py
+++ b/src/forest5/backtest/grid.py
@@ -328,6 +328,7 @@ def run_param_grid(
     # Optional: cache indicators globally to save recomputation across combos
     from ..core import indicators as _ind
     from joblib import Memory as _Memory
+
     _mem = _Memory(".cache/forest5-grid", verbose=0)
     _atr_orig, _ema_orig = _ind.atr, _ind.ema
     _ind.atr = _mem.cache(_ind.atr)

--- a/src/forest5/backtest/grid.py
+++ b/src/forest5/backtest/grid.py
@@ -325,6 +325,14 @@ def run_param_grid(
         "timestamp_utc": datetime.now(timezone.utc).isoformat(),
     }
 
+    # Optional: cache indicators globally to save recomputation across combos
+    from ..core import indicators as _ind
+    from joblib import Memory as _Memory
+    _mem = _Memory(".cache/forest5-grid", verbose=0)
+    _atr_orig, _ema_orig = _ind.atr, _ind.ema
+    _ind.atr = _mem.cache(_ind.atr)
+    _ind.ema = _mem.cache(_ind.ema)
+
     if dry_run:
         out = pd.DataFrame(combos)
         out.insert(
@@ -474,4 +482,7 @@ def run_param_grid(
         atomic_to_csv(to_save, results_path)
     if meta_path:
         atomic_write_json(meta, meta_path)
+    # restore indicators
+    _ind.atr = _atr_orig
+    _ind.ema = _ema_orig
     return out, meta

--- a/src/forest5/cli.py
+++ b/src/forest5/cli.py
@@ -278,9 +278,11 @@ def cmd_backtest(args: argparse.Namespace) -> int:
             "equity_end": equity_end,
             "return": ret,
             "max_dd": float(getattr(res, "max_dd", float("nan"))),
-            "trades": int(len(getattr(res, "trades", getattr(res, "trades", [])).trades))
-            if hasattr(res, "trades") and hasattr(res.trades, "trades")
-            else int(len(getattr(res, "trades", []))),
+            "trades": (
+                int(len(getattr(res, "trades", getattr(res, "trades", [])).trades))
+                if hasattr(res, "trades") and hasattr(res.trades, "trades")
+                else int(len(getattr(res, "trades", [])))
+            ),
         }
         Path(args.metrics_out).write_text(json.dumps(metrics), encoding="utf-8")
 
@@ -805,9 +807,7 @@ def cmd_data_inspect(args: argparse.Namespace) -> int:
             if multi:
                 base = p.stem
                 (out_dir / f"{base}_summary.txt").write_text(text, encoding="utf-8")
-                (out_dir / f"{base}_summary.json").write_text(
-                    json.dumps(summary), encoding="utf-8"
-                )
+                (out_dir / f"{base}_summary.json").write_text(json.dumps(summary), encoding="utf-8")
             else:
                 (out_dir / "summary.txt").write_text(text, encoding="utf-8")
                 (out_dir / "summary.json").write_text(json.dumps(summary), encoding="utf-8")

--- a/src/forest5/config/strategy.py
+++ b/src/forest5/config/strategy.py
@@ -24,6 +24,9 @@ class H1EmaRsiAtrParams(BaseModel):
     rr: float = 2.0
     timeframe: str = "H1"
     horizon_minutes: int = 240
+    trailing_atr: float = 0.0
+    entry_mode: Literal["breakout", "close", "close_next"] = "breakout"
+    use_ema_gates: bool = True
 
     engulf_eps_atr: float | None = 0.05
     engulf_body_ratio_min: float | None = 1.0
@@ -141,6 +144,9 @@ class BaseStrategySettings(BaseModel):
             "sl_atr",
             "sl_min_atr",
             "rr",
+            "trailing_atr",
+            "entry_mode",
+            "use_ema_gates",
             "timeframe",
             "horizon_minutes",
             "engulf_eps_atr",

--- a/src/forest5/decision.py
+++ b/src/forest5/decision.py
@@ -334,7 +334,9 @@ class DecisionAgent:
                 eff_w = float(tech_vote.weight)
             # For WAIT, hide votes like previous behavior
             details = None if action == "WAIT" else {"votes": [v.__dict__ for v in votes]}
-            result = DecisionResult(action, eff_w if fused >= 0 else -eff_w, reason or "ok", details or {})
+            result = DecisionResult(
+                action, eff_w if fused >= 0 else -eff_w, reason or "ok", details or {}
+            )
         else:
             result = _fuse_votes(votes, cfg)
 

--- a/src/forest5/decision.py
+++ b/src/forest5/decision.py
@@ -11,6 +11,7 @@ from .live.router import OrderRouter, PaperBroker
 from .time_only import TimeOnlyModel
 from .signals.fusion import _fuse_votes, _to_sign
 from .utils.log import setup_logger
+from .decision_core import fuse_with_time as _fuse_core
 
 
 Dir = Literal[-1, 0, 1]
@@ -238,6 +239,8 @@ class DecisionConfig:
     tech: Any = field(
         default_factory=lambda: SimpleNamespace(default_conf_int=0.5, conf_floor=0.2, conf_cap=0.9)
     )
+    # Optional: use shared fusion core for combining tech/time/ai
+    use_core_fusion: bool = False
 
 
 class DecisionAgent:
@@ -277,6 +280,9 @@ class DecisionAgent:
             return DecisionResult("WAIT", 0.0, "no_tech_signal")
         votes.append(tech_vote)
 
+        # Always evaluate time model outcome first for early WAIT
+        tm_decision = None
+        tm_weight = 1.0
         if self.config.time_model:
             tm_res = self.config.time_model.decide(ts, value)
             if isinstance(tm_res, tuple):
@@ -295,12 +301,43 @@ class DecisionAgent:
                 )
             )
 
+        ai_vote: DecisionVote | None = None
         if self.ai:
             ai_sent = self.ai.analyse(context_text, symbol)
-            votes.append(_normalize_ai_input(ai_sent, cfg))
+            ai_vote = _normalize_ai_input(ai_sent, cfg)
+            votes.append(ai_vote)
 
         log.debug("decision_inputs", votes=[v.__dict__ for v in votes])
-        result = _fuse_votes(votes, cfg)
+
+        # Optional shared fusion core (compat off by default)
+        if getattr(self.config, "use_core_fusion", False):
+            ai_param = None
+            if ai_vote is not None:
+                ai_param = (ai_vote.direction, ai_vote.weight)
+            fused, w, reason = _fuse_core(
+                tech_vote.direction,
+                pd.Timestamp(ts),
+                0.0,
+                self.config.time_model,
+                self.config.min_confluence,
+                ai_param,
+                return_weight=True,
+                return_reason=True,
+            )
+            action = "BUY" if fused > 0 else "SELL" if fused < 0 else "WAIT"
+            # Map reason for compatibility with existing messages
+            if reason == "not_enough_confluence":
+                reason = "below_min_confluence"
+            # Preserve legacy effective weight semantics (use tech weight when alone)
+            eff_w = float(w)
+            if fused != 0 and (ai_vote is None and tm_decision is None):
+                eff_w = float(tech_vote.weight)
+            # For WAIT, hide votes like previous behavior
+            details = None if action == "WAIT" else {"votes": [v.__dict__ for v in votes]}
+            result = DecisionResult(action, eff_w if fused >= 0 else -eff_w, reason or "ok", details or {})
+        else:
+            result = _fuse_votes(votes, cfg)
+
         log.debug(
             "decision_result",
             action=result.action,

--- a/src/forest5/decision_core.py
+++ b/src/forest5/decision_core.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Tuple
-
 import pandas as pd
 
 from .time_only import TimeOnlyModel
@@ -91,4 +89,3 @@ def fuse_with_time(
 
 
 __all__ = ["fuse_with_time"]
-

--- a/src/forest5/decision_core.py
+++ b/src/forest5/decision_core.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+import pandas as pd
+
+from .time_only import TimeOnlyModel
+from .signals.fusion import _to_sign
+
+
+def fuse_with_time(
+    tech_signal: int,
+    ts: pd.Timestamp,
+    price: float,
+    time_model: TimeOnlyModel | None,
+    min_conf: float,
+    ai_decision: int | tuple[int, float] | None = None,
+    *,
+    return_reason: bool = False,
+    return_weight: bool = False,
+):
+    """Fuse technical, time, and optional AI signals into one decision.
+
+    Returns -1/0/1 or tuples depending on flags, mirroring the previous
+    `_fuse_with_time` helper used in backtest engine.
+    """
+
+    votes: dict[str, tuple[int, float]] = {
+        "tech": (_to_sign(tech_signal), 1.0),
+        "time": (0, 0.0),
+        "ai": (0, 0.0),
+    }
+
+    if time_model:
+        tm_res = time_model.decide(ts)
+        if isinstance(tm_res, dict):
+            tm_decision = tm_res.get("decision")
+            tm_weight = tm_res.get("confidence", 1.0)
+        elif isinstance(tm_res, tuple):
+            tm_decision, tm_weight = tm_res
+        else:
+            tm_decision, tm_weight = tm_res, 1.0
+        if tm_decision in {"WAIT", "HOLD"}:
+            reason = "time_model_hold" if tm_decision == "HOLD" else "time_model_wait"
+            if return_reason and return_weight:
+                return 0, 0.0, reason
+            if return_reason:
+                return 0, reason
+            if return_weight:
+                return 0, 0.0
+            return 0
+        votes["time"] = (_to_sign(1 if tm_decision == "BUY" else -1), float(tm_weight))
+
+    if ai_decision is not None:
+        if isinstance(ai_decision, tuple):
+            ai_sig, ai_weight = ai_decision
+        else:
+            ai_sig, ai_weight = ai_decision, 1.0
+        votes["ai"] = (_to_sign(ai_sig), float(ai_weight))
+
+    pos_total = sum(w for s, w in votes.values() if s > 0)
+    neg_total = sum(w for s, w in votes.values() if s < 0)
+    if max(pos_total, neg_total) < max(min_conf, 1.0):
+        if return_reason and return_weight:
+            return 0, 0.0, "not_enough_confluence"
+        if return_reason:
+            return 0, "not_enough_confluence"
+        if return_weight:
+            return 0, 0.0
+        return 0
+
+    if pos_total > neg_total:
+        res_dec = 1
+        weights = [w for s, w in votes.values() if s > 0]
+    elif neg_total > pos_total:
+        res_dec = -1
+        weights = [w for s, w in votes.values() if s < 0]
+    else:
+        res_dec = 0
+        weights = []
+
+    final_weight = min(weights) if weights else 0.0
+
+    if return_reason and return_weight:
+        return res_dec, final_weight, None
+    if return_weight:
+        return res_dec, final_weight
+    if return_reason:
+        return res_dec, None
+    return res_dec
+
+
+__all__ = ["fuse_with_time"]
+

--- a/src/forest5/live/live_runner.py
+++ b/src/forest5/live/live_runner.py
@@ -239,6 +239,7 @@ def run_live(
             tie_epsilon=settings.decision.tie_epsilon,
             weights=settings.decision.weights,
             tech=settings.decision.tech,
+            use_core_fusion=True,
         ),
     )
 

--- a/src/forest5/signals/factory.py
+++ b/src/forest5/signals/factory.py
@@ -62,7 +62,7 @@ def compute_signal(
         candles = candles_signal(df)
         return confirm_with_candles(base, candles)
     if name == "h1_ema_rsi_atr":
-        params = getattr(strategy, "params", None)
+        params = getattr(strategy, "params", strategy)
         res = compute_primary_signal_h1(df, params, ctx=ctx)
         if compat_int:
             from .compat import contract_to_int

--- a/src/forest5/signals/h1_ema_rsi_atr.py
+++ b/src/forest5/signals/h1_ema_rsi_atr.py
@@ -333,7 +333,9 @@ def compute_primary_signal_h1(
             drivers=drivers,
             meta=meta,
         )
-        reg.arm(p["timeframe"], idx, signal, bar_time=now, ttl_minutes=p.get("ttl_minutes"), ctx=ctx)
+        reg.arm(
+            p["timeframe"], idx, signal, bar_time=now, ttl_minutes=p.get("ttl_minutes"), ctx=ctx
+        )
         if collector:
             extras = {
                 "action": action,

--- a/src/forest5/signals/h1_ema_rsi_atr.py
+++ b/src/forest5/signals/h1_ema_rsi_atr.py
@@ -50,6 +50,7 @@ DEFAULT_PARAMS: dict[str, Any] = {
     "sl_atr": 1.0,  # stop-loss distance in ATR multiples
     "sl_min_atr": 0.0,  # minimum stop-loss distance in ATR multiples
     "rr": 2.0,  # risk–reward ratio
+    "trailing_atr": 0.0,  # optional trailing stop in ATR multiples (0=off)
     "timeframe": "H1",
     "horizon_minutes": 240,
     "ttl_minutes": None,
@@ -204,25 +205,35 @@ def compute_primary_signal_h1(
     if collector:
         collector.note("setup_candidate", "base_ok", at=now, extras=meta)
 
-    # --- Trend gate -------------------------------------------------------
-    sep_ok = abs(ema_f_last - ema_s_last) >= p["t_sep_atr"] * atr_last
-    trend = 1 if ema_f_last > ema_s_last else -1 if ema_f_last < ema_s_last else 0
-    if not sep_ok:
-        trend = 0
-        if collector:
-            collector.note("setup_candidate", "trend_gate_failed", at=now, extras=meta)
+    # --- Trend & pullback gates (optional) -------------------------------
+    use_ema_gates = bool(p.get("use_ema_gates", True))
+    if use_ema_gates:
+        sep_ok = abs(ema_f_last - ema_s_last) >= p["t_sep_atr"] * atr_last
+        trend = 1 if ema_f_last > ema_s_last else -1 if ema_f_last < ema_s_last else 0
+        if not sep_ok:
+            trend = 0
+            if collector:
+                collector.note("setup_candidate", "trend_gate_failed", at=now, extras=meta)
 
-    # --- Pullback ---------------------------------------------------------
-    ema_f_prev = ema_f.iloc[-2]
-    atr_prev = atr_series.iloc[-2]
-    pullback = abs(close_prev - ema_f_prev) <= p["pullback_atr"] * atr_prev
-    if trend and not pullback and collector:
-        collector.note("setup_candidate", "pullback_gate_failed", at=now, extras=meta)
+        ema_f_prev = ema_f.iloc[-2]
+        atr_prev = atr_series.iloc[-2]
+        pullback = abs(close_prev - ema_f_prev) <= p["pullback_atr"] * atr_prev
+        if trend and not pullback and collector:
+            collector.note("setup_candidate", "pullback_gate_failed", at=now, extras=meta)
+    else:
+        # Without EMA gates, derive trend from RSI cross direction only when it occurs
+        trend = 0
+        pullback = True
 
     # --- Trigger ----------------------------------------------------------
     trigger_up = rsi_prev < 50 <= rsi_last
     trigger_down = rsi_prev > 50 >= rsi_last
     trigger = (trend == 1 and trigger_up) or (trend == -1 and trigger_down)
+    if not use_ema_gates and not trigger:
+        # No RSI cross -> no opportunity without EMA gating
+        pass
+    if not use_ema_gates and trigger and trend == 0:
+        trend = 1 if trigger_up else -1
     if trend and pullback and not trigger and collector:
         collector.note("setup_candidate", "rsi_gate_blocked", at=now, extras=meta)
 
@@ -233,16 +244,34 @@ def compute_primary_signal_h1(
     if trend and pullback and trigger:
         drivers = ["ema_trend", "pullback", "rsi_trigger"]
         risk = max(p["sl_atr"], p.get("sl_min_atr", 0.0)) * atr_last
-        if trend == 1:
-            entry = high.iloc[-1] + p["entry_buffer_atr"] * atr_last
-            sl = entry - risk
-            tp = entry + risk * p["rr"]
-            action = "BUY"
+        mode = p.get("entry_mode", "breakout")
+        if mode == "breakout":
+            if trend == 1:
+                entry = high.iloc[-1] + p["entry_buffer_atr"] * atr_last
+                sl = entry - risk
+                tp = entry + risk * p["rr"]
+                action = "BUY"
+            else:
+                entry = low.iloc[-1] - p["entry_buffer_atr"] * atr_last
+                sl = entry + risk
+                tp = entry - risk * p["rr"]
+                action = "SELL"
         else:
-            entry = low.iloc[-1] - p["entry_buffer_atr"] * atr_last
-            sl = entry + risk
-            tp = entry - risk * p["rr"]
-            action = "SELL"
+            # entry on close +/- buffer (this bar) or force next-open trigger
+            close_last = float(close.iloc[-1])
+            if trend == 1:
+                entry = close_last + p["entry_buffer_atr"] * atr_last
+                sl = entry - risk
+                tp = entry + risk * p["rr"]
+                action = "BUY"
+            else:
+                entry = close_last - p["entry_buffer_atr"] * atr_last
+                sl = entry + risk
+                tp = entry - risk * p["rr"]
+                action = "SELL"
+            if mode == "close_next":
+                # Hint to engine to trigger on next open regardless of level
+                meta["entry_on_next_open"] = True
 
         technical_score = 1.0 if action == "BUY" else -1.0
         confidence_tech = abs(technical_score)
@@ -287,6 +316,10 @@ def compute_primary_signal_h1(
                 drivers=[],
                 meta=meta,
             )
+        # Include trailing_atr hint in meta so engine can activate trailing stops
+        if p.get("trailing_atr", 0.0):
+            meta["trailing_atr"] = float(p["trailing_atr"])
+
         signal = TechnicalSignal(
             timeframe=p["timeframe"],
             action=action,
@@ -300,7 +333,7 @@ def compute_primary_signal_h1(
             drivers=drivers,
             meta=meta,
         )
-        reg.arm(p["timeframe"], idx, signal, bar_time=now, ctx=ctx)
+        reg.arm(p["timeframe"], idx, signal, bar_time=now, ttl_minutes=p.get("ttl_minutes"), ctx=ctx)
         if collector:
             extras = {
                 "action": action,

--- a/src/forest5/utils/io.py
+++ b/src/forest5/utils/io.py
@@ -374,9 +374,7 @@ def read_ohlc_csv(
         missing_need = [c for c in need if c not in sample.columns]
         if missing_need:
             cols = ", ".join(sample.columns)
-            raise ValueError(
-                f"CSV missing required columns: {missing_need} (found: {cols})"
-            )
+            raise ValueError(f"CSV missing required columns: {missing_need} (found: {cols})")
         cols = need + (["volume"] if "volume" in sample.columns else [])
         col_aliases = {c: aliases.get(c, c) for c in cols}
 

--- a/src/forest5/utils/io.py
+++ b/src/forest5/utils/io.py
@@ -249,17 +249,25 @@ def read_ohlc_csv_smart(
         lc = {c.lower(): c for c in df.columns}
         target = lc.get(time_col.lower())
         if target is None:
-            raise ValueError(f"Specified time column '{time_col}' not found")
+            available = ", ".join(df.columns)
+            raise ValueError(
+                f"Specified time column '{time_col}' not found (available: {available})"
+            )
         inferred_time = target
 
     if inferred_time is None or inferred_time not in df.columns:
-        raise ValueError("Unable to determine time column")
+        cols = ", ".join(df.columns)
+        raise ValueError(
+            f"Unable to determine time column (found columns: {cols}). "
+            f"Try --time-col or adjust --sep/--decimal."
+        )
 
     idx = pd.to_datetime(df[inferred_time], errors="coerce", utc=True, format="mixed")
     if idx.isna().any():
         bad = int(idx.isna().sum())
         raise ValueError(
-            f"Failed to parse {bad} timestamps from '{path}'. Check the 'time' column format."
+            f"Failed to parse {bad} timestamps from '{path}'. Check the 'time' column format "
+            f"or specify --time-col/--sep/--decimal."
         )
 
     df = df.drop(columns=[inferred_time])
@@ -269,7 +277,8 @@ def read_ohlc_csv_smart(
     need = ["open", "high", "low", "close"]
     missing = [c for c in need if c not in df.columns]
     if missing:
-        raise ValueError(f"CSV missing required columns: {missing}")
+        cols = ", ".join(df.columns)
+        raise ValueError(f"CSV missing required columns: {missing} (found: {cols})")
 
     cols = need + (["volume"] if "volume" in df.columns else [])
     df = df[cols].apply(pd.to_numeric, errors="coerce").dropna()
@@ -345,11 +354,18 @@ def read_ohlc_csv(
             lc = {c.lower(): c for c in sample.columns}
             target = lc.get(time_col.lower())
             if target is None:
-                raise ValueError(f"Specified time column '{time_col}' not found")
+                available = ", ".join(sample.columns)
+                raise ValueError(
+                    f"Specified time column '{time_col}' not found (available: {available})"
+                )
             inferred_time = target
 
         if inferred_time is None or inferred_time not in sample.columns:
-            raise ValueError("Unable to determine time column")
+            cols = ", ".join(sample.columns)
+            raise ValueError(
+                f"Unable to determine time column (found columns: {cols}). "
+                f"Try --time-col or adjust --sep/--decimal."
+            )
 
         aliases = sample.attrs.get("aliases", {})
         time_alias = aliases.get("time", inferred_time)
@@ -357,7 +373,10 @@ def read_ohlc_csv(
         need = ["open", "high", "low", "close"]
         missing_need = [c for c in need if c not in sample.columns]
         if missing_need:
-            raise ValueError(f"CSV missing required columns: {missing_need}")
+            cols = ", ".join(sample.columns)
+            raise ValueError(
+                f"CSV missing required columns: {missing_need} (found: {cols})"
+            )
         cols = need + (["volume"] if "volume" in sample.columns else [])
         col_aliases = {c: aliases.get(c, c) for c in cols}
 
@@ -398,7 +417,10 @@ def read_ohlc_csv(
                     df = pd.read_csv(path, **read_kwargs)
                 except ValueError as e:
                     if "Usecols do not match" in str(e):
-                        raise ValueError(f"CSV missing required columns: {missing_need}") from None
+                        cols = ", ".join(sample.columns)
+                        raise ValueError(
+                            f"CSV missing required columns: {missing_need} (found: {cols})"
+                        ) from None
                     raise
 
         rename_map = {v: k for k, v in col_aliases.items()}
@@ -439,16 +461,19 @@ def read_ohlc_csv(
     # Validation of required columns
     missing = [c for c in ["open", "high", "low", "close"] if c not in df.columns]
     if missing:
-        raise ValueError(f"CSV missing required columns: {missing}")
+        cols = ", ".join(df.columns)
+        raise ValueError(f"CSV missing required columns: {missing} (found: {cols})")
 
     if not isinstance(df.index, pd.DatetimeIndex):
         raise ValueError(
-            f"Failed to parse timestamps from '{path}'. Check the 'time' column format."
+            f"Failed to parse timestamps from '{path}'. Check the 'time' column format "
+            f"or specify --time-col/--sep/--decimal."
         )
     if df.index.isna().any():
         bad = int(df.index.isna().sum())
         raise ValueError(
-            f"Failed to parse {bad} timestamps from '{path}'. Check the 'time' column format."
+            f"Failed to parse {bad} timestamps from '{path}'. Check the 'time' column format "
+            f"or specify --time-col/--sep/--decimal."
         )
 
     df.index.name = "time"

--- a/tests/test_cli_backtest_metrics.py
+++ b/tests/test_cli_backtest_metrics.py
@@ -45,7 +45,9 @@ def test_backtest_metrics_out(tmp_path, monkeypatch):
         ]
     )
 
-    def fake_run_backtest(df, settings, symbol, price_col, atr_period, atr_multiple, collector=None):
+    def fake_run_backtest(
+        df, settings, symbol, price_col, atr_period, atr_multiple, collector=None
+    ):
         return SimpleNamespace(
             equity_curve=pd.Series([1000.0, 1010.0]),
             max_dd=0.05,
@@ -62,4 +64,3 @@ def test_backtest_metrics_out(tmp_path, monkeypatch):
     assert "equity_end" in data and data["equity_end"] == 1010.0
     assert "return" in data and isinstance(data["return"], float)
     assert data["trades"] == 0
-

--- a/tests/test_cli_backtest_metrics.py
+++ b/tests/test_cli_backtest_metrics.py
@@ -1,0 +1,65 @@
+import json
+from types import SimpleNamespace
+from pathlib import Path
+
+import pandas as pd
+
+from forest5.cli import build_parser, cmd_backtest
+
+
+def _write_csv(path: Path) -> Path:
+    idx = pd.date_range("2020-01-01", periods=5, freq="h")
+    df = pd.DataFrame(
+        {
+            "time": idx,
+            "open": [1.0, 1.1, 1.2, 1.3, 1.4],
+            "high": [1.1, 1.2, 1.3, 1.4, 1.5],
+            "low": [0.9, 1.0, 1.1, 1.2, 1.3],
+            "close": [1.0, 1.1, 1.2, 1.3, 1.4],
+        }
+    )
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_backtest_metrics_out(tmp_path, monkeypatch):
+    csv_path = _write_csv(tmp_path / "data.csv")
+    out_path = tmp_path / "metrics.json"
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "backtest",
+            "--csv",
+            str(csv_path),
+            "--symbol",
+            "EURUSD",
+            "--fast",
+            "2",
+            "--slow",
+            "3",
+            "--atr-period",
+            "1",
+            "--metrics-out",
+            str(out_path),
+        ]
+    )
+
+    def fake_run_backtest(df, settings, symbol, price_col, atr_period, atr_multiple, collector=None):
+        return SimpleNamespace(
+            equity_curve=pd.Series([1000.0, 1010.0]),
+            max_dd=0.05,
+            trades=SimpleNamespace(trades=[]),
+        )
+
+    monkeypatch.setattr("forest5.cli.run_backtest", fake_run_backtest)
+
+    rc = cmd_backtest(args)
+    assert rc == 0
+    assert out_path.exists()
+    data = json.loads(out_path.read_text())
+    assert data["symbol"] == "EURUSD"
+    assert "equity_end" in data and data["equity_end"] == 1010.0
+    assert "return" in data and isinstance(data["return"], float)
+    assert data["trades"] == 0
+

--- a/tests/test_cli_data_input_dir.py
+++ b/tests/test_cli_data_input_dir.py
@@ -43,4 +43,3 @@ def test_data_inspect_input_dir(tmp_path: Path):
     b_info = json.loads(b_js.read_text())
     assert a_info["rows"] == 3
     assert b_info["rows"] == 4
-

--- a/tests/test_cli_data_input_dir.py
+++ b/tests/test_cli_data_input_dir.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from forest5.cli import main
+
+
+def _write_csv(path: Path, rows: int = 3) -> Path:
+    idx = pd.date_range("2020-01-01", periods=rows, freq="h")
+    df = pd.DataFrame(
+        {
+            "time": idx,
+            "open": [1.0] * rows,
+            "high": [1.1] * rows,
+            "low": [0.9] * rows,
+            "close": [1.0] * rows,
+        }
+    )
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_data_inspect_input_dir(tmp_path: Path):
+    inp = tmp_path / "in"
+    out = tmp_path / "out"
+    inp.mkdir()
+    _write_csv(inp / "a.csv", rows=3)
+    _write_csv(inp / "b.csv", rows=4)
+
+    rc = main(["data", "inspect", "--input-dir", str(inp), "--out", str(out)])
+    assert rc == 0
+
+    a_txt = out / "a_summary.txt"
+    a_js = out / "a_summary.json"
+    b_txt = out / "b_summary.txt"
+    b_js = out / "b_summary.json"
+
+    assert a_txt.exists() and a_js.exists()
+    assert b_txt.exists() and b_js.exists()
+
+    a_info = json.loads(a_js.read_text())
+    b_info = json.loads(b_js.read_text())
+    assert a_info["rows"] == 3
+    assert b_info["rows"] == 4
+

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -10,4 +10,3 @@ def test_cli_version_prints_and_exits(capsys):
     assert exc.value.code == 0
     out = capsys.readouterr().out
     assert "forest5" in out.lower()
-

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,13 @@
+import pytest
+
+from forest5.cli import build_parser
+
+
+def test_cli_version_prints_and_exits(capsys):
+    parser = build_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["--version"])  # argparse prints and exits
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "forest5" in out.lower()
+

--- a/tests/test_cli_walkforward_out.py
+++ b/tests/test_cli_walkforward_out.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import pandas as pd
+
+from forest5.cli import build_parser, cmd_walkforward
+
+
+def _write_csv(path: Path) -> Path:
+    idx = pd.date_range("2020-01-01", periods=6, freq="h")
+    df = pd.DataFrame(
+        {
+            "time": idx,
+            "open": [1.0, 1.1, 1.2, 1.3, 1.4, 1.5],
+            "high": [1.1, 1.2, 1.3, 1.4, 1.5, 1.6],
+            "low": [0.9, 1.0, 1.1, 1.2, 1.3, 1.4],
+            "close": [1.0, 1.1, 1.2, 1.3, 1.4, 1.5],
+        }
+    )
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_walkforward_writes_out(tmp_path, monkeypatch):
+    csv_path = _write_csv(tmp_path / "data.csv")
+    out_path = tmp_path / "wf.csv"
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "walkforward",
+            "--csv",
+            str(csv_path),
+            "--symbol",
+            "EURUSD",
+            "--train",
+            "3",
+            "--test",
+            "1",
+            "--ema-fast",
+            "5",
+            "--ema-slow",
+            "8",
+            "--rsi-len",
+            "14",
+            "--atr-len",
+            "14",
+            "--out",
+            str(out_path),
+        ]
+    )
+
+    def fake_run_backtest(df, settings):
+        class R:
+            equity_curve = pd.Series([1000.0] * max(1, len(df.index)), index=df.index)
+
+        return R()
+
+    monkeypatch.setattr("forest5.cli.run_backtest", fake_run_backtest)
+
+    rc = cmd_walkforward(args)
+    assert rc == 0
+    assert out_path.exists()
+    df_out = pd.read_csv(out_path)
+    assert "train_start" in df_out.columns
+    assert "test_end" in df_out.columns
+    assert "equity_end" in df_out.columns
+    assert len(df_out) >= 1

--- a/tests/test_decision_agent_core.py
+++ b/tests/test_decision_agent_core.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+from forest5.decision import DecisionAgent, DecisionConfig
+from forest5.time_only import TimeOnlyModel
+
+
+def test_core_fusion_time_wait() -> None:
+    tm = TimeOnlyModel({0: (-1.0, 1.0)}, q_low=-1.0, q_high=1.0)
+    agent = DecisionAgent(config=DecisionConfig(time_model=tm, use_core_fusion=True))
+    ts = datetime(2024, 1, 1)
+    decision, votes, reason = agent.decide(ts, tech_signal=1, value=0.0, symbol="EURUSD")
+    assert (decision, votes, reason) == ("WAIT", {}, "timeonly_wait")
+
+
+def test_core_fusion_min_confluence() -> None:
+    agent = DecisionAgent(config=DecisionConfig(min_confluence=1.4, use_core_fusion=True))
+    ts = datetime(2024, 1, 1)
+    decision, votes, reason = agent.decide(ts, tech_signal=1, value=0.0, symbol="EURUSD")
+    # With only tech vote=1 and min_confluence=1.4, expect WAIT
+    assert (decision, votes, reason) == ("WAIT", {}, "below_min_confluence")
+

--- a/tests/test_decision_agent_core.py
+++ b/tests/test_decision_agent_core.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from datetime import datetime
 
 from forest5.decision import DecisionAgent, DecisionConfig
@@ -19,4 +18,3 @@ def test_core_fusion_min_confluence() -> None:
     decision, votes, reason = agent.decide(ts, tech_signal=1, value=0.0, symbol="EURUSD")
     # With only tech vote=1 and min_confluence=1.4, expect WAIT
     assert (decision, votes, reason) == ("WAIT", {}, "below_min_confluence")
-


### PR DESCRIPTION
This PR unifies the H1 strategy backtesting on the contract engine and adds CLI improvements, diagnostics and a mini-grid runner.\n\nKey changes:\n- Contract engine for H1 (SL/TP/TTL; high/low triggers; reasons)\n- CLI: --version, --metrics-out, --setup-ttl-bars, --entry-mode, --no-ema-gates\n- Entry modes: breakout/close/close_next; EMA-gate toggle; TTL control\n- Precompute EMA/RSI/ATR; shared decision_core; optional in live agent\n- Scripts: debug_h1_decision.py, h1_mini_grid.py\n- Tests: CLI and decision core\n- .gitignore: ignore Fxdata/, out_*/ and *.csv (keeps docs/equity.csv)\n\nNo local data/results are committed.